### PR TITLE
Removing serial option for this release

### DIFF
--- a/sorc/arch/Config.pl
+++ b/sorc/arch/Config.pl
@@ -132,7 +132,7 @@ $nceplib_flags = "-lwrfio -lg2_v${sw_g2v}_4 -lg2tmpl_v${sw_g2tmplv} -lnemsio_d -
 $validresponse = 0 ;
 
 ## UPP only supports dmpar @platforms for this release
-@platforms = qw ( dmpar ) ;
+@platforms = qw ( serial dmpar ) ;
 
 until ( $validresponse ) {
   print "-"x73 . "\n" .
@@ -249,6 +249,7 @@ while ( <CONFIGURE_DEFAULTS> )
 # Serial compile uses a stub library for mpi calls
         if ( $paropt eq 'serial' )
         {
+          die "\nERROR ERROR ERROR ERROR ERROR ERROR\n\nserial builds are not available for this release;\nThis option will be re-implemented in the future\n\nERROR ERROR ERROR ERROR ERROR ERROR\n";
           $sw_serial_mpi_stub  = "wrfmpi_stubs" ;
           $sw_serial_mpi_lib   = "-lmpi" ;
           $sw_dmparallelflag   = "-DSTUBMPI" ;

--- a/sorc/arch/Config.pl
+++ b/sorc/arch/Config.pl
@@ -131,8 +131,8 @@ $nceplib_flags = "-lwrfio -lg2_v${sw_g2v}_4 -lg2tmpl_v${sw_g2tmplv} -lnemsio_d -
 # Display the choices to the user and get selection
 $validresponse = 0 ;
 
-## UPP only supports serial @platforms = qw ( serial dmpar ) ;
-@platforms = qw ( serial dmpar ) ;
+## UPP only supports dmpar @platforms for this release
+@platforms = qw ( dmpar ) ;
 
 until ( $validresponse ) {
   print "-"x73 . "\n" .


### PR DESCRIPTION
Since we did not have the time/resources to implement a full serial build for the NCEPLIBS for this release, the configure script will quit with an error message if the user selects a serial option.

 ## Example ./configure output

```kavulich@wrigley:/d1/kavulich/UPP/EMC_post_mkavulich$ ./configure
Will use NETCDF in:            /home/kavulich/UPP/libs/netcdf
Will use NCEPlibs in:          test
bindir  /d1/kavulich/UPP/EMC_post_mkavulich/exec
incmod  /d1/kavulich/UPP/EMC_post_mkavulich/include
libdir  /d1/kavulich/UPP/EMC_post_mkavulich/lib
-------------------------------------------------------------------------
Please select from among the following supported platforms.

   1.  Linux x86_64, PGI compiler  (serial)
   2.  Linux x86_64, PGI compiler  (dmpar)
   3.  Linux x86_64, Intel compiler	 (serial)
   4.  Linux x86_64, Intel compiler	 (dmpar)
   5.  Linux x86_64, Intel compiler, SGI MPT	 (serial)
   6.  Linux x86_64, Intel compiler, SGI MPT	 (dmpar)
   7.  Linux x86_64, gfortran compiler  (serial)
   8.  Linux x86_64, gfortran compiler  (dmpar)
   9.  Linux x86_64, Intel compiler, IBM POE	 (serial)
  10.  Linux x86_64, Intel compiler, IBM POE	 (dmpar)
  11.  Linux x86_64, gfortran compiler: -f90=gfortran  (serial)
  12.  Linux x86_64, gfortran compiler: -f90=gfortran  (dmpar)
  13.  Linux x86_64, PGI compiler: -f90=pgf90  (serial)
  14.  Linux x86_64, PGI compiler: -f90=pgf90  (dmpar)

Enter selection [1-14] : 1
-------------------------------------------------------------------------

ERROR ERROR ERROR ERROR ERROR ERROR

serial builds are not available for this release;
This option will be re-implemented in the future

ERROR ERROR ERROR ERROR ERROR ERROR
```