### PR TITLE
Disable recursive checkout on gtg code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "sorc/post_gtg.fd"]
 	path = sorc/post_gtg.fd
 	url = https://github.com/NCAR/UPP_GTG
+        update = none


### PR DESCRIPTION
Add a change for skipping submodule sorc/post_gtg.fd checkout for general UPP users.
The users with access of private gtg code repository can check out gtg code as:
`git -c submodule."sorc/post_gtg.fd".update=checkout submodule update --init --recursive`