### PR TITLE
Sync scatter fix and update cmake build for removing GRIBIT.F

### DIFF
--- a/sorc/ncep_post.fd/CALPW.f
+++ b/sorc/ncep_post.fd/CALPW.f
@@ -290,7 +290,7 @@
           DO I=1,IM
              DP      = PINT(I,J,L+1) - PINT(I,J,L)
              PW(I,J) = PW(I,J) + Qdum(I,J)*DP*GI*HTM(I,J,L)
-            IF (IDECID == 17) THEN
+            IF (IDECID == 17 .or. IDECID == 20 .or. IDECID == 21) THEN
              PW(I,J) = PW(I,J) + Qdum(I,J)*MAX(DP,0.)*GI*HTM(I,J,L)
             ENDIF
             IF (IDECID == 19) THEN

--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -67,7 +67,6 @@ list(APPEND LIB_SRC
     GFSPOST.F
     GPVS.f
     grib2_module.f
-    GRIBIT.F
     GRIDAVG.f
     GRIDSPEC.f
     gtg_algo.f90


### PR DESCRIPTION
1) Sync the fix of scattering calculation from GEFS V12 implementation
2) Update CMakeLists.txt for removing GRIBIT.F since grib1 output was removed from the UPP.