### PR TITLE
Small fixes for HREFv3 UPP code

### DIFF
--- a/modulefiles/post/v8.0.0-cray-intel
+++ b/modulefiles/post/v8.0.0-cray-intel
@@ -19,7 +19,9 @@ module use -a /usrx/local/prod/modulefiles
 module use -a /gpfs/hps/nco/ops/nwprod/lib/modulefiles
 module load PrgEnv-intel
 module load craype-sandybridge
-module switch intel intel/16.3.210
+# module switch intel intel/16.3.210
+module rm intel
+module load intel/18.1.163
 module load craype/2.3.0
 module load prod_util/1.0.33
 module load cray-libsci/13.0.3
@@ -39,11 +41,10 @@ module load w3nco-intel/2.0.6
 module load cray-netcdf/4.3.2
 module load wrfio-intel/1.1.1
 module load g2tmpl-intel/1.6.0
-module use -a /usrx/local/nceplibs/NCEPLIBS/modulefiles
-module load crtm/2.3.0
+module load crtm-intel/2.3.0
 
 setenv myFC ftn
-setenv OPENMP "-openmp"
+setenv OPENMP "-qopenmp"
 setenv myFCFLAGS "-O2 -convert big_endian -traceback -g -fp-model source -fpp"
 setenv myCPP /lib/cpp 
 setenv myCPPFLAGS "-P"

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -81,7 +81,7 @@
 !
       use vrbls3d,    only: pmid, uh, vh, t, zmid, pint, alpint, q, omga
       use vrbls3d,    only: catedr,mwt,gtg
-      use vrbls2d,    only: pblh, cprate
+      use vrbls2d,    only: pblh, cprate, prec
       use masks,      only: lmh
       use params_mod, only: d00, h99999, h100, h1, h1m12, pq0, a2, a3, a4,    &
                             rhmin, rgamog, tfrz
@@ -3604,7 +3604,7 @@
 !$omp parallel do private(i,j)
                DO J=JSTA,JEND
                  DO I=1,IM
-                   IF (CPRATE(I,J) > PTHRESH) THEN
+                   IF (PREC(I,J) > PTHRESH) THEN
                     GRID1(I,J) = EGRID5(I,J)
                    ELSE
                     GRID1(I,J) = 0


### PR DESCRIPTION
Makes a module change to switch from a dev version of CRTM v2.3 to a prod version.  This change required also changing from Intel 16 and Intel 18 of compiler.  Also changes the precipitation field checked when computing the lightning field (switches to prec from cprate), which is needed since this code is processing runs without parameterized convection (so cprate is always zero).