### PR TITLE
Make executable directory name switchable with exec 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,12 @@ if(BUILD_POSTEXEC)
   endif()
 endif()
 
+### Switch RUNTIME DESTINATION DIR between bin and exec
+set(exec_dir bin)
+if(EMC_EXEC_DIR)
+  set(exec_dir exec)
+endif()
+
 add_subdirectory(sorc)
 add_subdirectory(parm)
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Builds include:
 ```
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install 
-make 
-make test
+cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install
+(or cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install -DEMC_EXEC_DIR=ON)
+make -j 4
 make install
 ```
 

--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -230,7 +230,7 @@ if(BUILD_POSTEXEC)
     target_link_libraries(${EXENAME} PRIVATE
       wrf_io::wrf_io)
   endif()
-  install(TARGETS ${EXENAME} RUNTIME DESTINATION bin)
+  install(TARGETS ${EXENAME} RUNTIME DESTINATION ${exec_dir})
 endif()
 
 install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
@@ -238,6 +238,6 @@ install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
 install(
   TARGETS ${LIBNAME}
   EXPORT ${PROJECT_NAME}Exports
-  RUNTIME DESTINATION bin
+  RUNTIME DESTINATION ${exec_dir}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)


### PR DESCRIPTION
# Description:
- The parameter `RUNTIME DESTINATION` in CMAKE is switchable between `bin` and `exec`.
- The NCO standards require that the directory name of the binary executables should be `exec` (NCO WCOSS Implementation Standards, ver 11.0.0, January 19, 2022, pp 19, Table 4).
- A new parameter `EMC_EXEC_DIR` is introduced for the selection. This is the same as the approach in UFS_UTILS.
- To change the directory name to `exec`, another cmake argument `-DEMC_EXEC_DIR=ON` is necessary when building the app.

# Build Steps:
- For `bin`: Same as before
- For `exec`:
```
mkdir build
cd build
cmake .. -DCMAKE_INSTALL_PREFIX=.. -DEMC_EXEC_DIR=ON 
make -j 4
make install
```

# Issue:
Fix the issue mentioned in #447.