### PR TITLE
Exception handling if anl input not found (#443)

### DIFF
--- a/scripts/exgdas_atmos_nceppost.sh
+++ b/scripts/exgdas_atmos_nceppost.sh
@@ -18,6 +18,7 @@ echo " Aug 20 - Meng - Remove .ecf extentsion per EE2 review."
 echo " Sep 20 - Meng - Update clean up files per EE2 review."
 echo " Mar 21 - Meng - Update POSTGRB2TBL default setting."
 echo " Oct 21 - Meng - Remove jlogfile for wcoss2 transition."
+echo " Feb 22 - Lin - Exception handling if anl input not found."
 echo "-----------------------------------------------------"
 #####################################################################
 
@@ -178,6 +179,11 @@ then
 
    fi
    rm pgbfile.grib2 
+else
+  #### atmanl file not found need failing job
+  echo " *** FATAL ERROR: No model anl file output "
+  export err=9
+  err_chk
 fi
 
 #----------------------------------

--- a/scripts/exgfs_atmos_nceppost.sh
+++ b/scripts/exgfs_atmos_nceppost.sh
@@ -30,6 +30,7 @@ echo " Mar 21 - Meng - Update POSTGRB2TBL default setting."
 echo " Jun 21 - Mao  - Instead of err_chk, catch err and print out"
 echo "                 WAFS failure warnings to avoid job crashing"
 echo " Oct 21 - Meng - Remove jlogfile for wcoss2 transition."
+echo " Feb 22 - Lin - Exception handling if anl input not found."
 echo "-----------------------------------------------------"
 #####################################################################
 
@@ -235,7 +236,11 @@ then
    fi
   fi
 ##########################  WAFS U/V/T analysis end  ##########################
-
+else
+  #### atmanl file not found need failing job
+  echo " *** FATAL ERROR: No model anl file output "
+  export err=9
+  err_chk
 fi
 
 #----------------------------------


### PR DESCRIPTION
Exception handling to exgdas_atmos_nceppost.sh and exgfs_atmos_nceppost.sh fail the job if input not found.
Fix for issue #443