### PR TITLE
Bug fix for SLLEVEL bound issue when not RUC LSM

### DIFF
--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -2292,6 +2292,7 @@
 ! assign soil depths for RUC LSM, hard wire 9 soil depths here
 ! so they aren't missing.
 
+       IF (NSOIL==9) THEN
          SLLEVEL(1) = 0.0
          SLLEVEL(2) = 0.01
          SLLEVEL(3) = 0.04
@@ -2301,6 +2302,7 @@
          SLLEVEL(7) = 1.0
          SLLEVEL(8) = 1.6
          SLLEVEL(9) = 3.0
+       END IF
  
 ! liquid volumetric soil mpisture in fraction using nemsio
       VarName='soill1'


### PR DESCRIPTION
A bug was uncovered by @mark-a-potts with running the SRW using the GNU compiler. #456 

This PR fixes the bug.

An out-of-bound issue was occurring with 'SLLEVEL'. This variable is allocated based on NSOIL, which differs with model LSM. However, this variable is always filled based on 9 levels of RUC LSM in INITPOST_NETCDF.f, and thus creates a bounds issue if it is only allocated for 4 levels as for Noah LSM, etc.

This fix is to add an IF (NSOIL==9) statement (similar to code reading in soil moisture/temp variables for levels beyond 4).

This fix was tested on Cheyenne intel/gnu LAM case and using developer RT on Hera. The only "supposedly" changed result was for rap pe test for WRFPRS.GrbF16 - but I see no diffs. (/scratch1/BMC/dtc/hertneky/upp/developer_rt/rt.log.HERA)