### PR TITLE
Pre-release improvements: remove unnecessary JASPER check, check that CRTM exists in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -18,6 +18,18 @@ for arg ; do
     esac
 done
 
+# First, check if CRTM submodule has been properly checked out; quit if not
+if [ ! -f "sorc/comlibs/crtm2/src/makefile" ] ; then
+  echo "sorc/comlibs/crtm2/src/makefile does not exist!"
+  echo "If you cloned the code from github, you probably have not checked out the crtm submodule"
+  echo ""
+  echo "Try the following command to fix this issue:"
+  echo ""
+  echo "git submodule update --init --recursive --progress"
+  echo ""
+  exit 2
+fi
+
 # =============================================================================
 # If NETCDF is not set, look for legacy locations:
 # =============================================================================

--- a/configure
+++ b/configure
@@ -331,40 +331,6 @@ else
   fi
 fi
 
-# Legacy variables; accept with or without underscores
-if [ ! -z "$JASPERLIB" ]; then
-  export JASPER_LIB=$JASPERLIB
-fi
-if [ ! -z "$JASPERINC" ]; then
-  export JASPER_INC=$JASPERINC
-fi
-
-# Find location of JASPER libs and includes (for GRIB2 support)
-if [ -z "$NOGRIB2" ]; then
-  if [ -z "$JASPER_LIB" ] || [ -z "$JASPER_INC" ]; then
-    if [ -z "$JASPER" ]; then
-      echo "ERROR: You must define the locations of JASPER library (JASPER_LIB) and include (JASPER_INC) files"
-      echo "       to compile UPP with GRIB2 support"
-      echo ""
-      echo "       To disable GRIB2 support, set the environment variable NOGRIB2 (NOT RECOMMENDED)"
-      exit 1
-    else
-      export JASPER_LIB="$JASPER/lib"
-      export JASPER_INC="$JASPER/include"
-    fi
-  else
-    echo "Will use JASPER libraries in: " $JASPER_LIB
-    echo "Will use JASPER includes in:  " $JASPER_INC
-  fi
-  if [ ! -d "$JASPER_LIB" ] || [ ! -d "$JASPER_INC" ]; then
-    echo "ERROR: Check your JASPER location; one or both of these paths does not exist:"
-    echo $JASPER_LIB
-    echo $JASPER_INC
-    exit 2
-  fi
-fi
-
-
 #
 # if the uname command exists, give it a shot and see if
 # we can narrow the choices; otherwise, spam 'em
@@ -421,8 +387,7 @@ fi
 # proceed with configuration if OS is supported
 srch=`grep -i "^#ARCH.*$os" sorc/arch/configure.defaults | grep -i "$mach"`
 if [ -n "$srch" ] ; then
-  perl sorc/arch/Config.pl -jasperlib=$JASPER_LIB -jasperinc=$JASPER_INC       \
-                           -netcdf=$NETCDF -USENETCDFF=$USENETCDFF             \
+  perl sorc/arch/Config.pl -netcdf=$NETCDF -USENETCDFF=$USENETCDFF             \
                            -os=$os -mach=$mach                                 \
                            -bindir=$BINDIR -incmod=$INCMOD -libdir=$LIBDIR     \
                            -debug=$DEBUG -spv=$SPLIB_VERSION                   \
@@ -454,12 +419,3 @@ NCEPLIBINCESC=$(echo $NCEPLIBINCESC | sed 's|/|\\/|g') #Of course, this assumes 
 sed "s|CONFIGURE_NCEPLIBS_LIB|$NCEPLIBLIBESC|g" configure.upp > .configure.upp.edit
 sed "s/CONFIGURE_NCEPLIBS_INC/$NCEPLIBINCESC/g" .configure.upp.edit > configure.upp
 
-if [ ! -z "$NOGRIB2" ]; then
-  echo "Variable NOGRIB2 is set; compiling UPP without GRIB2 support"
-  echo ""
-  echo "WARNING WARNING WARNING"
-  echo "  GRIB1 support for UPP will be deprecated in a future release"
-  echo "  Compiling for GRIB2 is strongly recommended"
-  echo "WARNING WARNING WARNING"
-  echo ""
-fi

--- a/sorc/arch/Config.pl
+++ b/sorc/arch/Config.pl
@@ -21,8 +21,6 @@ select((select(STDOUT), $|=1)[0]);
 $sw_netcdf_path = "" ;
 $sw_usenetcdff = "" ;         # for 3.6.2 and greater, the fortran bindings
                               # might be in a separate lib file
-$sw_jasperlib_path = "" ;
-$sw_jasperinc_path = "" ;
 $sw_os = "ARCH" ;             # ARCH will match any
 $sw_mach = "ARCH" ;           # ARCH will match any
 $sw_fc = "\$(SFC)" ;
@@ -57,14 +55,6 @@ while ( substr( $ARGV[0], 0, 1 ) eq "-" )
   if ( substr( $ARGV[0], 1, 7 ) eq "netcdf=" )
   {
     $sw_netcdf_path = substr( $ARGV[0], 8 ) ;
-  }
-  if ( substr( $ARGV[0], 1, 10 ) eq "jasperlib=" )
-  {
-    $sw_jasperlib_path = substr( $ARGV[0], 11 ) ;
-  }
-  if ( substr( $ARGV[0], 1, 10 ) eq "jasperinc=" )
-  {
-    $sw_jasperinc_path = substr( $ARGV[0], 11 ) ;
   }
   if ( substr( $ARGV[0], 1, 3 ) eq "os=" )
   {
@@ -133,50 +123,6 @@ while ( substr( $ARGV[0], 0, 1 ) eq "-" )
   shift @ARGV ;
  }
 
-#
-# Check for compression libraries needed in support of GRIB2 format
-# As of today unipost will not compile without these libraries
-if (($sw_jasperlib_path ne '') && ($sw_jasperinc_path ne '')) {
-  $sw_grib2_libs= "-L$sw_jasperlib_path -lpng -lz -ljasper";
-  $sw_grib2_inc= "-I$sw_jasperinc_path";
-  print "JASPER Environment found :: GRIB2 library ::\n";
-}
-
-# Try and set these based on what we can find
-else
-{
-    # most LIUX boxes have this
-    $tmp1 = '/usr/lib/libjasper.a';
-    if (-e $tmp1) {
-      $sw_grib2_libs = '-L/usr/lib -ljasper -lpng12 -lpng -lz' ;
-      $sw_grib2_inc = '-I/usr/include -I/usr/include/jasper' ;
-        printf "\$JASPER_LIB or \$JASPER_INC not found in environment. Using ...\n";
-    }
-
-    else {
-      # JET has this
-      $tmp1 = '/opt/local/lib';
-      if (-e $tmp1) {
-        $sw_grib2_libs = '-L/opt/local/lib -ljasper -lpng -lz';
-        $sw_grib2_inc = '-I/opt/local/include';
-        printf "\$JASPER_LIB or \$JASPER_INC not found in environment. Using ...\n";
-      }
-
-      # Bluefire has this (AIX)
-      elsif (-d '/contrib/jasper') {
-      $sw_grib2_libs = '-L/contrib/jasper/lib -L/opt/freeware/lib -ljasper -lpng -lz';
-      $sw_grib2_inc = '-I/contrib/libpng/include -I/contrib/zlib/include -I/contrib/jasper/include';
-        printf "\$JASPER_LIB or \$JASPER_INC not found in environment. Using ...\n";
-      }
-      else {
-        die "FATAL ERROR: JASPER libraries not found for GRIB2.\nYou really shouldn't ever get here...." unless defined($ENV{NOGRIB2});
-      }
-    }
-}
-if (not defined($ENV{NOGRIB2})) {
-  print "grib2lib = $sw_grib2_libs\n";
-  print "grib2inc = $sw_grib2_inc\n";
-}
 # Build string of nceplib flags based off input from configure script
 $nceplib_flags = "-lwrfio -lg2_v${sw_g2v}_4 -lg2tmpl_v${sw_g2tmplv} -lnemsio_d -lsigio_v${sw_sigiov}_4 -lsfcio_v${sw_sfciov}_4 -lgfsio_4 -lsp_v${sw_spv}_d -lw3nco_v${sw_w3ncov}_4 -lw3emc_v${sw_w3emcv}_4 -lbacio_4" ;
 


### PR DESCRIPTION
This is a variety of fixes needed prior to the stand-alone UPP release.

 - Remove check in configure/compile system for jasper libraries; this was only necessary when we were building our own copies of the NCEP libraries
 - Add check for missing CRTM; the message may need to be modified depending on how we decide to release the code to the community
 - Remove and rename files to get around the compilation issue for case-insensitive operating systems. This has not yet been tested for the NCEP build but it should work.