### PR TITLE
correct installation directory for Fortran module files.

### DIFF
--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -218,7 +218,7 @@ install(
   TARGETS ${LIBNAME}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
-install(DIRECTORY ${module_dir} DESTINATION include)
+install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
 
 add_executable(${EXENAME} ${EXE_SRC})
 target_link_libraries(


### PR DESCRIPTION
This PR fixes the installation path of compiled Fortran module files.

Previously their destination was:
 `${CMAKE_INSTALL_PREFIX}/include/include`

This has now been corrected to:
`${CMAKE_INSTALL_PREFIX}/include`


closes #129