### PR TITLE
itag bug

### DIFF
--- a/scripts/run_unipost
+++ b/scripts/run_unipost
@@ -379,6 +379,7 @@ ${outFormat}
 ${YY}-${MM}-${DD}_${HH}:00:00
 ${tag}
 ${flxFileName}
+postxconfig-NT.txt
 EOF
     fi
 

--- a/scripts/run_unipostandgempak
+++ b/scripts/run_unipostandgempak
@@ -381,6 +381,7 @@ ${outFormat}
 ${YY}-${MM}-${DD}_${HH}:00:00
 ${tag}
 ${flxFileName}
+postxconfig-NT.txt
 EOF
     fi
 

--- a/scripts/run_unipostandgrads
+++ b/scripts/run_unipostandgrads
@@ -384,6 +384,7 @@ ${outFormat}
 ${YY}-${MM}-${DD}_${HH}:00:00
 ${tag}
 ${flxFileName}
+postxconfig-NT.txt
 EOF
     fi
 


### PR DESCRIPTION
Add the flat file name (postxconfig-NT.txt) to fix the itag bug for GFS case.