### PR TITLE
Fix post crash on macOS

### DIFF
--- a/sorc/ncep_post.fd/GFSPOST.F
+++ b/sorc/ncep_post.fd/GFSPOST.F
@@ -435,7 +435,7 @@ end subroutine
 !        call rsearch1(km-k-1,h(k+1),1,h(k)+hd,kd)
 	call rsearch1(k-2,h(2),1,h(k)+hd,kd)
 !        td=t(k+kd)+(h(k)+hd-h(k+kd))/(h(k+kd+1)-h(k+kd))*(t(k+kd+1)-t(k+kd))
-	td=t(kd+2)+(h(k)+hd-h(2+kd))/(h(kd+1)-h(2+kd))*(t(kd+1)-t(2+kd))
+        td=t(kd+2)+(h(k)+hd-h(2+kd))/(h(kd+1)-h(2+kd))*(t(kd+1)-t(2+kd))
         gami=(t(k)-td)/hd
         if(gami.le.gamtp) then
           ktp=k

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -221,11 +221,12 @@
     real,allocatable    :: datafld(:,:)
     real,allocatable    :: datafldtmp(:)
 !
-    character(1) cgrib(max_bytes)
+    character(1), dimension(:), allocatable :: cgrib
 !
 !
 !---------------- code starts here --------------------------
 !
+    allocate(cgrib(max_bytes))
 !
 !******* part 1 resitribute data ********
 !
@@ -328,9 +329,9 @@
 !
          call baclose(lunout,ierr)
          print *,'finish one grib file'
-      endif
+      endif ! if(me==0)
 !
-!for more fields, use pararrle i/o
+!for more fields, use parallel i/o
     else
 !
 !      print *,'in grib2,num_procs=',num_procs
@@ -459,6 +460,7 @@
 !
    deallocate(datafld,bmap,mg)
    deallocate(nfld_pe,snfld_pe,enfld_pe,jsta_pe,jend_pe)
+   deallocate(cgrib)
 !
   end subroutine gribit2
 !


### PR DESCRIPTION
This PR changes the declaration of the cgrib array to prevent a post crash on macOS ("illegal instruction"). This is not a bug in the code, but on macOS I believe. The same bug was previously fixed in gfsphysics' `sfcsub.F`. The new/alternative declaration is valid Fortran.

Also correcting minor typos/replace tab with spaces.

I have tested this thus far on macOS and Redhat Linux.