### PR TITLE
Add COMPONENT variable to scripts for new atmos subdirectory

### DIFF
--- a/jobs/JGLOBAL_NCEPPOST
+++ b/jobs/JGLOBAL_NCEPPOST
@@ -64,6 +64,7 @@ export g2tmpl_ver=${g2tmpl_ver:-v1.5.0}
 ##############################################
 export CDATE=${CDATE:-${PDY}${cyc}}
 export CDUMP=${CDUMP:-${RUN:-"gfs"}}
+export COMPONENT=${COMPONENT:-atmos}
 if [ $RUN_ENVIR = "nco" ]; then
     export ROTDIR=${COMROOT:?}/$NET/$envir
 fi
@@ -81,11 +82,11 @@ export PARMpost=${PARMpost:-$HOMEgfs/parm/post}
 export INLINE_POST=${WRITE_DOPOST:-".false."}
 
 if [ $RUN_ENVIR = "nco" ]; then
-    export COMIN=${COMIN:-$ROTDIR/$RUN.$PDY/$cyc}
-    export COMOUT=${COMOUT:-$ROTDIR/$RUN.$PDY/$cyc}
+    export COMIN=${COMIN:-$ROTDIR/$RUN.$PDY/$cyc/$COMPONENT}
+    export COMOUT=${COMOUT:-$ROTDIR/$RUN.$PDY/$cyc/$COMPONENT}
 else
-    export COMIN="$ROTDIR/$CDUMP.$PDY/$cyc"
-    export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc"
+    export COMIN="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
+    export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
 fi
 [[ ! -d $COMOUT ]] && mkdir -m 775 -p $COMOUT
 

--- a/jobs/JGLOBAL_POST_MANAGER
+++ b/jobs/JGLOBAL_POST_MANAGER
@@ -41,6 +41,7 @@ date
 ####################################
 export NET=${NET:-gfs}
 export RUN=${RUN:-gfs}
+export COMPONENT=${COMPONENT:-atmos}
 
 #################################### 
 # obtain unique process id (pid) and make temp directories
@@ -91,8 +92,8 @@ setpdy.sh
 . PDY
 
 export ROTDIR=${COMROOT:?}/$NET/$envir
-export COMIN=${COMIN:-$ROTDIR/$RUN.$PDY/$cyc}
-export COMOUT=${COMOUT:-$ROTDIR/$RUN.$PDY/$cyc}
+export COMIN=${COMIN:-$ROTDIR/$RUN.$PDY/$cyc/$COMPONENT}
+export COMOUT=${COMOUT:-$ROTDIR/$RUN.$PDY/$cyc/$COMPONENT}
 
 
 ########################################################


### PR DESCRIPTION
The GFSv16 is being restructured to add a component subdirectory under the cycle folder. This PR adds the $COMPONENT variable to the com paths and sets it to "atmos" for the atmospheric component.

Work on this task is documented in this global-workflow issue:

https://github.com/NOAA-EMC/global-workflow/issues/94