### PR TITLE
Updated support on Odin & Stampede to use NCEPLIBS public-v2 release

### DIFF
--- a/modulefiles/post/v8.0.0-odin
+++ b/modulefiles/post/v8.0.0-odin
@@ -1,14 +1,12 @@
 #%Module######################################################################
 #############################################################
-## Lin.Gan@noaa.gov
-## EMC
-## post v7.0.0
-## Wen Meng 07/2018: set post to v8.0.0 for fv3gfs
+## NSSL
+## post v8.0.0
 #############################################################
 proc ModulesHelp { } {
-puts stderr "Set environment veriables for post"
-puts stderr "This module initializes the users environment"
-puts stderr "to build the post for WCOSS production.\n"
+    puts stderr "Set environment veriables for post"
+    puts stderr "This module initializes the users environment"
+    puts stderr "to build the post for WCOSS production.\n"
 }
 module-whatis "post"
 
@@ -24,59 +22,39 @@ module load cray-libsci
 module load cray-netcdf-hdf5parallel
 module load cray-parallel-netcdf
 module load cray-hdf5-parallel
-module load gcc/6.1.0
+module load gcc/8.3.0
 module load slurm
 
 # Loding nceplibs modules
-module use -a /oldscratch/ywang/external/modulefiles
-module load sigio/v2.0.1
-#module load jasper/v1.900.1
-#module load png/v1.2.44
-#module load z/v1.2.6
-module load sfcio/v1.0.0
-module load nemsio/v2.2.2
-module load bacio/v2.0.2
-#module load g2/v2.5.2
-#module load xmlparse/v2.0.0
-module load gfsio/v1.1.0
-module load ip/v3.0.0
-module load sp/v2.0.2
-module load w3emc/v2.3.0
-module load w3nco/v2.0.6
-module load crtm/v2.2.5
-module load g2/v3.1.0
-module load g2tmpl/v1.5.0
-module load wrfio/1.1.1
-#module load netcdf/3.6.3
-#module load netcdf/4.6.1
+module use -a  /oldscratch/ywang/external/NCEPLIBS_SRWv2.0/modules
+module load sigio
+module load sfcio
+module load nemsio
+module load bacio
+#module load g2
+module load gfsio
+module load ip
+module load sp
+module load w3emc
+module load w3nco
+module load crtm
+module load g2
+module load g2tmpl
+module load wrf_io
+
+setenv SIGIO_INC4 /oldscratch/ywang/external/NCEPLIBS_SRWv2.0/sigio-2.3.2/include
+setenv GFSIO_INC4 /oldscratch/ywang/external/NCEPLIBS_SRWv2.0/gfsio-1.4.1/include
+setenv SFCIO_INC4 /oldscratch/ywang/external/NCEPLIBS_SRWv2.0/sfcio-1.4.1/include
+
+setenv GFSIO_LIB4 /oldscratch/ywang/external/NCEPLIBS_SRWv2.0/gfsio-1.4.1/lib/libgfsio.a
+setenv SIGIO_LIB4 /oldscratch/ywang/external/NCEPLIBS_SRWv2.0/sigio-2.3.2/lib/libsigio.a
+setenv SFCIO_LIB4 /oldscratch/ywang/external/NCEPLIBS_SRWv2.0/sfcio-1.4.1/lib/libsfcio.a
+setenv WRFIO_LIB  /oldscratch/ywang/external/NCEPLIBS_SRWv2.0/wrf_io-1.1.1/lib/libwrf_io.a
 
 setenv NETCDF /opt/cray/pe/netcdf-hdf5parallel/4.6.3.2/INTEL/19.0
 setenv JASPER_LIB "-ljasper"
 setenv PNG_LIB "-lpng"
 
-#setenv NCEPLIBS /mnt/lfs3/projects/hfv3gfs/gwv/ljtjet/lib
-
-#module use /mnt/lfs3/projects/hfv3gfs/gwv/ljtjet/lib/modulefiles
-#module load g2tmpl-intel/1.5.0
-
-#module use /mnt/lfs3/projects/hfv3gfs/gwv/ljtjet/lib/wrf.post.lib/modulefiles
-#module load wrf-io-v1.1.1
-#
-#setenv WRFIO_LIB /mnt/lfs3/projects/hfv3gfs/gwv/ljtjet/lib/wrf.post.lib/v1.1.1/lib/wrf_io/libwrfio_nf.a
-
-
-#set dlib   /mnt/lfs3/projects/hfv3gfs/gwv/ltmp2/lib/g2/v3.1.0/
-#set bname  "G2"
-#
-### Export environment variables
-#setenv ${bname}_SRC  $dlib/src
-#setenv ${bname}_INC4 $dlib/intel/include/g2_v3.1.0_4
-#setenv ${bname}_INCd $dlib/intel/include/g2_v3.1.0_d
-#setenv ${bname}_LIB4 $dlib/intel/libg2_v3.1.0_4.a
-#setenv ${bname}_LIBd $dlib/intel/libg2_v3.1.0_d.a
-#setenv ${bname}_VER v3.1.0
-
-#setenv WRFPATH /mnt/lfs3/projects/hfv3gfs/nwprod/wrf_shared.v1.1.0/
 setenv myFC ftn
 setenv OPENMP "-qopenmp"
 setenv myFCFLAGS "-O3 -convert big_endian -traceback -g -fp-model source -qopenmp -fpp -target-cpu=x86-64"

--- a/modulefiles/post/v8.0.0-stampede
+++ b/modulefiles/post/v8.0.0-stampede
@@ -1,15 +1,14 @@
 #%Module######################################################################
 #############################################################
-## Lin.Gan@noaa.gov
-## EMC
-## post v7.0.0 
-## Wen Meng 07/2018: set post to v8.0.0 for fv3gfs
+## NSSL
+## post v8.0.0
 #############################################################
 proc ModulesHelp { } {
-puts stderr "Set environment veriables for post"
-puts stderr "This module initializes the users environment"
-puts stderr "to build the post for WCOSS production.\n"
+    puts stderr "Set environment veriables for post"
+    puts stderr "This module initializes the users environment"
+    puts stderr "to build the post for WCOSS production.\n"
 }
+
 module-whatis "post"
 
 set ver v8.0.0
@@ -22,23 +21,32 @@ module load parallel-netcdf/4.6.2
 module load phdf5/1.10.4
 
 # Loding nceplibs modules
-#module use -a /mnt/lfs3/projects/hfv3gfs/nwprod/lib/modulefiles
-module use -a /work/00315/tg455890/stampede2/external/modulefiles
-module load sigio/v2.1.0
-module load sfcio/v1.0.0
-module load nemsio/v2.2.3
-module load bacio/v2.0.2
-#module load g2/v2.5.2
-#module load xmlparse/v2.0.0
-module load gfsio/v1.1.0
-module load ip/v3.0.0
-module load sp/v2.0.2
-module load w3emc/v2.3.0
-module load w3nco/v2.0.6
-module load crtm/v2.2.3
-module load g2/v3.1.0
-module load g2tmpl/v1.6.0
-module load wrfio/1.1.1
+# DH* todo - shared directory
+module use -a /work/06146/tg854455/stampede2/ufs-stack-20200728/intel-18.0.2/impi-18.0.2/modules
+# *DH
+module load bacio/2.4.0
+module load crtm/2.3.0
+module load g2/3.4.0
+module load g2tmpl/1.9.0
+module load ip/3.3.0
+module load nemsio/2.5.1
+module load sp/2.3.0
+module load w3emc/2.7.0
+module load w3nco/2.4.0
+
+module load gfsio/1.4.0
+module load sfcio/1.4.0
+module load sigio/2.3.0
+module load wrf_io/1.1.1
+
+setenv SIGIO_INC4 /work/06146/tg854455/stampede2/ufs-stack-20200728/intel-18.0.2/impi-18.0.2/sigio-2.3.0/include
+setenv GFSIO_INC4 /work/06146/tg854455/stampede2/ufs-stack-20200728/intel-18.0.2/impi-18.0.2/gfsio-1.4.0/include
+setenv SFCIO_INC4 /work/06146/tg854455/stampede2/ufs-stack-20200728/intel-18.0.2/impi-18.0.2/sfcio-1.4.0/include
+
+setenv GFSIO_LIB4 /work/06146/tg854455/stampede2/ufs-stack-20200728/intel-18.0.2/impi-18.0.2/gfsio-1.4.0/lib/libgfsio.a
+setenv SIGIO_LIB4 /work/06146/tg854455/stampede2/ufs-stack-20200728/intel-18.0.2/impi-18.0.2/sigio-2.3.0/lib/libsigio.a
+setenv SFCIO_LIB4 /work/06146/tg854455/stampede2/ufs-stack-20200728/intel-18.0.2/impi-18.0.2/sfcio-1.4.0/lib/libsfcio.a
+setenv WRFIO_LIB  /work/06146/tg854455/stampede2/ufs-stack-20200728/intel-18.0.2/impi-18.0.2/wrf_io-1.1.1/lib/libwrf_io.a
 
 setenv NETCDF /opt/apps/intel18/netcdf/4.6.2/x86_64
 setenv JASPER_LIB "-ljasper"
@@ -50,5 +58,5 @@ setenv myFCFLAGS "-O3 -convert big_endian -traceback -g -fp-model source -qopenm
 #
 #setenv myFCFLAGS "-O0 -convert big_endian -fp-model source -openmp -g -check all -ftrapuv -fp-stack-check -fstack-protector -heap-arrays -recursive -traceback"
 
-setenv myCPP /lib/cpp 
+setenv myCPP /lib/cpp
 setenv myCPPFLAGS "-P"


### PR DESCRIPTION
I just updated the module files on Odin and Stampede to use the newly built NCEPLIBS from NCEPLIBS repository from branch "public-v2".
