### PR TITLE
release/public-v1: bugfix for finding NetCDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 find_package(MPI REQUIRED)
 find_package(PNG REQUIRED)
 find_package(Jasper REQUIRED)
-find_package(NetCDF REQUIRED COMPONENTS Fortran)
+find_package(NetCDF MODULE REQUIRED COMPONENTS Fortran)
 
 if(OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)


### PR DESCRIPTION
This bug fix is required for compiling the NCEPLIBS MRW 1.1 code on some platforms. It uses the same `MODULE` version to find NetCDF as UFS_UTILS does, and works with the particular version of CMakeModules used for MRW 1.1.

We will need to retag EMC_post after this merge and update the "post" external in ufs-mrweather-app and the submodule pointer in the NCEPLIBS umbrella build.

For some reason, this bugfix is only required on a certain platforms, on others the current version works.

Follow-up NCEPLIBS umbrella build PR: https://github.com/NOAA-EMC/NCEPLIBS/pull/119