### PR TITLE
Starting UPP version numbers with 10.0.0 for develop branch

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,1 @@
-9.9.9
-# This is a placeholder version number.
-# It will be replaced with an appropriate version following a discussion within the UPP management.
+10.0.0


### PR DESCRIPTION
Begin UPP version system.  Code managers agreed to start with v10.0.0 series in develop, keeping frozen release branches with separate version series to avoid any confusions.  gfsv16 uses v8* series, and release/public-v2 uses v9* series.  