### PR TITLE
build application with wrfio library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/Modules"
 
 option(OPENMP "use OpenMP threading" OFF)
 option(BUILD_POSTEXEC "Build NCEPpost executable" ON)
-option(BUILD_WITH_WRFLIB "Build NCEPpost with WRF library" OFF)
+option(BUILD_WITH_WRFIO "Build NCEPpost with WRF-IO library" OFF)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(STATUS "Setting build type to 'Release' as none was specified.")
@@ -33,11 +33,6 @@ if(OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)
 endif()
 
-if(BUILD_WITH_WRFLIB)
-  find_package(wrf REQUIRED)
-else()
-  set(wrf_FOUND FALSE)
-endif()
 
 find_package(w3nco REQUIRED)
 find_package(g2 REQUIRED)
@@ -53,6 +48,9 @@ if(BUILD_POSTEXEC)
   find_package(sfcio REQUIRED)
   find_package(nemsio REQUIRED)
   find_package(gfsio REQUIRED)
+  if(BUILD_WITH_WRFIO)
+    find_package(wrfio REQUIRED)
+  endif()
 endif()
 
 add_subdirectory(sorc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(BUILD_POSTEXEC)
   find_package(nemsio REQUIRED)
   find_package(gfsio REQUIRED)
   if(BUILD_WITH_WRFIO)
-    find_package(wrfio REQUIRED)
+    find_package(wrf_io REQUIRED)
   endif()
 endif()
 

--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -170,7 +170,7 @@ list(APPEND EXE_SRC
     wrf_io_flags.h)
 
 # Use IO stubs in place of WRFLIB
-if(NOT wrf_FOUND)
+if(NOT wrfio_FOUND)
   list(APPEND EXE_SRC
     io_int_stubs.f)
 endif()
@@ -228,6 +228,10 @@ if(BUILD_POSTEXEC)
     nemsio::nemsio
     sfcio::sfcio
     sigio::sigio)
+  if(wrfio_FOUND)
+    target_link_libraries(${EXENAME} PRIVATE
+      wrfio::wrfio)
+  endif()
   install(TARGETS ${EXENAME} RUNTIME DESTINATION bin)
 endif()
 

--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -170,7 +170,7 @@ list(APPEND EXE_SRC
     wrf_io_flags.h)
 
 # Use IO stubs in place of WRFLIB
-if(NOT wrfio_FOUND)
+if(NOT wrf_io_FOUND)
   list(APPEND EXE_SRC
     io_int_stubs.f)
 endif()
@@ -228,9 +228,9 @@ if(BUILD_POSTEXEC)
     nemsio::nemsio
     sfcio::sfcio
     sigio::sigio)
-  if(wrfio_FOUND)
+  if(wrf_io_FOUND)
     target_link_libraries(${EXENAME} PRIVATE
-      wrfio::wrfio)
+      wrf_io::wrf_io)
   endif()
   install(TARGETS ${EXENAME} RUNTIME DESTINATION bin)
 endif()


### PR DESCRIPTION
This PR:
- enables building the standalone executable with WRF-IO library from NCEPLIBS-wrf_io.
- requires the wrfio library be built with cmake. See NCEPLIBS-wrf_io PR [1](https://github.com/NOAA-EMC/NCEPLIBS-wrf_io/pull/1)

Change-Id: I01537949ef59e839339d07f59faaedb9e14512f5