### PR TITLE
Install postxconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,5 +93,6 @@ if(NOT TARGET crtm)
   find_package(crtm REQUIRED)
 endif()
 
-
 add_subdirectory(sorc/ncep_post.fd)
+
+install(FILES parm/postxconfig-NT-GFS.txt parm/postxconfig-NT-GFS-F00.txt DESTINATION share)


### PR DESCRIPTION
This PR adds the capability to install the files
```
src/postxconfig-NT-GFS.txt
src/postxconfig-NT-GFS-F00.txt
```
in the `share` subdirectory of the install location. This is required to have versioning on these files and avoid uploading the data somewhere else (e.g. an FTP server) with manual versioning.

Requested by @jedwards4b and @DusanJovic-NOAA.
