### PR TITLE
Enhancement of wafs processing component

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [gtg]
-tag = ncep_post_gtg.v2.0.1
+tag = ncep_post_gtg.v2.0.4
 protocol = git
 repo_url = git@github.com:NCAR/UPP_GTG.git
 local_path = sorc/post_gtg.fd

--- a/scripts/exgfs_atmos_nceppost.sh
+++ b/scripts/exgfs_atmos_nceppost.sh
@@ -202,18 +202,22 @@ then
       export PGIOUT=wafsifile
 
       $POSTGPSH
-      export err=$?; err_chk
+      export err=$?
 
-      # WAFS package doesn't process this part.
-      # Need to be saved for WAFS U/V/T verification, 
-      # resolution higher than WAFS 1.25 deg for future compatibility
-      wafsgrid="latlon 0:1440:0.25 90:721:-0.25"
-      $WGRIB2 $PGBOUT -set_grib_type same -new_grid_winds earth \
+      if [ $err -ne 0 ] ; then
+	  echo " *** GFS POST WARNING: WAFS output failed for analysis, err=$err"
+      else
+
+        # WAFS package doesn't process this part.
+	# Need to be saved for WAFS U/V/T verification, 
+        # resolution higher than WAFS 1.25 deg for future compatibility
+        wafsgrid="latlon 0:1440:0.25 90:721:-0.25"
+	$WGRIB2 $PGBOUT -set_grib_type same -new_grid_winds earth \
               -new_grid_interpolation bilinear -set_bitmap 1 \
 	      -new_grid $wafsgrid ${PGBOUT}.tmp
 
-      if test $SENDCOM = "YES"
-      then
+	if test $SENDCOM = "YES"
+	then
          cp ${PGBOUT}.tmp $COMOUT/${PREFIX}wafs.0p25.anl
          $WGRIB2 -s ${PGBOUT}.tmp > $COMOUT/${PREFIX}wafs.0p25.anl.idx
 
@@ -221,8 +225,9 @@ then
 #            $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2 $job $COMOUT/${PREFIX}wafs.0p25.anl
 #            $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2__WIDX $job $COMOUT/${PREFIX}wafs.0p25.anl.idx
 #         fi
+	fi
+	rm $PGBOUT ${PGBOUT}.tmp
       fi
-      rm $PGBOUT ${PGBOUT}.tmp
    fi
   fi
 ##########################  WAFS U/V/T analysis end  ##########################
@@ -528,16 +533,20 @@ do
                $POSTGPSH
 	  fi
 
-          export err=$?; err_chk
+          export err=$?
 
-          if [ -e $PGBOUT ]
-          then
-          if test $SENDCOM = "YES"
-          then
-              cp $PGBOUT $COMOUT/${PREFIX}wafs.grb2f$fhr
-              cp $PGIOUT $COMOUT/${PREFIX}wafs.grb2if$fhr
-          fi
-          fi
+	  if [ $err -ne 0 ] ; then
+              echo " *** GFS POST WARNING: WAFS output failed for f${fhr}, err=$err"
+	  else
+              if [ -e $PGBOUT ]
+              then
+		  if test $SENDCOM = "YES"
+		  then
+		      cp $PGBOUT $COMOUT/${PREFIX}wafs.grb2f$fhr
+		      cp $PGIOUT $COMOUT/${PREFIX}wafs.grb2if$fhr
+		  fi
+              fi
+	  fi
       fi
       [[ -f wafsfile ]] && rm wafsfile ; [[ -f wafsifile ]] && rm wafsifile
     fi

--- a/ush/gfs_nceppost.sh
+++ b/ush/gfs_nceppost.sh
@@ -349,6 +349,12 @@ ${APRUN:-mpirun.lsf} $POSTGPEXEC < itag > outpost_gfs_${VDATE}_${CTL}
 
 export ERR=$?
 export err=$ERR
+
+if [ $err -ne 0 ] ; then
+    if [ $PGBOUT = "wafsfile" ] ; then
+	exit $err
+    fi
+fi
 $ERRSCRIPT||exit 2
 
 if [ $FILTER = "1" ] ; then


### PR DESCRIPTION
To solve GTG crash issue because of extreme strong wind and make GFS post continue even in case of WAFS failure:
1. modify the GTG source code: when there is a high wind (>500 m/s), send out a warning WITHOUT error message
    and let the computation continue.
2. modify the script so the WAFS failure will not affect generation of GFS pgb file generation.