### PR TITLE
Fix duplicate symbols and include common symbols on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,12 @@ if(OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)
 endif()
 
+if(APPLE)
+  # The linker on macOS does not include `common symbols` by default
+  # Passing the -c flag includes them and fixes an error with undefined symbols
+  set(CMAKE_Fortran_ARCHIVE_FINISH "<CMAKE_RANLIB> -c <TARGET>")
+endif()
+
 find_package(bacio REQUIRED)
 find_package(crtm REQUIRED)
 find_package(g2 REQUIRED)

--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -158,7 +158,6 @@ list(APPEND EXE_SRC
     getVariable.f
     getlvls.f
     intio_tags.f
-    native_endianness.f
     retrieve_index.f
     wrf_io_flags.f
     wrf_io_flags.h)


### PR DESCRIPTION
On macOS common symbols (modules with variables and no functions) aren't included by default, so pass -c to ranlib on macOS.

native_endianness is compiled twice in exe_src and lib_src which results in duplicate symbols.

Fix #320 #319 