### PR TITLE
fixed CMake build for removed file GRIBIT.F

### DIFF
--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -67,7 +67,6 @@ list(APPEND LIB_SRC
     GFSPOST.F
     GPVS.f
     grib2_module.f
-    GRIBIT.F
     GRIDAVG.f
     GRIDSPEC.f
     gtg_algo.f90


### PR DESCRIPTION
Fixes #215 

fixed CMake build for removed file GRIBIT.F

