### PR TITLE
Unify the public-v2 executable name

### DIFF
--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -191,7 +191,7 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
 endif()
 
 set(LIBNAME "nceppost")
-set(EXENAME "nceppost.x")
+set(EXENAME "ncep_post")
 
 set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include")
 


### PR DESCRIPTION
Change the public-v2 executable name from nceppost.x --> ncep_post to be consistent across applications (MRW, EMC operations, community standalone, SRW).  Note that this naming convention is slated to be reviewed and potentially changed again in the future.  Consistency now will make that future step cleaner.  