### PR TITLE
release/public-v1: update submodule pointer for CMakeModules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 find_package(MPI REQUIRED)
 find_package(PNG REQUIRED)
 find_package(Jasper REQUIRED)
-find_package(NetCDF MODULE REQUIRED)
+find_package(NetCDF REQUIRED COMPONENTS Fortran)
 
 if(OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)

--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -220,11 +220,15 @@ install(
   ARCHIVE DESTINATION lib)
 install(DIRECTORY ${module_dir} DESTINATION include)
 
+# DH* 20200811 - stupid gaea gets the netCDF linker order wrong,
+# thus need to list NETCDF_Fortran_LIBRARIES explicitly before
+# NETCDF_C_LIBRARIES
 add_executable(${EXENAME} ${EXE_SRC})
 target_link_libraries(
   ${EXENAME}
   ${LIBNAME}
-  ${NETCDF_LIBRARIES}
+  ${NETCDF_Fortran_LIBRARIES}
+  ${NETCDF_C_LIBRARIES}
   ${CMAKE_DL_LIBS})
 
 install(TARGETS ${EXENAME} RUNTIME DESTINATION bin)

--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -191,7 +191,7 @@ set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include")
 add_library(${LIBNAME} ${LIB_SRC})
 set_target_properties(${LIBNAME} PROPERTIES Fortran_MODULE_DIRECTORY
                                             ${module_dir})
-target_include_directories(${LIBNAME} PUBLIC ${NETCDF_INCLUDES} ${module_dir})
+target_include_directories(${LIBNAME} PUBLIC ${NETCDF_INCLUDE_DIRS} ${module_dir})
 target_link_libraries(
   ${LIBNAME}
   sp_4


### PR DESCRIPTION
This PR updates the submodule pointer for CMakeModules to point to the latest version of its release/public-v1 branch (which is also tag v1.1.0). This version of CMakeModules only contains two CMake macros to find ESMF and netCDF, nothing else.

Updating CMakeModules requires minor updates to the CMake build config to work with the new FindNetCDF.cmake version.

This has been tested to work with the release/public-v1 branches (or PRs that are in preparation) for the release/public-v1 NCEPLIBS umbrella build.