### PR TITLE
Doxygen in EXCH.f, FDLVL.f, FILL_PSETFLD.f, FRZLVL.f, and FRZLVL2.f.

### DIFF
--- a/sorc/ncep_post.fd/EXCH.f
+++ b/sorc/ncep_post.fd/EXCH.f
@@ -1,7 +1,7 @@
 !> @file
-!> @brief Subroutine that exchange one halo row.
+!> @brief Subroutines that exchange one halo row.
 !>
-!> This routine is to exchange one halo row.
+!> These routines are to exchange one halo row.
 !> 
 !> @param[in] A Array to have halos exchanged.
 !> @param[out] A Array with halos exchanged.
@@ -11,7 +11,7 @@
 !> -----|------------|---------
 !> 2000-01-06 | Jim Tuccillo | Initial
 !>
-!> Remarks: The 1st line is an inlined compiler directive that turns off -qcheck
+!> @note The 1st line is an inlined compiler directive that turns off -qcheck
 !> during compilation, even if it's specified as a compiler option in the
 !> makefile (Tuccillo, personal communication;  Ferrier, Feb '02).
 !>
@@ -56,11 +56,11 @@
       end
 
 !!@PROCESS NOCHECK
-!
-!--- The 1st line is an inlined compiler directive that turns off -qcheck
-!    during compilation, even if it's specified as a compiler option in the
-!    makefile (Tuccillo, personal communication;  Ferrier, Feb '02).
-!
+!>
+!> @note The 1st line is an inlined compiler directive that turns off -qcheck
+!> during compilation, even if it's specified as a compiler option in the
+!> makefile (Tuccillo, personal communication;  Ferrier, Feb '02).
+!>
       subroutine exch_f(a)
  
       use ctlblk_mod, only: num_procs, jend, iup, jsta, idn,    &

--- a/sorc/ncep_post.fd/EXCH.f
+++ b/sorc/ncep_post.fd/EXCH.f
@@ -61,6 +61,7 @@
 !> during compilation, even if it's specified as a compiler option in the
 !> makefile (Tuccillo, personal communication;  Ferrier, Feb '02).
 !>
+!> @author Jim Tuccillo IBM @date 2000-01-06
       subroutine exch_f(a)
  
       use ctlblk_mod, only: num_procs, jend, iup, jsta, idn,    &

--- a/sorc/ncep_post.fd/EXCH.f
+++ b/sorc/ncep_post.fd/EXCH.f
@@ -1,37 +1,21 @@
 !> @file
-!
-!> SUBPROGRAM:    EXCH        EXCHANGE ONE HALO ROW
-!!   PRGRMMR: TUCCILLO        ORG: IBM
-!!
-!! ABSTRACT:
-!!     EXCHANGE ONE HALO ROW
-!!
-!! PROGRAM HISTORY LOG:
-!!   00-01-06  TUCCILLO - ORIGINAL
-!!
-!! USAGE:    CALL EXCH(A)
-!!   INPUT ARGUMENT LIST:
-!!      A - ARRAY TO HAVE HALOS EXCHANGED
-!!
-!!   OUTPUT ARGUMENT LIST:
-!!      A - ARRAY WITH HALOS EXCHANGED
-!!
-!!   OUTPUT FILES:
-!!     STDOUT  - RUN TIME STANDARD OUT.
-!!
-!!   SUBPROGRAMS CALLED:
-!!       MPI_SENDRECV
-!!     UTILITIES:
-!!       NONE
-!!     LIBRARY:
-!!       COMMON - CTLBLK.comm
-!!
-!@PROCESS NOCHECK
-!
-!--- The 1st line is an inlined compiler directive that turns off -qcheck
-!    during compilation, even if it's specified as a compiler option in the
-!    makefile (Tuccillo, personal communication;  Ferrier, Feb '02).
-!
+!> @brief Subroutine that exchange one halo row.
+!>
+!> This routine is to exchange one halo row.
+!> 
+!> @param[in] A Array to have halos exchanged.
+!> @param[out] A Array with halos exchanged.
+!>
+!> ### Program history log:
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 2000-01-06 | Jim Tuccillo | Initial
+!>
+!> Remarks: The 1st line is an inlined compiler directive that turns off -qcheck
+!> during compilation, even if it's specified as a compiler option in the
+!> makefile (Tuccillo, personal communication;  Ferrier, Feb '02).
+!>
+!> @author Jim Tuccillo IBM @date 2000-01-06
       SUBROUTINE EXCH(A)
 
       use ctlblk_mod, only: num_procs, jend, iup, jsta, idn, mpi_comm_comp, im,&

--- a/sorc/ncep_post.fd/FDLVL.f
+++ b/sorc/ncep_post.fd/FDLVL.f
@@ -1,71 +1,45 @@
 !> @file
-!
-!> SUBPROGRAM:    FDLVL       COMPUTES FD LEVEL T, Q, U, V
-!!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 92-12-22       
-!!     
-!! ABSTRACT:
-!!     THIS ROUTINE COMPUTES TEMPERATURE, SPEC. HUM, U WIND COMPONENT,
-!!     AND V WIND COMPONENT ON THE NFD=6 FD LEVELS.  THE
-!!     HEIGHT OF THESE LEVELS (IN METERS) IS GIVEN IN THE 
-!!     DATA STATEMENT BELOW.  THE ALGORITHM PROCEEDS AS 
-!!     FOLLOWS. (AGL IN PARENTHESES)
-!!     
-!!     AT EACH MASS POINT MOVE UP VERTICALLY FROM THE LM-TH (LOWEST
-!!     ATMOSPHERIC) ETA LAYER.  FIND THE ETA LAYERS WHOSE 
-!!     HEIGHT (ABOVE GROUND) BOUNDS THE TARGET FD LEVEL HEIGHT.
-!!     VERTICALLY INTERPOLATE TO GET TEMPERATURE AT THIS FD
-!!     LEVEL.  AVERAGE THE FOUR SURROUNDING WINDS
-!!     TO GET A MASS POINT WIND.  VERTICALLY INTERPOLATE THESE
-!!     MASS POINT WINDS TO THE TARGET FD LEVEL.  CONTINUE THIS
-!!     PROCESS UNTIL ALL NFD=6 FD LEVELS HAVE BEEN PROCESSED.
-!!     MOVE ON TO THE NEXT MASS POINT.  
-!!     
-!!     AVERAGING THE FOUR ABOVE GROUND WINDS TO THE MASS POINT
-!!     WAS FOUND TO SMOOTH THE FIELD AND REDUCE THE OCCURRENCE
-!!     OF POINT PEAK WINDS FAR IN EXCESS OF THE WINDS AT 
-!!     ADJACENT POINTS.  MASS POINT VALUES ARE RETURNED.
-!!     
-!! PROGRAM HISTORY LOG:
-!!   92-12-22  RUSS TREADON
-!!   93-11-23  RUSS TREADON - CORRECTED ROUTINE TO COMPUTE
-!!             FD LEVELS WITH REPECT TO MEAN SEA LEVEL.
-!!   94-01-04  MICHAEL BALDWIN - INCLUDE OPTIONS FOR COMPUTING
-!!                               EITHER AGL OR MSL
-!!   98-06-15  T BLACK - CONVERSION FROM 1-D TO 2-D
-!!   00-01-04  JIM TUCCILLO - MPI VERSION            
-!!   02-01-15  MIKE BALDWIN - WRF VERSION
-!!   11-12-14  SARAH LU - ADD GOCART AEROSOL AERFD
-!!     
-!! USAGE:    CALL FDLVL(ITYPE,TFD,QFD,UFD,VFD)
-!!   INPUT ARGUMENT LIST:
-!!     ITYPE    - FLAG THAT DETERMINES WHETHER MSL (1) OR AGL (2)
-!!                   LEVELS ARE USED.
-!!
-!!   OUTPUT ARGUMENT LIST: 
-!!     TFD      - TEMPERATURE (K) ON FD LEVELS.
-!!     QFD      - SPEC HUM ON FD LEVELS.
-!!     UFD      - U WIND (M/S) ON FD LEVELS.
-!!     VFD      - V WIND (M/S) ON FD LEVELS.
-!!     
-!!   OUTPUT FILES:
-!!     NONE
-!!     
-!!   SUBPROGRAMS CALLED:
-!!     UTILITIES:
-!!
-!!     LIBRARY:
-!!       COMMON   - 
-!!                  LOOPS
-!!                  MASKS
-!!                  OPTIONS
-!!                  INDX
-!!     
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : CRAY C-90
-!!
-!      SUBROUTINE FDLVL(NFD,ITYPE,HTFD,TFD,QFD,UFD,VFD,PFD)
-!      SUBROUTINE FDLVL(ITYPE,TFD,QFD,UFD,VFD,PFD,ICINGFD)
+!> @brief Subroutine that computes FD level T, Q, U, V.
+!>
+!> This routine computes temperature, spec. hum, u wind component,
+!> and v wind component on the NFD=6 FD levels. The 
+!> height of these levels (in meters) is given in the 
+!> date statement below. The alogrithm proceeds as
+!> follows. (AGL in parentheses)
+!> 
+!> At each mass point move up vertically from the LM-TH (lowest
+!> atmospheric) ETA layer. Find the ETA layers whose  
+!> height (above ground) bounds the target FD level height.
+!> Vertically interpolate to get temperature at this FD
+!> level. Average the four surrounding winds 
+!> to get a mass point wind. Vertically interpolate these 
+!> mass point winds to the target FD level. Continue this 
+!> process until all NFD=6 FD levels have been processed.
+!> Move on to the next mass point.  
+!>     
+!> Averaging the four above ground winds to the mass point
+!> was found to smooth the field and reduce the occurrence
+!> of point peak winds far in excess of the winds at 
+!> adjacent points. Mass point values are returned.
+!>
+!> @param[in] ITYPE Flag that determines whether MSL (1) or AGL (2) Levels are used.
+!> @param[out] TFD Temperature (K) on FD levels.
+!> @param[out] QFD Spec hum on FD levels.
+!> @param[out] UFD U wind (m/s) on FD levels.
+!> @param[out] VFD V wind (m/s) on FD levels.
+!>     
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1992-12-22 | Russ Treadon | Initial
+!> 1993-11-23 | Russ Treadon | Corrected routine to compute FD levels with respect to mean sea level
+!> 1994-01-04 | Mike Baldwin | Include options for computing either AGL or MSL
+!> 1998-06-15 | T Black      | Conversion from 1-D to 2-D
+!> 2000-01-04 | Jim Tuccillo | MPI version           
+!> 2002-01-15 | Mike Baldwin | WRF version           
+!> 2011-12-14 | Sarah Lu     | Add GOCART aerosol AERFD
+!>
+!> @author Russ Treadon W/NP2 @date 1992-12-22
       SUBROUTINE FDLVL(ITYPE,TFD,QFD,UFD,VFD,PFD,ICINGFD,AERFD)
 
 !     
@@ -468,74 +442,48 @@
       RETURN
       END
 
+!> Computes FD level u,v.
+!>
+!> This routine computes u/v wind component on NFD FD levels.
+!> The height of these levels (in meters) is passed as an 
+!> input parameter. The alogrithm proceeds as
+!> follows. (AGL in parentheses)
+!> 
+!> At each mass point move up vertically from the LM-TH (lowest
+!> atmospheric) ETA layer. Find the ETA layers whose  
+!> height (above ground) bounds the target FD level height.
+!> Vertically interpolate to get temperature at this FD
+!> level. Average the four surrounding winds 
+!> to get a mass point wind. Vertically interpolate these 
+!> mass point winds to the target FD level. Continue this 
+!> process until all NFD FD levels have been processed.
+!> Move on to the next mass point.  
+!>     
+!> Averaging the four above ground winds to the mass point
+!> was found to smooth the field and reduce the occurrence
+!> of point peak winds far in excess of the winds at 
+!> adjacent points. Mass point values are returned.
+!>
+!> @param[in] ITYPE Flag that determines whether MSL (1) or AGL (2) Levels are used.
+!> @param[in] NFD Number of FD levels.
+!> @param[in] HTFD FD levels.
+!> @param[out] UFD U wind (m/s) on FD levels.
+!> @param[out] VFD V wind (m/s) on FD levels.
+!>     
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1992-12-22 | Russ Treadon | Initial
+!> 1993-11-23 | Russ Treadon | Corrected routine to compute FD levels with respect to mean sea level
+!> 1994-01-04 | Mike Baldwin | Include options for computing either AGL or MSL
+!> 1998-06-15 | T Black      | Conversion from 1-D to 2-D
+!> 2000-01-04 | Jim Tuccillo | MPI version           
+!> 2002-01-15 | Mike Baldwin | WRF version           
+!> 2011-12-14 | Sarah Lu     | Add GOCART aerosol AERFD
+!> 2019-09-25 | Y Mao        | Seperate U/V from mass
+!>
+!> @author Russ Treadon W/NP2 @date 1992-12-22
       SUBROUTINE FDLVL_UV(ITYPE,NFD,HTFD,UFD,VFD)
-!$$$  SUBPROGRAM DOCUMENTATION BLOCK
-!                .      .    .     
-! SUBPROGRAM:    FDLVL_UV       COMPUTES FD LEVEL U, V
-!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 92-12-22       
-!     
-! ABSTRACT:
-!     THIS ROUTINE COMPUTES U/V WIND COMPONENT ON NFD FD LEVELS.
-!     THE HEIGHT OF THESE LEVELS (IN METERS) IS PASSED AS AN
-!     INPUT PARAMETER.  THE ALGORITHM PROCEEDS AS 
-!     FOLLOWS. (AGL IN PARENTHESES)
-!     
-!     AT EACH MASS POINT MOVE UP VERTICALLY FROM THE LM-TH (LOWEST
-!     ATMOSPHERIC) ETA LAYER.  FIND THE ETA LAYERS WHOSE 
-!     HEIGHT (ABOVE GROUND) BOUNDS THE TARGET FD LEVEL HEIGHT.
-!     VERTICALLY INTERPOLATE TO GET TEMPERATURE AT THIS FD
-!     LEVEL.  AVERAGE THE FOUR SURROUNDING WINDS
-!     TO GET A MASS POINT WIND.  VERTICALLY INTERPOLATE THESE
-!     MASS POINT WINDS TO THE TARGET FD LEVEL.  CONTINUE THIS
-!     PROCESS UNTIL ALL NFD FD LEVELS HAVE BEEN PROCESSED.
-!     MOVE ON TO THE NEXT MASS POINT.  
-!     
-!     AVERAGING THE FOUR ABOVE GROUND WINDS TO THE MASS POINT
-!     WAS FOUND TO SMOOTH THE FIELD AND REDUCE THE OCCURRENCE
-!     OF POINT PEAK WINDS FAR IN EXCESS OF THE WINDS AT 
-!     ADJACENT POINTS.  MASS POINT VALUES ARE RETURNED.
-!   .     
-!     
-! PROGRAM HISTORY LOG:
-!   92-12-22  RUSS TREADON
-!   93-11-23  RUSS TREADON - CORRECTED ROUTINE TO COMPUTE
-!             FD LEVELS WITH REPECT TO MEAN SEA LEVEL.
-!   94-01-04  MICHAEL BALDWIN - INCLUDE OPTIONS FOR COMPUTING
-!                               EITHER AGL OR MSL
-!   98-06-15  T BLACK - CONVERSION FROM 1-D TO 2-D
-!   00-01-04  JIM TUCCILLO - MPI VERSION            
-!   02-01-15  MIKE BALDWIN - WRF VERSION
-!   11-12-14  SARAH LU - ADD GOCART AEROSOL AERFD
-!   19-25-09  Y Mao - Seperate U/V from mass
-!     
-! USAGE:    CALL FDLVL_UV(ITYPE,NFD,HTFD,UFD,VFD)
-!   INPUT ARGUMENT LIST:
-!     ITYPE    - FLAG THAT DETERMINES WHETHER MSL (1) OR AGL (2)
-!                   LEVELS ARE USED.
-!     NFD      - NUMBER OF FD LEVELS
-!     HTFD     - FD LEVELS
-!
-!   OUTPUT ARGUMENT LIST: 
-!     UFD      - U WIND (M/S) ON FD LEVELS.
-!     VFD      - V WIND (M/S) ON FD LEVELS.
-!     
-!   OUTPUT FILES:
-!     NONE
-!     
-!   SUBPROGRAMS CALLED:
-!     UTILITIES:
-!
-!     LIBRARY:
-!       COMMON   - 
-!                  LOOPS
-!                  MASKS
-!                  OPTIONS
-!                  INDX
-!     
-!   ATTRIBUTES:
-!     LANGUAGE: FORTRAN
-!     MACHINE : CRAY C-90
-!$$$  
 !     
 !
       use vrbls3d,    only: ZMID, PMID, UH, VH
@@ -795,106 +743,76 @@
       RETURN
       END
 
-      SUBROUTINE FDLVL_MASS(ITYPE,NFD,PTFD,HTFD,NIN,QIN,QTYPE,QFD)
-!$$$  SUBPROGRAM DOCUMENTATION BLOCK
-!                .      .    .     
-! SUBPROGRAM:    FDLVL_MASS       COMPUTES FD LEVEL FOR MASS VARIABLES
-!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 92-12-22       
-!     
-! ABSTRACT:
-!     THIS ROUTINE COMPUTES MASS VARIABLES (TEMPERATURE, SPEC. HUM...)
-!     ON NFD FD LEVELS.  THE HEIGHT OF THESE LEVELS (IN METERS) IS
-!     PASSED AS AN INPUT PARAMETER.  THE ALGORITHM PROCEEDS AS 
-!     FOLLOWS. (AGL IN PARENTHESES)
-!     
-!     AT EACH MASS POINT MOVE UP VERTICALLY FROM THE LM-TH (LOWEST
-!     ATMOSPHERIC) ETA LAYER.  FIND THE ETA LAYERS WHOSE 
-!     HEIGHT (ABOVE GROUND) BOUNDS THE TARGET FD LEVEL HEIGHT.
-!     VERTICALLY INTERPOLATE TO GET TEMPERATURE AT THIS FD
-!     LEVEL.  AVERAGE THE FOUR SURROUNDING WINDS
-!     TO GET A MASS POINT WIND.  VERTICALLY INTERPOLATE THESE
-!     MASS POINT WINDS TO THE TARGET FD LEVEL.  CONTINUE THIS
-!     PROCESS UNTIL ALL NFD FD LEVELS HAVE BEEN PROCESSED.
-!     MOVE ON TO THE NEXT MASS POINT.  
-!     
-!     AVERAGING THE FOUR ABOVE GROUND WINDS TO THE MASS POINT
-!     WAS FOUND TO SMOOTH THE FIELD AND REDUCE THE OCCURRENCE
-!     OF POINT PEAK WINDS FAR IN EXCESS OF THE WINDS AT 
-!     ADJACENT POINTS.  MASS POINT VALUES ARE RETURNED.
-!   .     
-!     
-! PROGRAM HISTORY LOG:
-!   92-12-22  RUSS TREADON
-!   93-11-23  RUSS TREADON - CORRECTED ROUTINE TO COMPUTE
-!             FD LEVELS WITH REPECT TO MEAN SEA LEVEL.
-!   94-01-04  MICHAEL BALDWIN - INCLUDE OPTIONS FOR COMPUTING
-!                               EITHER AGL OR MSL
-!   98-06-15  T BLACK - CONVERSION FROM 1-D TO 2-D
-!   00-01-04  JIM TUCCILLO - MPI VERSION            
-!   02-01-15  MIKE BALDWIN - WRF VERSION
-!   11-12-14  SARAH LU - ADD GOCART AEROSOL AERFD
-!   17-06-01  Y Mao - ADD FD levels for GTG(EDPARM CATEDR MWTURB) and allow 
-!                     levels input from control file
-!   19-09-25  Y MAO - SEPERATE MASS FROM UV
-!                     ALLOW ARRAY OF MASS INPUT TO INTERPOLATE MULTIPLE FIELDS 
-!                     WITH THE SAME LEVELS AT ONE TIME
-!                     DUST=>AERFD CAN BE PROCESSED WHEN NIN=NBIN_DU
-!   20-11-10  JESSE MENG - USE UPP_PHYSICS MODULE
-!     
-! USAGE:    CALL FDLVL_MASS(ITYPE,NFD,PTFD,HTFD,NIN,QIN,QTYPE,QFD)
-!   INPUT ARGUMENT LIST:
-!     ITYPE    - FLAG THAT DETERMINES WHETHER MSL (1) OR AGL (2)
-!                   LEVELS ARE USED.
-!     NFD      - NUMBER OF FD LEVELS
-!     PTFD     - FD PRESSURE LEVELS
-!     HTFD     - FD HEIGHT LEVELS
-!     NIN      - NUMBER OF INPUT FIELDS
-!     QIN      - ARRAY OF MASS POINT VALUE ON MODEL LEVELS
-!     QTYPE    - CHARACTER ARRAY OF VARIABLE TYPE TO DIFFERENTIATE UNDERGROUND INTERPOLATION 
+!> Computes FD level for mass variables.
+!>
+!> This routine computes mass variables (temperature, spec. hum...)
+!> on NFD FD levels. The height of these levels (in meters) is 
+!> passed as an input parameter. The alogrithm proceeds as
+!> follows. (AGL in parentheses)
+!> 
+!> At each mass point move up vertically from the LM-TH (lowest
+!> atmospheric) ETA layer. Find the ETA layers whose  
+!> height (above ground) bounds the target FD level height.
+!> Vertically interpolate to get temperature at this FD
+!> level. Average the four surrounding winds 
+!> to get a mass point wind. Vertically interpolate these 
+!> mass point winds to the target FD level. Continue this 
+!> process until all NFD FD levels have been processed.
+!> Move on to the next mass point.
+!>     
+!> Averaging the four above ground winds to the mass point
+!> was found to smooth the field and reduce the occurrence
+!> of point peak winds far in excess of the winds at 
+!> adjacent points. Mass point values are returned.
+!>
+!> NOTES for Q fields by Y Mao:
+!> The following safety check should be executed by the caller of FDLVL subroutines.
+!> Safety check to avoid tiny QFD values.
+!><pre>
+!>    KRF: Need NCAR and NMM WRF cores in this check as well?
+!>    IF(MODELNAME=='RAPR' .OR. MODELNAME=='NCAR' .OR. MODELNAME=='NMM') THEN   !
+!>      DO IFD = 1,NFD
+!>        DO J=JSTA,JEND
+!>        DO I=1,IM
+!>           if(QFD(I,J,IFD) < 1.0e-8) QFD(I,J,IFD)=0.0
+!>        ENDDO
+!>        ENDDO
+!>      ENDDO
+!>    endif
+!></pre>
+!>
+!> @param[in] ITYPE Flag that determines whether MSL (1) or AGL (2) Levels are used.
+!> @param[in] NFD Number of FD levels.
+!> @param[in] PTFD FD pressure levels.
+!> @param[in] HTFD FD height levels.
+!> @param[in] NIN Number of input fields.
+!> @param[in] QIN Array of mass point value on model levels.
+!> @param[in] QTYPE Charater array of variable type to differentiate underground interpolation.
+!><pre>
 !                    C-5 Cloud Species
 !                    K-TURBULENT KINETIC ENERGY
 !                    Q-Specific Humidity
 !                    T-Temperature, 
 !                    W-Vertical Velocity or Omega
-!                    
-!   OUTPUT ARGUMENT LIST: 
-!     QFD     - ARRAY OF MASS POINT VALUE ON FD LEVELS.
-!     
-!   OUTPUT FILES:
-!     NONE
-!     
-!   SUBPROGRAMS CALLED:
-!     UTILITIES:
-!
-!     LIBRARY:
-!       COMMON   - 
-!                  LOOPS
-!                  MASKS
-!                  OPTIONS
-!                  INDX
-!     
-!   ATTRIBUTES:
-!     LANGUAGE: FORTRAN
-!     MACHINE : CRAY C-90
-!$$$  
-!     
-!
-
-! NOTES for Q fields by Y Mao:
-! The following safety check should be executed by the caller of FDLVL subroutines.
-!  safety check to avoid tiny QFD values
-!     !KRF: Need NCAR and NMM WRF cores in this check as well?
-!     IF(MODELNAME=='RAPR' .OR. MODELNAME=='NCAR' .OR. MODELNAME=='NMM') THEN   !
-!       DO IFD = 1,NFD
-!         DO J=JSTA,JEND
-!         DO I=1,IM
-!            if(QFD(I,J,IFD) < 1.0e-8) QFD(I,J,IFD)=0.0
-!         ENDDO
-!         ENDDO
-!       ENDDO
-!     endif
-!
-
+!></pre>
+!> @param[out] QFD Array of mass point value on FD levels.
+!>     
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1992-12-22 | Russ Treadon | Initial
+!> 1993-11-23 | Russ Treadon | Corrected routine to compute FD levels with respect to mean sea level
+!> 1994-01-04 | Mike Baldwin | Include options for computing either AGL or MSL
+!> 1998-06-15 | T Black      | Conversion from 1-D to 2-D
+!> 2000-01-04 | Jim Tuccillo | MPI version           
+!> 2002-01-15 | Mike Baldwin | WRF version           
+!> 2011-12-14 | Sarah Lu     | Add GOCART aerosol AERFD
+!> 2017-06-01 | Y Mao        | Add FD levels for GTG(EDPARM CATEDR MWTURB) and allow levels input from control file
+!> 2019-09-25 | Y Mao        | Seperate mass from UV allow array of mass input to interpolate multiple fields with the same levels at one time. Dust=> AERFD can be processed when NIN=NBIN_DU
+!> 2020-11-10 | Jesse Meng   | Use UPP_PHYSICS module
+!>
+!> @author Russ Treadon W/NP2 @date 1992-12-22
+      SUBROUTINE FDLVL_MASS(ITYPE,NFD,PTFD,HTFD,NIN,QIN,QTYPE,QFD)
       use vrbls3d,    only: T,Q,ZMID,PMID,PINT,ZINT
       use vrbls2d,    only: FIS
       use masks,      only: LMH

--- a/sorc/ncep_post.fd/FDLVL.f
+++ b/sorc/ncep_post.fd/FDLVL.f
@@ -4,8 +4,8 @@
 !> This routine computes temperature, spec. hum, u wind component,
 !> and v wind component on the NFD=6 FD levels. The 
 !> height of these levels (in meters) is given in the 
-!> date statement below. The alogrithm proceeds as
-!> follows. (AGL in parentheses)
+!> data statement below. The alogrithm proceeds as
+!> follows. (AGL-Above ground level in parentheses)
 !> 
 !> At each mass point move up vertically from the LM-TH (lowest
 !> atmospheric) ETA layer. Find the ETA layers whose  
@@ -447,7 +447,7 @@
 !> This routine computes u/v wind component on NFD FD levels.
 !> The height of these levels (in meters) is passed as an 
 !> input parameter. The alogrithm proceeds as
-!> follows. (AGL in parentheses)
+!> follows. (AGL-Above ground level in parentheses)
 !> 
 !> At each mass point move up vertically from the LM-TH (lowest
 !> atmospheric) ETA layer. Find the ETA layers whose  
@@ -748,7 +748,7 @@
 !> This routine computes mass variables (temperature, spec. hum...)
 !> on NFD FD levels. The height of these levels (in meters) is 
 !> passed as an input parameter. The alogrithm proceeds as
-!> follows. (AGL in parentheses)
+!> follows. (AGL-Above ground level in parentheses)
 !> 
 !> At each mass point move up vertically from the LM-TH (lowest
 !> atmospheric) ETA layer. Find the ETA layers whose  
@@ -768,8 +768,8 @@
 !> NOTES for Q fields by Y Mao:
 !> The following safety check should be executed by the caller of FDLVL subroutines.
 !> Safety check to avoid tiny QFD values.
-!><pre>
-!>    KRF: Need NCAR and NMM WRF cores in this check as well?
+!> KRF: Need NCAR and NMM WRF cores in this check as well?
+!> @code
 !>    IF(MODELNAME=='RAPR' .OR. MODELNAME=='NCAR' .OR. MODELNAME=='NMM') THEN   !
 !>      DO IFD = 1,NFD
 !>        DO J=JSTA,JEND
@@ -779,7 +779,7 @@
 !>        ENDDO
 !>      ENDDO
 !>    endif
-!></pre>
+!> @endcode 
 !>
 !> @param[in] ITYPE Flag that determines whether MSL (1) or AGL (2) Levels are used.
 !> @param[in] NFD Number of FD levels.
@@ -789,11 +789,11 @@
 !> @param[in] QIN Array of mass point value on model levels.
 !> @param[in] QTYPE Charater array of variable type to differentiate underground interpolation.
 !><pre>
-!                    C-5 Cloud Species
-!                    K-TURBULENT KINETIC ENERGY
-!                    Q-Specific Humidity
-!                    T-Temperature, 
-!                    W-Vertical Velocity or Omega
+!>                   C-5 Cloud Species
+!>                   K-TURBULENT KINETIC ENERGY
+!>                   Q-Specific Humidity
+!>                   T-Temperature, 
+!>                   W-Vertical Velocity or Omega
 !></pre>
 !> @param[out] QFD Array of mass point value on FD levels.
 !>     

--- a/sorc/ncep_post.fd/FDLVL.f
+++ b/sorc/ncep_post.fd/FDLVL.f
@@ -1,5 +1,5 @@
 !> @file
-!> @brief Subroutine that computes FD level T, Q, U, V.
+!> @brief Subroutine that computes T, Q, U, V on the flight levels (FD).
 !>
 !> This routine computes temperature, spec. hum, u wind component,
 !> and v wind component on the NFD=6 FD levels. The 
@@ -442,7 +442,7 @@
       RETURN
       END
 
-!> Computes FD level u,v.
+!> Computes FD level for u,v.
 !>
 !> This routine computes u/v wind component on NFD FD levels.
 !> The height of these levels (in meters) is passed as an 

--- a/sorc/ncep_post.fd/FILL_PSETFLD.f
+++ b/sorc/ncep_post.fd/FILL_PSETFLD.f
@@ -1,5 +1,5 @@
 !> @file
-!> @brief fill_psetfld reads post xml control file.
+!> @brief fill_psetfld() reads post xml control file.
 !>
 !> This routine set the output field GRIB2 information such    
 !> as parameter name, level type etc from post available field

--- a/sorc/ncep_post.fd/FILL_PSETFLD.f
+++ b/sorc/ncep_post.fd/FILL_PSETFLD.f
@@ -1,12 +1,12 @@
 !> @file
-!> @brief READCNTRLgrb2_xml reads Post xml control file.
+!> @brief fill_psetfld reads post xml control file.
 !>
 !> This routine set the output field GRIB2 information such    
 !> as parameter name, level type etc from post available field
 !> table.
 !>
 !> @param[in] param_ofld output field.
-!> @param[in] param_afld available field in POST.
+!> @param[in] param_afld available field in post.
 !> @param[out] param_ofld output field.
 !>
 !> ### Program History Log

--- a/sorc/ncep_post.fd/FILL_PSETFLD.f
+++ b/sorc/ncep_post.fd/FILL_PSETFLD.f
@@ -1,39 +1,22 @@
 !> @file
-!                .      .    .     
-!> SUBPROGRAM:    READCNTRLgrb2_xml  READS POST xml CONTROL FILE
-!!   PRGRMMR: J. WANG         ORG: NCEP/EMC   DATE: 12-01-27       
-!!     
-!! ABSTRACT:
-!!     THIS ROUTINE SET THE OUTPUT FIELD GRIB2 INFORMATION SUCH    
-!!     AS PARAMETER NAME, LEVEL TYPE ETC FROM POST AVAILABLE FIELD
-!!     TABLE
-!!     
-!! PROGRAM HISTORY LOG:
-!!   01_27_2012  Jun Wang - INITIAL CODE
-!!   04_03_2012  Jun Wang - Add table info
-!!   03_10_2015  Lin Gan  - Using flat file data
-!!     
-!! USAGE:    CALL READCNTRL_XML(kth,kpv,pv)
-!!   INPUT ARGUMENT LIST:
-!!     param_ofld: output field
-!!     param_afld: available field in POST
-!!
-!!   OUTPUT ARGUMENT LIST: 
-!!     param_ofld: output field
-!!     
-!!   OUTPUT FILES:
-!!     NONE
-!!     
-!!   SUBPROGRAMS CALLED:
-!!     UTILITIES:
-!!
-!!     LIBRARY:
-!!       MODULE:   - xml_data_post_t
-!!     
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : IBM      
-!!
+!> @brief READCNTRLgrb2_xml reads Post xml control file.
+!>
+!> This routine set the output field GRIB2 information such    
+!> as parameter name, level type etc from post available field
+!> table.
+!>
+!> @param[in] param_ofld output field.
+!> @param[in] param_afld available field in POST.
+!> @param[out] param_ofld output field.
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 2012-01-27 | Jun Wang | Initial
+!> 2012-04-03 | Jun Wang | Add table info
+!> 2015-03-10 | Lin Gan  | Using flat file data
+!>
+!> @author J. Wang NCEP/EMC @date 2012-01-27
       subroutine fill_psetfld(param_ofld,param_afld)
 !
 

--- a/sorc/ncep_post.fd/FRZLVL.f
+++ b/sorc/ncep_post.fd/FRZLVL.f
@@ -1,67 +1,42 @@
 !> @file
-!
-!> SUBPROGRAM:    FRZLVL      COMPUTES FRZING LVL Z AND RH
-!!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 92-12-22       
-!! T. Smirnova - 8-27-2010 - added PFRZL to the output
-!!     
-!! ABSTRACT:
-!!     THIS ROUTINE COMPUTES THE FREEZING LEVEL HEIGHT AND RELATIVE
-!!     HUMIDITY AT THIS LEVEL FOR EACH MASS POINT ON THE ETA GRID.
-!!     THE COMPUTED FREEZING LEVEL HEIGHT IS THE MEAN SEA LEVEL
-!!     HEIGHT.  AT EACH MASS POINT WE MOVE UP FROM THE SURFACE TO 
-!!     FIND THE FIRST ETA LAYER WHERE THE TEMPERATURE IS LESS THAN
-!!     273.16K.  VERTICAL INTERPOLATION IN TEMPERATURE TO THE FREEZING
-!!     TEMPERATURE GIVES THE FREEZING LEVEL HEIGHT.  PRESSURE AND 
-!!     SPECIFIC HUMIDITY ARE INTERPOLATED TO THIS LEVEL AND ALONG WITH
-!!     THE TEMPERATURE PROVIDE THE FREEZING LEVEL RELATIVE HUMIDITY.
-!!     IF THE SURFACE (SKIN) TEMPERATURE IS BELOW FREEZING, THE ROUTINE
-!!     USES SURFACE BASED FIELDS TO COMPUTE THE RELATIVE HUMIDITY.
-!!     
-!!     NOTE THAT IN POSTING FREEZING LEVEL DATA THE LFM LOOK-ALIKE FILE
-!!     (IE, GRID 26), WE PACK 273.15K AS THE FREEZING TEMPERATURE.  ALL
-!!     OTHER OUTPUT GRIDS USE 273.16K
-!!     
-!! PROGRAM HISTORY LOG:
-!!   92-12-22  RUSS TREADON
-!!   93-06-10  RUSS TREADON - CORRECTED FREEZING LEVEL HEIGHTS TO BE
-!!                            WITH REPSECT TO MEAN SEA LEVEL, NOT  
-!!                            ABOVE GROUND LEVEL.
-!!   98-06-15  T BLACK      - CONVERSION FROM 1-D TO 2-D
-!!   98-08-17  MIKE BALDWIN - COMPUTE RH OVER ICE IF NECESSARY
-!!   98-12-22  MIKE BALDWIN - BACK OUT RH OVER ICE
-!!   00-01-04  JIM TUCCILLO - MPI VERSION
-!!   01-10-25  H CHUANG     - MODIFIED TO PROCESS HYBRID MODEL OUTPUT
-!!   02-01-15  MIKE BALDWIN - WRF VERSION
-!!   19-10-30  Bo CUI - REMOVE "GOTO" STATEMENT
-!!   20-11-10  JESSE MENG   - USE UPP_PHYSICS MODULE
-!!     
-!! USAGE:    CALL FRZLVL(ZFRZ,RHFRZ)
-!!   INPUT ARGUMENT LIST:
-!!     NONE     
-!!
-!!   OUTPUT ARGUMENT LIST: 
-!!     ZFRZ     - ABOVE GROUND LEVEL FREEZING HEIGHT.
-!!     RHFRZ    - RELATIVE HUMIDITY AT FREEZING LEVEL.
-!!     PFRZL    - PRESSURE AT FREEZING LEVEL.
-!!     
-!!   OUTPUT FILES:
-!!     NONE
-!!     
-!!   SUBPROGRAMS CALLED:
-!!     UTILITIES:
-!!       NONE
-!!     LIBRARY:
-!!       COMMON   - 
-!!                  LOOPS
-!!                  PVRBLS
-!!                  MASKS
-!!                  MAPOT
-!!                  POSTVAR
-!!     
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : CRAY C-90
-!!
+!> @brief Subroutine that computes FRZING LVL, Z and RH.
+!>
+!> This routine computes the freezing level height and relative
+!> humidity at this level for each mass point on the ETA grid.
+!> The computed freezing level height is the mean sea level
+!> height. At each mass point we move up from the surface to  
+!> find the first ETA layer where the temperature is less than
+!> 273.16K. Vertical interpolation in temperature to the freezing 
+!> temperature gives the freezing level height. Pressure and   
+!> specific humidity are interpolated to this level and along with
+!> the temperature provide the freezing level relative humidity.
+!> If the surface (skin) temperature is below freezing, the routine
+!> uses surface based fields to compute the relative humidity.
+!> 
+!> Note that in posting freezing level data the LFM look-alike file
+!> (IE, GRID 26), we pack 273.15K as the freezing temperature. All 
+!> other output grids use 273.16K.
+!>
+!> @param[out] ZFRZ Above ground level freezing height.
+!> @param[out] RHFRZ Relative humidity at freezing level.
+!> @param[out] PFRZL pressure at freezing level.
+!> 
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1992-12-22 | Russ Treadon | Initial
+!> 1993-06-05 | Russ Treadon | Corrected freezing level heights to be with respect to mean sea level, not above ground level
+!> 1998-06-15 | T Black      | Conversion from 1-D to 2-D
+!> 1998-08-17 | Mike Baldwin | Compute RH over ice if necessary
+!> 1998-12-22 | Mike Baldwin | Back out RH over ice
+!> 2000-01-04 | Jim Tuccillo | MPI version           
+!> 2001-10-25 | H Chuang     | Modified to process hybrid model output
+!> 2002-01-15 | Mike Baldwin | WRF version
+!> 2010-08-27 | T. Smirnova  | Added PFRZL to the output
+!> 2019-10-30 | Bo Cui       | Remove "GOTO" statement
+!> 2020-11-10 | Jesse Meng   | Use UPP_PHYSICS module
+!>
+!> @author Russ Treadon W/NP2 @date 1992-12-22
       SUBROUTINE FRZLVL(ZFRZ,RHFRZ,PFRZL)
 
 !     

--- a/sorc/ncep_post.fd/FRZLVL2.f
+++ b/sorc/ncep_post.fd/FRZLVL2.f
@@ -1,66 +1,47 @@
 !> @file
-!
-!> SUBPROGRAM:    FRZLVL      COMPUTES FRZING LVL Z AND RH
-!!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 92-12-22       
-!!     
-!! ABSTRACT:
-!!     THIS ROUTINE COMPUTES THE ISOTHERMAL LEVEL HEIGHT AND RELATIVE
-!!     HUMIDITY AT THIS LEVEL FOR EACH MASS POINT ON THE ETA GRID.
-!!     THE COMPUTED ISOTHERMAL LEVEL HEIGHT IS THE MEAN SEA LEVEL
-!!     HEIGHT.  AT EACH MASS POINT WE MOVE UP FROM THE SURFACE TO 
-!!     FIND THE LAST ETA LAYER WHERE THE TEMPERATURE IS LESS THAN
-!!     ISOTHERM AND THE TEMP IN THE LAYER BELOW IS ABOVE ISOTHERM.
-!!     VERTICAL INTERPOLATION IN TEMPERATURE TO THE ISOTHERMAL
-!!     TEMPERATURE GIVES THE ISOTHERMAL LEVEL HEIGHT.  PRESSURE AND 
-!!     SPECIFIC HUMIDITY ARE INTERPOLATED TO THIS LEVEL AND ALONG WITH
-!!     THE TEMPERATURE PROVIDE THE ISOTHERMAL LEVEL RELATIVE HUMIDITY.
-!!     IF THE ENTIRE ATMOSPHERE IS BELOW ISOTHERM, THE ROUTINE
-!!     USES SURFACE BASED FIELDS TO COMPUTE THE RELATIVE HUMIDITY.
-!!     
-!!     NOTE THAT IN POSTING FREEZING LEVEL DATA THE LFM LOOK-ALIKE FILE
-!!     (IE, GRID 26), WE PACK 273.15K AS THE FREEZING TEMPERATURE.  ALL
-!!     OTHER OUTPUT GRIDS USE 273.16K
-!!     
-!! PROGRAM HISTORY LOG:
-!!   92-12-22  RUSS TREADON
-!!   93-06-10  RUSS TREADON - CORRECTED FREEZING LEVEL HEIGHTS TO BE
-!!                            WITH REPSECT TO MEAN SEA LEVEL, NOT  
-!!                            ABOVE GROUND LEVEL.
-!!   95-03-10  MIKE BALDWIN - GET HIGHEST FREEZING LEVEL.
-!!   98-06-15  T BLACK      - CONVERSION FROM 1-D TO 2-D
-!!   98-08-17  MIKE BALDWIN - COMPUTE RH OVER ICE IF NECESSARY
-!!   98-12-22  MIKE BALDWIN - BACK OUT RH OVER ICE
-!!   98-12-22  MIKE BALDWIN - BACK OUT RH OVER ICE
-!!   00-01-04  JIM TUCCILLO - MPI VERSION
-!!   01-10-25  H CHUANG     - MODIFIED TO PROCESS HYBRID MODEL OUTPUT
-!!   02-01-15  MIKE BALDWIN - WRF VERSION
-!!   10-08-27  T. Smirnova  - added PFRZL to the output
-!!   16-01-21  C. Alexander - Generalized function for any isotherm
-!!   20-11-10  JESSE MENG   - USE UPP_PHYSICS MODULE
-!!   21-07-28  W. Meng      - Restrict compuatation from undefined grids
-!!
-!! USAGE:    CALL FRZLVL2(ISOTHERM,ZFRZ,RHFRZ,PFRZL)
-!!   INPUT ARGUMENT LIST:
-!!     ISOTHERM - ISOTHERMAL VALUE OF HEIGHT TO BE OUTPUT. 
-!!
-!!   OUTPUT ARGUMENT LIST: 
-!!     ZFRZ     - ABOVE GROUND LEVE/ZFL AT ISOTHERM HEIGHT.
-!!     RHFRZ    - RELATIVE HUMIDITY AT ISOTHERM LEVEL.
-!!     PFRZL    - PRESSURE AT ISOTHERM LEVEL.
-!!     
-!!   OUTPUT FILES:
-!!     NONE
-!!     
-!!   SUBPROGRAMS CALLED:
-!!     UTILITIES:
-!!       NONE
-!!     LIBRARY:
-!!       COMMON   - 
-!!     
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : CRAY C-90
-!!
+!> @brief Subroutine that computes FRZING LVL, Z and RH.
+!>
+!> This routine computes the isothermal level height and relative
+!> humidity at this level for each mass point on the ETA grid.
+!> The computed isothermal level height is the mean sea level
+!> height. At each mass point we move up from the surface to  
+!> find the last ETA layer where the temperature is less than
+!> isotherm and the temp in the layer below is above isotherm.
+!> Vertical interpolation in temperature to the isotherm
+!> temperature gives the isothermal level height. Pressure and   
+!> specific humidity are interpolated to this level and along with
+!> the temperature provide the isothermal level relative humidity.
+!> If the entire atmosphere is below isotherm, the routine
+!> uses surface based fields to compute the relative humidity.
+!> 
+!> Note that in posting freezing level data the LFM look-alike file
+!> (IE, GRID 26), we pack 273.15K as the freezing temperature. All 
+!> other output grids use 273.16K.
+!>
+!> @param[in] isotherm isothermal value of height to be output.
+!> @param[out] ZFRZ Above ground level/ZFL at isotherm height.
+!> @param[out] RHFRZ Relative humidity at isotherm level.
+!> @param[out] PFRZL pressure at isotherm level.
+!> 
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1992-12-22 | Russ Treadon | Initial
+!> 1993-06-05 | Russ Treadon | Corrected freezing level heights to be with respect to mean sea level, not above ground level
+!> 1995-03-10 | Mike Baldwin | Get highest freezing level
+!> 1998-06-15 | T Black      | Conversion from 1-D to 2-D
+!> 1998-08-17 | Mike Baldwin | Compute RH over ice if necessary
+!> 1998-12-22 | Mike Baldwin | Back out RH over ice
+!> 2000-01-04 | Jim Tuccillo | MPI version           
+!> 2001-10-25 | H Chuang     | Modified to process hybrid model output
+!> 2002-01-15 | Mike Baldwin | WRF version
+!> 2010-08-27 | T. Smirnova  | Added PFRZL to the output
+!> 2016-01-21 | C. Alexander | Generalized function for any isotherm
+!> 2019-10-30 | Bo Cui       | Remove "GOTO" statement
+!> 2020-11-10 | Jesse Meng   | Use UPP_PHYSICS module
+!> 2021-07-28 | W. Meng      | Restrict compuatation from undefined grids
+!>
+!> @author Russ Treadon W/NP2 @date 1992-12-22
       SUBROUTINE FRZLVL2(ISOTHERM,ZFRZ,RHFRZ,PFRZL)
 
 !     


### PR DESCRIPTION
This is part of Issue #392.

Fixes the doxygen warnings in EXCH.f, FDLVL.f, FILL_PSETFLD.f, FRZLVL.f, and FRZLVL2.f.

Please review the changes. Thank you.