### PR TITLE
Change INTERFACE to PUBLIC in target_include_directories

### DIFF
--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -193,7 +193,7 @@ add_library(${PROJECT_NAME}::${LIBNAME} ALIAS ${LIBNAME})
 set_target_properties(${LIBNAME} PROPERTIES Fortran_MODULE_DIRECTORY
                                             ${module_dir})
 
-target_include_directories(${LIBNAME} INTERFACE
+target_include_directories(${LIBNAME} PUBLIC
   $<BUILD_INTERFACE:${module_dir}>
   $<INSTALL_INTERFACE:include>)
 


### PR DESCRIPTION
Included directories should be marked as PUBLIC so that the build includes the module directory.

INTERFACE means to only include the module dir only for libraries that consume the target, but UPP itself should also include its modules.

Fix #350 

@climbfuji 