### PR TITLE
Post ips

### DIFF
--- a/modulefiles/post/lib-hera
+++ b/modulefiles/post/lib-hera
@@ -28,8 +28,6 @@ setenv version v8.0.0
 module purge
 
 # Loading Intel Compiler Suite
-#module load intel/19.0.4.243
-#module load impi/2019.0.4
 module load intel/18.0.5.274
 module load impi/2018.0.4
 
@@ -42,7 +40,7 @@ module load g2/3.1.0
 module load g2tmpl/1.6.0
 #module load xmlparse/v2.0.0
 
-module load w3emc/2.3.1
+module load w3emc_para/2.4.0
 module load w3nco/2.0.7
 module load bacio/2.0.3
 module load gfsio/1.1.0

--- a/modulefiles/post/lib-jet
+++ b/modulefiles/post/lib-jet
@@ -29,10 +29,10 @@ module purge
 
 # Loading Intel Compiler Suite
 module load intel/18.0.5.274
-module load impi
+module load impi/2018.4.274
 
 # Loading nceplibs modules
-module use -a /mnt/lfs3/projects/hfv3gfs/nwprod/NCEPLIBS/modulefiles
+module use -a /mnt/lfs3/HFIP/hfv3gfs/nwprod/NCEPLIBS/modulefiles
 module load jasper/v1.900.1
 module load png/v1.2.44
 module load z/v1.2.6
@@ -40,13 +40,13 @@ module load g2/v3.1.0
 module load g2tmpl/v1.6.0
 #module load xmlparse/v2.0.0
 
-module load w3emc/v2.3.0
+module load w3emc/v2.4.0
 module load w3nco/v2.0.6
 module load bacio/v2.0.2
 module load gfsio/v1.1.0
 #module load sigio/2.1.1
 module load ip/v3.0.1
 module load sp/v2.0.2
-module load crtm/v2.2.6
+module load crtm/v2.3.0
 
 

--- a/modulefiles/post/lib-wcoss_dell_p3
+++ b/modulefiles/post/lib-wcoss_dell_p3
@@ -29,7 +29,7 @@ setenv version v8.0.0
 module purge
 
 # Loading Intel Compiler Suite
-module load ips/18.0.5.274
+module load ips/18.0.1.163
 module load impi/18.0.1
 #module load prod_util/1.1.0
 

--- a/modulefiles/post/lib-wcoss_dell_p3
+++ b/modulefiles/post/lib-wcoss_dell_p3
@@ -41,7 +41,7 @@ module load g2/3.1.0
 module load g2tmpl/1.6.0
 #module load xmlparse/v2.0.0
 
-module load w3emc/2.3.0
+#module load w3emc/2.3.0
 module load w3nco/2.0.6
 module load bacio/2.0.2
 module load gfsio/1.1.0
@@ -50,5 +50,6 @@ module load ip/3.0.1
 module load sp/2.0.2
 module use -a /usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
 module load crtm/2.3.0
+module load w3emc_para/2.4.0
 
 

--- a/modulefiles/post/lib-wcoss_dell_p3
+++ b/modulefiles/post/lib-wcoss_dell_p3
@@ -29,7 +29,7 @@ setenv version v8.0.0
 module purge
 
 # Loading Intel Compiler Suite
-module load ips/18.0.1.163
+module load ips/18.0.5.274
 module load impi/18.0.1
 #module load prod_util/1.1.0
 

--- a/modulefiles/post/v8.0.0-jet
+++ b/modulefiles/post/v8.0.0-jet
@@ -17,13 +17,12 @@ set ver v8.0.0
 # Loading Intel Compiler Suite
 #module load intel/15.0.3.187 
 module load intel/18.0.5.274
-module load impi 
+module load impi/2018.4.274 
 
 module use /contrib/modulefiles
 
 # Loding nceplibs modules
-#module use -a /mnt/lfs3/projects/hfv3gfs/nwprod/lib/modulefiles
-module use -a /mnt/lfs3/projects/hfv3gfs/nwprod/NCEPLIBS/modulefiles
+module use -a /mnt/lfs3/HFIP/hfv3gfs/nwprod/NCEPLIBS/modulefiles
 module load sigio/v2.1.0
 module load jasper/v1.900.1
 module load png/v1.2.44
@@ -36,14 +35,13 @@ module load xmlparse/v2.0.0
 module load gfsio/v1.1.0
 module load ip/v3.0.1
 module load sp/v2.0.2
-module load w3emc/v2.3.0
+module load w3emc/v2.4.0
 module load w3nco/v2.0.6
-module load crtm/v2.2.6
+module load crtm/v2.3.0
 module load g2/v3.1.0
 module load g2tmpl/v1.6.0
 module load wrfio/v1.1.1
-#module load netcdf/3.6.3
-module load netcdf/4.6.1
+module load netcdf/4.7.0
 
 #setenv NCEPLIBS /mnt/lfs3/projects/hfv3gfs/gwv/ljtjet/lib
 

--- a/modulefiles/post/v8.0.0-wcoss_dell_p3
+++ b/modulefiles/post/v8.0.0-wcoss_dell_p3
@@ -12,7 +12,7 @@ module-whatis "post"
 
 set ver v8.0.0
 
-module load ips/18.0.5.274
+module load ips/18.0.1.163
 module load impi/18.0.1
 module load prod_util/1.1.0 
 

--- a/modulefiles/post/v8.0.0-wcoss_dell_p3
+++ b/modulefiles/post/v8.0.0-wcoss_dell_p3
@@ -12,7 +12,7 @@ module-whatis "post"
 
 set ver v8.0.0
 
-module load ips/18.0.1.163
+module load ips/18.0.5.274
 module load impi/18.0.1
 module load prod_util/1.1.0 
 

--- a/ush/fv3gfs_downstream_nems.sh
+++ b/ush/fv3gfs_downstream_nems.sh
@@ -99,7 +99,7 @@ fi
 
 #-----------------------------------------------------
 #-----------------------------------------------------
-if [ $machine = WCOSS -o $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 ]; then
+if [ $machine = WCOSS -o $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 -o $machine = HERA ]; then
 #-----------------------------------------------------
 #-----------------------------------------------------
 export nset=1
@@ -173,6 +173,15 @@ date
   launcher=${APRUN_DWN:-"aprun -j 1 -n 24 -N 24 -d 1 cfp"}
   if [ $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 ] ; then
      $launcher $MP_CMDFILE
+  elif [ $machine = HERA ] ; then
+     if [ -s $DATA/poescript_srun ]; then rm -f $DATA/poescript_srun; fi
+     touch $DATA/poescript_srun
+     nm=0
+     cat $DATA/poescript | while read line; do
+         echo "$nm  $line" >> $DATA/poescript_srun 
+         nm=$((nm+1))
+     done
+     ${launcher:-"srun --export=ALL"}  -n $nm --multi-prog $DATA/poescript_srun
   else
      $launcher
   fi
@@ -299,7 +308,7 @@ else
                                            -new_grid $grid1p0  pgb2file_${fhr3}_1p0
   export err=$?; err_chk
   #tweak sea ice cover
-  count=`$WGRIB2 pgb2file_${fhr3}_0p25 -match "LAND|ICEC" |wc -l`
+  count=`$WGRIB2 pgb2file_${fhr3}_${iproc}_0p25 -match "LAND|ICEC" |wc -l`
   if [ $count -eq 2 ]; then
     $MODICEC pgb2file_${fhr3}_0p25
     $MODICEC pgb2file_${fhr3}_1p0

--- a/ush/fv3gfs_downstream_nems.sh
+++ b/ush/fv3gfs_downstream_nems.sh
@@ -299,7 +299,7 @@ else
                                            -new_grid $grid1p0  pgb2file_${fhr3}_1p0
   export err=$?; err_chk
   #tweak sea ice cover
-  count=`$WGRIB2 pgb2file_${fhr3}_${iproc}_0p25 -match "LAND|ICEC" |wc -l`
+  count=`$WGRIB2 pgb2file_${fhr3}_0p25 -match "LAND|ICEC" |wc -l`
   if [ $count -eq 2 ]; then
     $MODICEC pgb2file_${fhr3}_0p25
     $MODICEC pgb2file_${fhr3}_1p0

--- a/ush/fv3gfs_downstream_nems.sh
+++ b/ush/fv3gfs_downstream_nems.sh
@@ -308,7 +308,7 @@ else
                                            -new_grid $grid1p0  pgb2file_${fhr3}_1p0
   export err=$?; err_chk
   #tweak sea ice cover
-  count=`$WGRIB2 pgb2file_${fhr3}_${iproc}_0p25 -match "LAND|ICEC" |wc -l`
+  count=`$WGRIB2 pgb2file_${fhr3}_0p25 -match "LAND|ICEC" |wc -l`
   if [ $count -eq 2 ]; then
     $MODICEC pgb2file_${fhr3}_0p25
     $MODICEC pgb2file_${fhr3}_1p0


### PR DESCRIPTION
The main changes:
1) Make loaded modules consistent for building both UPP executable and library on Hera.
2) Upgrade with crtm 2.3.0 and netcdf 4.7.0 on Jet.
3) Add MDMP function for generating both pgrb2 and pgrb2b datasets on Hera.