### PR TITLE
added link to built docs on gh-pages branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Examples of UPP products include:
 Support for the UFS UPP is provided through the UFS Forum by the
 Developmental Testbed Center (DTC) for FV3-based applications.
 
+For full documentation see https://noaa-emc.github.io/UPP/.
+
 The UPP uses some of the [NCEPLIBS](https://github.com/NOAA-EMC/NCEPLIBS)
 project. 
 


### PR DESCRIPTION
Fixes #226 

The built documentation (for the develop branch, as of today) is now up on-line via gh-pages.

In this PR I add a link in the README file.

Next steps would be to:
* Continue to improve the documentation.
* Update the on-line documentation with each UPP release.

Future improvements could also involve the possibility of multiple versions of the software on-line at the same time.