### PR TITLE
Doxygen in GFSPOSTSIG.F NGMFLD.f OTLFT.f OTLIFT.f PARA_RANGE.f PROCESS.f and retrieve_index.f.

### DIFF
--- a/sorc/ncep_post.fd/GFSPOSTSIG.F
+++ b/sorc/ncep_post.fd/GFSPOSTSIG.F
@@ -1,6 +1,6 @@
 !> @file
 !>
-!> @brief rtsig reads and transforms sigma file.
+!> @brief rtsig() reads and transforms sigma file.
 !>
 !> This subprogram reads a sigma file and transforms
 !> the fields to a designated global grid.
@@ -225,7 +225,7 @@ subroutine rtsig(lusig,head,k1,k2,kgds,ijo,levs,ntrac,jcap,lnt2,me,     &
 end subroutine  
 
 ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-!> modstuff computes model coordinate dependent functions.
+!> modstuff() computes model coordinate dependent functions.
 !>
 !> This subprogram computes fields which depend on the model coordinate
 !> such as pressure thickness and vertical velocity.
@@ -249,7 +249,7 @@ end subroutine
 !> Date | Programmer | Comments
 !> -----|------------|---------
 !> 1999-10-18 | Mark Iredell | Initial
-!> 2013-04-19 | Jun Wang     | Add option to get pi by using 8byte real computation
+!> 2013-04-19 | Jun Wang     | Add option to get pi by using 8 byte real computation
 !>
 !> @author Mark Iredell np23 @date 1999-10-18
   subroutine modstuff(km,idvc,idsl,nvcoord,vcoord,ps,psx,psy,d,u,v,&
@@ -300,7 +300,7 @@ end subroutine
   end subroutine
 
 !-------------------------------------------------------------------------------
-!> modstuff2 computes model coordinate dependent functions.
+!> modstuff2() computes model coordinate dependent functions.
 !>
 !> This subprogram computes fields which depend on the model coordinate
 !> such as pressure thickness and vertical velocity.
@@ -326,7 +326,7 @@ end subroutine
 !> Date | Programmer | Comments
 !> -----|------------|---------
 !> 1999-10-18 | Mark Iredell      | Initial
-!> 2013-04-19 | Jun  Wang         | Add option to get pi by using 8byte real computation
+!> 2013-04-19 | Jun  Wang         | Add option to get pi by using 8 byte real computation
 !> 2013-08-13 | Shrinivas Moorthi | Modified to include im points and thread
 !>
 !> @author Mark Iredell np23 @date 1999-10-18
@@ -404,7 +404,7 @@ end subroutine
   end subroutine
 
 !-----------------------------------------------------------------------
-!> trssc transforms sigma spectral fields to grid.
+!> trssc() transforms sigma spectral fields to grid.
 !>
 !> Transforms sigma spectral fields to grid and converts
 !> log surface pressure to surface pressure and virtual temperature

--- a/sorc/ncep_post.fd/GFSPOSTSIG.F
+++ b/sorc/ncep_post.fd/GFSPOSTSIG.F
@@ -1,77 +1,54 @@
 !> @file
-!
-!> Subprogram: rtsig      Read and transform sigma file
-!!   Prgmmr: Iredell      Org: np23        Date: 1999-10-18
-!!
-!! Abstract: This subprogram reads a sigma file and transforms
-!!   the fields to a designated global grid.
-!!
-!! Program history log:
-!!   1999-10-18  Mark Iredell
-!!   2013-04-19  Jun  Wang:  add option to get tmp and ps(in pascal) 
-!!                           from enthalpy and ps(cb) option
-!!   2013-05-06 Shrinivas Moorthi: Initialize midea to 0
-!!   2013-05-07 Shrinivas Moorthi: Remove mo3, mct, midea and define io3, ict etc
-!!                                 correctly and get correct cloud condensate.
-!!   2013-08-02 Shrinivas Moorthi: Rewrote the whole routine to read the sigma
-!!                                 file differently and to read all tracers
-!!                                 Addedd sptezj for two 2d fields
-!!   2014-02-20 Shrinivas Moorthi: Modified conversion from spectral to grid
-!!                                 taking advantage of threding in SP library.
-!!                                 This really speeds up the code
-!!                                 Also threaded loop for Temperature from Tv
-
-!!
-!! Usage:  call rtsig(lusig,head,k1,k2,kgds,ijo,nct,                     &
-!!                    h,p,px,py,t,tx,ty,u,v,d,z,sh,o3,ct,iret,o,o2)
-!!   Input argument list:
-!!     lusig    integer(sigio_intkind) sigma file unit number
-!!     head     type(sigio_head) sigma file header
-!!     k1       integer first model level to return
-!!     k2       integer last model level to return
-!!     kgds     integer (200) GDS to which to transform
-!!     ijo      integer dimension of output fields
-!!     levs     integer number of total vertical levels
-!!     ntrac    integer number of output tracers
-!!     jcap     integer number of waves
-!!     lnt2     integer (jcap+1)*(jcap+2)
-!!   Output argument list:
-!!     h        real (ijo) surface orography (m)
-!!     p        real (ijo) surface pressure (Pa)
-!!     px       real (ijo) log surface pressure x-gradient (1/m)
-!!     py       real (ijo) log surface pressure y-gradient (1/m)
-!!     t        real (ijo,k1:k2) temperature (K)
-!!     tx       real (ijo,k1:k2) virtual temperature x-gradient (K/m)
-!!     ty       real (ijo,k1:k2) virtual temperature y-gradient (K/m)
-!!     u        real (ijo,k1:k2) x-component wind (m/s)
-!!     v        real (ijo,k1:k2) y-component wind (m/s)
-!!     d        real (ijo,k1:k2) wind divergence (1/s)
-!!     trc      real (ijo,k1:k2,ntrac) tracers
-!!                                1 = specific humidity (kg/kg)
-!!                                2 = Ozone mixing ratio (kg/kg)
-!!                                3 = cloud condensate mixing ratio (kg/kg)
-!!                                .
-!!                                .
-!!                                    atomic oxyge, oxygen etc
-!!
-!!     iret     integer return code
-!!
-!! Modules used:
-!!   sigio_r_module sigma file I/O
-!!
-!! Subprograms called:
-!!   sigio_rrdati   read sigma single data field
-!!   sptez          scalar spectral transform
-!!   sptezd         gradient spectral transform
-!!   sptezm         multiple scalar spectral transform
-!!   sptezmv        multiple vector spectral transform
-!!
-!! Attributes:
-!!   Language: Fortran 90
-!!
-!!
-! Add Iredells subroutine to read sigma files
-!-------------------------------------------------------------------------------
+!>
+!> @brief rtsig reads and transforms sigma file.
+!>
+!> This subprogram reads a sigma file and transforms
+!> the fields to a designated global grid.
+!> Add Iredells subroutine to read sigma files.
+!>
+!> @param[out] lusig integer(sigio_intkind) sigma file unit number.
+!> @param[out] head type(sigio_head) sigma file header.
+!> @param[out] k1 integer first model level to return.
+!> @param[out] k2 integer last model level to return.
+!> @param[out] kgds integer (200) GDS to which to transform.
+!> @param[out] ijo integer dimension of output fields.
+!> @param[out] levs integer number of total vertical levels.
+!> @param[out] ntrac integer number of output tracers.
+!> @param[out] jcap integer number of waves.
+!> @param[out] lnt2 integer (jcap+1)*(jcap+2).
+!> @param[out] h real (ijo) surface orography (m).
+!> @param[out] p real (ijo) surface pressure (Pa).
+!> @param[out] px real (ijo) log surface pressure x-gradient (1/m).
+!> @param[out] py real (ijo) log surface pressure y-gradient (1/m).
+!> @param[out] t real (ijo,k1:k2) temperature (K).
+!> @param[out] tx real (ijo,k1:k2) virtual temperature x-gradient (K/m).
+!> @param[out] ty real (ijo,k1:k2) virtual temperature y-gradient (K/m).
+!> @param[out] u real (ijo,k1:k2) x-component wind (m/s).
+!> @param[out] v real (ijo,k1:k2) y-component wind (m/s).
+!> @param[out] d real (ijo,k1:k2) wind divergence (1/s).
+!> @param[out] trc real (ijo,k1:k2,ntrac) tracers.
+!><pre>
+!>                                   1 = specific humidity (kg/kg)
+!>                                   2 = Ozone mixing ratio (kg/kg)
+!>                                   3 = cloud condensate mixing ratio (kg/kg)
+!>                                   .
+!>                                   .
+!>                                       atomic oxyge, oxygen etc
+!>
+!></pre>
+!> @param[out] iret Integer return code.
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1999-10-18 | Mark Iredell      | Initial
+!> 2013-04-19 | Jun  Wang         | Add option to get tmp and ps(in pascal) from enthalpy and ps(cb) option
+!> 2013-05-06 | Shrinivas Moorthi | Initialize midea to 0
+!> 2013-05-07 | Shrinivas Moorthi | Remove mo3, mct, midea and define io3, ict etc correctly and get correct cloud condensate.
+!> 2013-08-02 | Shrinivas Moorthi | Rewrote the whole routine to read the sigma file differently and to read all tracers. Added sptezj for two 2d fields
+!> 2014-02-20 | Shrinivas Moorthi | Modified conversion from spectral to grid taking advantage of threding in SP library. This really speeds up the code. Also threaded loop for Temperature from Tv
+!>
+!> @author Mark Iredell np23 @date 1999-10-18
 subroutine rtsig(lusig,head,k1,k2,kgds,ijo,levs,ntrac,jcap,lnt2,me,     &
                  h,p,px,py,t,u,v,d,trc,iret)
 
@@ -248,43 +225,35 @@ subroutine rtsig(lusig,head,k1,k2,kgds,ijo,levs,ntrac,jcap,lnt2,me,     &
 end subroutine  
 
 ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!> modstuff computes model coordinate dependent functions.
+!>
+!> This subprogram computes fields which depend on the model coordinate
+!> such as pressure thickness and vertical velocity.
+!>
+!> @param[in] km integer number of levels.
+!> @param[in] idvc integer vertical coordinate id (1 for sigma and 2 for hybrid).
+!> @param[in] idsl integer type of sigma structure (1 for phillips or 2 for mean).
+!> @param[in] nvcoord integer number of vertical coordinates.
+!> @param[in] vcoord real (km+1,nvcoord) vertical coordinates.
+!> @param[in] ps real surface pressure (Pa).
+!> @param[in] psx real log surface pressure x-gradient (1/m).
+!> @param[in] psy real log surface pressure y-gradient (1/m).
+!> @param[in] d real (km) wind divergence (1/s).
+!> @param[in] u real (km) x-component wind (m/s).
+!> @param[in] v real (km) y-component wind (m/s).
+!> @param[out] pi real (km+1) interface pressure (Pa).
+!> @param[out] pm real (km) mid-layer pressure (Pa).
+!> @param[out] om real (km) vertical velocity (Pa/s).
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1999-10-18 | Mark Iredell | Initial
+!> 2013-04-19 | Jun Wang     | Add option to get pi by using 8byte real computation
+!>
+!> @author Mark Iredell np23 @date 1999-10-18
   subroutine modstuff(km,idvc,idsl,nvcoord,vcoord,ps,psx,psy,d,u,v,&
                       pi,pm,om)
-!$$$  Subprogram documentation block
-!
-! Subprogram: modstuff   Compute model coordinate dependent functions
-!   Prgmmr: Iredell      Org: np23        Date: 1999-10-18
-!
-! Abstract: This subprogram computes fields which depend on the model coordinate
-!           such as pressure thickness and vertical velocity.
-!
-! Program history log:
-!   1999-10-18  Mark Iredell
-!   2013-04-19  Jun  Wang:  add option to get pi by using 8byte real computation
-!
-! Usage:  call modstuff(km,idvc,idsl,nvcoord,vcoord,ps,psx,psy,d,u,v,&
-!                       pd,pi,pm,os,om,px,py)
-!   Input argument list:
-!     km       integer number of levels
-!     idvc     integer vertical coordinate id (1 for sigma and 2 for hybrid)
-!     idsl     integer type of sigma structure (1 for phillips or 2 for mean)
-!     nvcoord  integer number of vertical coordinates
-!     vcoord   real (km+1,nvcoord) vertical coordinates
-!     ps       real surface pressure (Pa)
-!     psx      real log surface pressure x-gradient (1/m)
-!     psy      real log surface pressure y-gradient (1/m)
-!     d        real (km) wind divergence (1/s)
-!     u        real (km) x-component wind (m/s)
-!     v        real (km) y-component wind (m/s)
-!   Output argument list:
-!     pi       real (km+1) interface pressure (Pa)
-!     pm       real (km) mid-layer pressure (Pa)
-!     om       real (km) vertical velocity (Pa/s)
-!
-! Attributes:
-!   Language: Fortran 90
-!
-!$$$
     use sigio_module, only: sigio_modprd
     implicit none
     integer,intent(in):: km,idvc,idsl,nvcoord
@@ -331,46 +300,38 @@ end subroutine
   end subroutine
 
 !-------------------------------------------------------------------------------
+!> modstuff2 computes model coordinate dependent functions.
+!>
+!> This subprogram computes fields which depend on the model coordinate
+!> such as pressure thickness and vertical velocity.
+!>
+!> @param[in] im integer inner computational domain.
+!> @param[in] ix integer maximum inner dimension.
+!> @param[in] km integer number of levels.
+!> @param[in] idvc integer vertical coordinate id (1 for sigma and 2 for hybrid).
+!> @param[in] idsl integer type of sigma structure (1 for phillips or 2 for mean).
+!> @param[in] nvcoord integer number of vertical coordinates.
+!> @param[in] vcoord real (km+1,nvcoord) vertical coordinates.
+!> @param[in] ps real surface pressure (Pa).
+!> @param[in] psx real log surface pressure x-gradient (1/m).
+!> @param[in] psy real log surface pressure y-gradient (1/m).
+!> @param[in] d real (km) wind divergence (1/s).
+!> @param[in] u real (km) x-component wind (m/s).
+!> @param[in] v real (km) y-component wind (m/s).
+!> @param[out] pi real (km+1) interface pressure (Pa).
+!> @param[out] pm real (km) mid-layer pressure (Pa).
+!> @param[out] om real (km) vertical velocity (Pa/s).
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1999-10-18 | Mark Iredell      | Initial
+!> 2013-04-19 | Jun  Wang         | Add option to get pi by using 8byte real computation
+!> 2013-08-13 | Shrinivas Moorthi | Modified to include im points and thread
+!>
+!> @author Mark Iredell np23 @date 1999-10-18
   subroutine modstuff2(im,ix,km,idvc,idsl,nvcoord,vcoord,ps,psx,psy,d,u,v,&
                        pi,pm,om,me)
-!$$$  Subprogram documentation block
-!
-! Subprogram: modstuff   Compute model coordinate dependent functions
-!   Prgmmr: Iredell      Org: np23        Date: 1999-10-18
-!
-! Abstract: This subprogram computes fields which depend on the model coordinate
-!           such as pressure thickness and vertical velocity.
-!
-! Program history log:
-!   1999-10-18  Mark Iredell
-!   2013-04-19  Jun  Wang:  add option to get pi by using 8byte real computation
-!   2013-08-13  Shrinivas Moorthi - Modified to include im points and thread
-!
-! Usage:  call modstuff(km,idvc,idsl,nvcoord,vcoord,ps,psx,psy,d,u,v,&
-!                       pd,pi,pm,os,om,px,py)
-!   Input argument list:
-!     im       integer - inner computational domain
-!     ix       integer - maximum inner dimension
-!     km       integer number of levels
-!     idvc     integer vertical coordinate id (1 for sigma and 2 for hybrid)
-!     idsl     integer type of sigma structure (1 for phillips or 2 for mean)
-!     nvcoord  integer number of vertical coordinates
-!     vcoord   real (km+1,nvcoord) vertical coordinates
-!     ps       real surface pressure (Pa)
-!     psx      real log surface pressure x-gradient (1/m)
-!     psy      real log surface pressure y-gradient (1/m)
-!     d        real (km) wind divergence (1/s)
-!     u        real (km) x-component wind (m/s)
-!     v        real (km) y-component wind (m/s)
-!   Output argument list:
-!     pi       real (km+1) interface pressure (Pa)
-!     pm       real (km) mid-layer pressure (Pa)
-!     om       real (km) vertical velocity (Pa/s)
-!
-! Attributes:
-!   Language: Fortran 90
-!
-!$$$
     use sigio_module, only : sigio_modprd
     implicit none
     integer,                    intent(in)  :: im,ix,km,idvc,idsl,nvcoord,me
@@ -443,61 +404,47 @@ end subroutine
   end subroutine
 
 !-----------------------------------------------------------------------
+!> trssc transforms sigma spectral fields to grid.
+!>
+!> Transforms sigma spectral fields to grid and converts
+!> log surface pressure to surface pressure and virtual temperature
+!> to temperature.
+!>
+!> @param[in] jcap integer spectral truncation.
+!> @param[in] nc integer first dimension (nc>=(jcap+1)*(jcap+2)).
+!> @param[in] km integer number of levels.
+!> @param[in] ntrac integer number of tracers.
+!> @param[in] idvm integer mass variable id.
+!> @param[in] idrt integer data representation type.
+!> @param[in] lonb integer number of longitudes.
+!> @param[in] latb integer number of latitudes.
+!> @param[in] ijl integer horizontal dimension.
+!> @param[in] j1 integer first latitude.
+!> @param[in] j2 integer last latitude.
+!> @param[in] jc integer number of cpus.
+!> @param[in] szs real (nc) orography.
+!> @param[in] sps real (nc) log surface pressure.
+!> @param[in] st real (nc,levs) virtual temperature.
+!> @param[in] sd real (nc,levs) divergence.
+!> @param[in] sz real (nc,levs) vorticity.
+!> @param[in] sq real (nc,levs*ntrac) tracers.
+!> @param[out] zs real (ijl) orography.
+!> @param[out] ps real (ijl) surface pressure.
+!> @param[out] t real (ijl,km) temperature.
+!> @param[out] u real (ijl,km) zonal wind.
+!> @param[out] v real (ijl,km) meridional wind.
+!> @param[out] q real (ijl,km*ntrac) tracers.
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1999-10-18 | Mark Iredell | Initial
+!>
+!> @author Mark Iredell w/nmc23 @date 1992-10-31
       subroutine trssc(jcap,nc,km,ntrac,idvc,idvm,idsl,nvcoord,vcoord,     &
                        cpi,idrt,lonb,latb,ijl,ijn,j1,j2,jc,chgq0,          &
                        szs,sps,st,sd,sz,sq,gfszs,gfsps,gfsp,gfsdp,         &
                        gfst,gfsu,gfsv,gfsq,gfsw)
-!$$$  subprogram documentation block
-!
-! subprogram:    trssc       transform sigma spectral fields to grid
-!   prgmmr: iredell          org: w/nmc23     date: 92-10-31
-!
-! abstract: transforms sigma spectral fields to grid and converts
-!   log surface pressure to surface pressure and virtual temperature
-!   to temperature.
-!
-! program history log:
-!   91-10-31  mark iredell
-!
-! usage:    call trssc(jcap,nc,km,ntrac,idvm,
-!    &                 idrt,lonb,latb,ijl,j1,j2,jc,
-!    &                 szs,sps,st,sd,sz,sq,zs,ps,t,u,v,q)
-!   input argument list:
-!     jcap         integer spectral truncation
-!     nc           integer first dimension (nc>=(jcap+1)*(jcap+2))
-!     km           integer number of levels
-!     ntrac        integer number of tracers
-!     idvm         integer mass variable id
-!     idrt         integer data representation type
-!     lonb         integer number of longitudes
-!     latb         integer number of latitudes
-!     ijl          integer horizontal dimension
-!     j1           integer first latitude
-!     j2           integer last latitude
-!     jc           integer number of cpus
-!     szs          real (nc) orography
-!     sps          real (nc) log surface pressure
-!     st           real (nc,levs) virtual temperature
-!     sd           real (nc,levs) divergence
-!     sz           real (nc,levs) vorticity
-!     sq           real (nc,levs*ntrac) tracers
-!   output argument list:
-!     zs           real (ijl) orography
-!     ps           real (ijl) surface pressure
-!     t            real (ijl,km) temperature
-!     u            real (ijl,km) zonal wind
-!     v            real (ijl,km) meridional wind
-!     q            real (ijl,km*ntrac) tracers
-!
-! subprograms called:
-!   sptran       perform a scalar spherical transform
-!
-! attributes:
-!   language: fortran
-!
-!c$$$
-!!      use gfsio_module
-!      use gfsio_rst
       implicit none
       integer,intent(in)::jcap,nc,km,ntrac,idvc,idvm,idsl,nvcoord,idrt,lonb,latb
       integer,intent(in)::ijl,ijn,j1,j2,jc,chgq0

--- a/sorc/ncep_post.fd/NGMFLD.f
+++ b/sorc/ncep_post.fd/NGMFLD.f
@@ -3,20 +3,17 @@
 !>
 !> This routine computes a handful of NGM layer mean 
 !> fields.  This is done to provide a fully complete 
-!> ETA NGM look-alike output file.  The sigma (layer)
-!> fields computed bu this routine are tabulated below.
-!><pre>
-!>       Sigma (layer)         Field(s)
-!>      ---------------     --------------
-!>      0.47191-1.00000          RH
-!>      0.47171-0.96470          RH
-!>      0.18019-0.47191          RH
-!>      0.84368-0.98230          RH
-!>      0.85000-1.00000         MCONV
-!> where
-!>      RH    = Relative humidity
-!>      MCONV = Moisture convergence
-!></pre>
+!> ETA NGM look-alike output file.
+!> ### The sigma (layer) fields computed bu this routine are tabulated below.
+!> Sigma (layer) | Field(s) | 
+!> --------------|----------|
+!> 0.47191 - 1.00000 |  RH    |
+!> 0.47171 - 0.96470 |  RH    |
+!> 0.18019 - 0.47191 |  RH    |
+!> 0.84368 - 0.98230 |  RH    |
+!> 0.85000 - 1.00000 | MCONV  |
+!> where RH = Relative humidity and MCONV = Moisture convergence
+!>
 !> Layer means are a summation over ETA layers mapping into
 !> The pressure range corresponding to the sigma range above.
 !> The calculation of these bounding pressures is done at

--- a/sorc/ncep_post.fd/NGMFLD.f
+++ b/sorc/ncep_post.fd/NGMFLD.f
@@ -1,5 +1,5 @@
 !> @file
-!> @brief NGMFLD computes layer mean NGM fields
+!> @brief ngmfld() computes layer mean NGM fields
 !>
 !> This routine computes a handful of NGM layer mean 
 !> fields.  This is done to provide a fully complete 

--- a/sorc/ncep_post.fd/NGMFLD.f
+++ b/sorc/ncep_post.fd/NGMFLD.f
@@ -1,81 +1,50 @@
 !> @file
-!                .      .    .     
-!> SUBPROGRAM:    NGMFLD      COMPUTES LAYER MEAN NGM FIELDS
-!!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 92-12-22
-!!     
-!! ABSTRACT:
-!!     THIS ROUTINE COMPUTES A HANDFUL OF NGM LAYER MEAN 
-!!     FIELDS.  THIS IS DONE TO PROVIDE A FULLY COMPLETE 
-!!     ETA NGM LOOK-ALIKE OUTPUT FILE.  THE SIGMA (LAYER)
-!!     FIELDS COMPUTED BY THIS ROUTINE ARE TABULATED BELOW.
-!!     
-!!           SIGMA (LAYER)         FIELD(S)
-!!          ---------------     --------------
-!!          0.47191-1.00000          RH
-!!          0.47171-0.96470          RH
-!!          0.18019-0.47191          RH
-!!          0.84368-0.98230          RH
-!!          0.85000-1.00000         MCONV
-!!     WHERE 
-!!          RH    = RELATIVE HUMIDITY
-!!          MCONV = MOISTURE CONVERGENCE
-!!
-!!     LAYER MEANS ARE A SUMMATION OVER ETA LAYERS MAPPING INTO
-!!     THE PRESSURE RANGE CORRESPONDING TO THE SIGMA RANGE ABOVE.
-!!     THE CALCULATION OF THESE BOUNDING PRESSURES IS DONE AT 
-!!     EACH HORIZONTAL GRID POINT BASED ON THE SURFACE PRESSURE.
-!!     EACH TERM IN THE SUMMATION IS WEIGHTED BY THE THICKNESS OF
-!!     THE ETA LAYER.  THE FINAL LAYER MEAN IS THIS SUM NORMALIZED
-!!     BY THE TOTAL DEPTH OF THE LAYER.
-
-!!
-!!     
-!! PROGRAM HISTORY LOG:
-!!   92-12-22  RUSS TREADON
-!!   93-07-27  RUSS TREADON - MODIFIED SUMMATION LIMITS FROM
-!!                            0.66*PSFC TO 0.75*PSFC AND 0.33*PSFC 
-!!                            TO 0.50*PSFC, WHERE PSFC IS THE
-!!                            SURFACES PRESSURE.  THE REASON FOR
-!!                            THIS CHANGE WAS RECOGNITION THAT IN 
-!!                            THE LFM 0.33 AND 0.66 WERE MEASURED
-!!                            FROM THE SURFACE TO THE TROPOPAUSE,
-!!                            NOT THE TOP OF THE MODEL.
-!!   93-09-13  RUSS TREADON - RH CALCULATIONS WERE MADE INTERNAL
-!!                            TO THE ROUTINE.
-!!   98-06-16  T BLACK      - CONVERSION FROM 1-D TO 2-D
-!!   98-08-18  MIKE BALDWIN - COMPUTE RH OVER ICE
-!!   98-12-22  MIKE BALDWIN - BACK OUT RH OVER ICE
-!!   00-01-04  JIM TUCCILLO - MPI VERSION
-!!   02-04-24  MIKE BALDWIN - WRF VERSION
-!!     
-!!     
-!! USAGE:    CALL NGMFLD(RH4710,RH4796,RH1847,RH8498,QM8510)
-!!   INPUT ARGUMENT LIST:
-!!     NONE
-!!
-!!   OUTPUT ARGUMENT LIST: 
-!!     RH4710   - SIGMA LAYER 0.47-1.00 MEAN RELATIVE HUMIDITY.
-!!     RH4796   - SIGMA LAYER 0.47-0.96 MEAN RELATIVE HUMIDITY.
-!!     RH1847   - SIGMA LAYER 0.18-0.47 MEAN RELATIVE HUMIDITY.
-!!     RH8498   - SIGMA LAYER 0.84-0.98 MEAN RELATIVE HUMIDITY.
-!!     QM8510   - SIGMA LAYER 0.85-1.00 MEAN MOISTURE CONVERGENCE.
-!!     
-!!   OUTPUT FILES:
-!!     NONE
-!!     
-!!   LIBRARY:
-!!     COMMON   - 
-!!                MASKS
-!!                OPTIONS
-!!                LOOPS
-!!                MAPOT
-!!                DYNAMD
-!!                INDX
-!!
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : CRAY C-90
-!!
+!> @brief NGMFLD computes layer mean NGM fields
+!>
+!> This routine computes a handful of NGM layer mean 
+!> fields.  This is done to provide a fully complete 
+!> ETA NGM look-alike output file.  The sigma (layer)
+!> fields computed bu this routine are tabulated below.
+!><pre>
+!>       Sigma (layer)         Field(s)
+!>      ---------------     --------------
+!>      0.47191-1.00000          RH
+!>      0.47171-0.96470          RH
+!>      0.18019-0.47191          RH
+!>      0.84368-0.98230          RH
+!>      0.85000-1.00000         MCONV
+!> where
+!>      RH    = Relative humidity
+!>      MCONV = Moisture convergence
+!></pre>
+!> Layer means are a summation over ETA layers mapping into
+!> The pressure range corresponding to the sigma range above.
+!> The calculation of these bounding pressures is done at
+!> each horizontal grid point based on the surface pressure.
+!> Each term in the summation is weighted by the thickness of
+!> the ETA layer.  The final layer mean is this sum normalized
+!> by the total depth of the layer.
+!>
+!> @param[out] RH4710 Sigma layer 0.47-1.00 mean relative humidity.
+!> @param[out] RH4796 Sigma layer 0.47-0.96 mean relative humidity.
+!> @param[out] RH1847 Sigma layer 0.18-0.47 mean relative humidity.
+!> @param[out] RH8498 Sigma layer 0.84-0.98 mean relative humidity.
+!> @param[out] QM8510 Sigma layer 0.85-1.00 mean moisture convergence.
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1992-12-22 | Russ Treadon | Initial
+!> 1993-07-27 | Russ Treadon | Modified summation limits from 0.66*PSFC to 0.75*PSFC and 0.33*PSFC to 0.50*PSFC, where PSFC is the surfaces pressure.  The reason for this change was recognition that in the LFM 0.33 and 0.66 were measured from the surface to the tropopause not the top of the model.
+!> 1993-09-13 | Russ Treadon | RH calculations were made internal to the routine.
+!> 1996-03-04 | Mike Baldwin | Change PW CALC to include CLD WTR
+!> 1998-06-16 | T Black      | Conversion from 1-D to 2-D
+!> 1998-08-17 | Mike Baldwin | Compute RH over ice
+!> 1998-12-22 | Mike Baldwin | Back out RH over ice
+!> 2000-01-04 | Jim Tuccillo | MPI Version
+!> 2002-04-24 | Mike Baldwin | WRF Version
+!>
+!> @author Russ Treadon W/NP2 @date 1992-12-22
       SUBROUTINE NGMFLD(RH4710,RH4796,RH1847,RH8498,QM8510)
 
 !     

--- a/sorc/ncep_post.fd/OTLFT.f
+++ b/sorc/ncep_post.fd/OTLFT.f
@@ -1,5 +1,5 @@
 !> @file
-!> @brief OTLFT computes lifted index.
+!> @brief otlft() computes lifted index.
 !>
 !> This routine computes lifts a parcel specified by the
 !> passed pressure, temperature, and specific humidity to

--- a/sorc/ncep_post.fd/OTLFT.f
+++ b/sorc/ncep_post.fd/OTLFT.f
@@ -1,50 +1,29 @@
 !> @file
-!
-!> SUBPROGRAM:    OTLFT       COMPUTES LIFTED INDEX
-!!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 93-03-10       
-!!     
-!! ABSTRACT:
-!!     THIS ROUTINE COMPUTES LIFTS A PARCEL SPECIFIED BY THE
-!!     PASSED PRESSURE, TEMPERATURE, AND SPECIFIC HUMIDITY TO
-!!     500MB AND THEN COMPUTES A LIFTED INDEX.  THIS LIFTED 
-!!     LIFTED INDEX IS THE DIFFERENCE BETWEEN THE LIFTED 
-!!     PARCEL'S TEMPERATURE AT 500MB AND THE AMBIENT 500MB
-!!     TEMPERATURE.
-!!     
-!! PROGRAM HISTORY LOG:
-!!   93-03-10  RUSS TREADON - MODIFIED OTLIFT2 TO LIFT PARCELS
-!!                            SPECIFIED BY PASSED P, T, AND Q.
-!!   98-06-15  T BLACK      - CONVERSION FROM 1-D TO 2-D
-!!   00-01-04  JIM TUCCILLO - MPI VERSION
-!!   02-06-17  MIKE BALDWIN - WRF VERSION
-!!   11-04-12  GEOFF MANIKIN - USE VIRTUAL TEMPERATURE
-!!   20-11-10  JESSE MENG   - USE UPP_PHYSICS MODULE
-!!     
-!! USAGE:    CALL OTLFT(PBND,TBND,QBND,SLINDX)
-!!   INPUT ARGUMENT LIST:
-!!     PBND     - PARCEL PRESSURE.
-!!     TBND     - PARCEL TEMPERATURE.
-!!     QBND     - PARCEL SPECIFIC HUMIDITY.
-!!
-!!   OUTPUT ARGUMENT LIST: 
-!!     SLINDX   - LIFTED INDEX.
-!!     
-!!   OUTPUT FILES:
-!!     NONE
-!!     
-!!   SUBPROGRAMS CALLED:
-!!     UTILITIES:
-!!       NONE
-!!     LIBRARY:
-!!       COMMON   - CTLBLK
-!!                  LOOPS
-!!                  MASKS
-!!                  PHYS
-!!     
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : CRAY C-90
-!!
+!> @brief OTLFT computes lifted index.
+!>
+!> This routine computes lifts a parcel specified by the
+!> passed pressure, temperature, and specific humidity to
+!> 500mb and then computes a lifted index.  This lifted
+!> lifted index is the difference between the lifted
+!> parcel's temperature at 500mb and the ambient 500mb
+!> temperature.
+!>
+!> @param[in] PBND Parcel pressure.
+!> @param[in] TBND Parcel temperature.
+!> @param[in] QBND Parcel specific humidity.
+!> @param[out] SLINDX Lifted index.
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1993-03-10 | Russ Treadon  | Initial. Modified OTLIFT2 to lift parcels specified by passed P, T, and Q.
+!> 1998-06-15 | T Black       | Conversion from 1-D to 2-D
+!> 2000-01-04 | Jim Tuccillo  | MPI Version
+!> 2002-06-17 | Mike Baldwin  | WRF Version
+!> 2011-04-12 | Geoff Manikin | Use virtual temperature
+!> 2020-11-10 | Jesse Meng    | Use UPP_PHYSICS Module
+!>
+!> @author Russ Treadon W/NP2 @date 1993-03-10
       SUBROUTINE OTLFT(PBND,TBND,QBND,SLINDX)
 
 !     

--- a/sorc/ncep_post.fd/OTLIFT.f
+++ b/sorc/ncep_post.fd/OTLIFT.f
@@ -1,44 +1,27 @@
 !> @file
-!
-!> SUBPROGRAM:    OTLIFT      COMPUTES SFC TO 500MB LIFTED INDEX
-!!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 93-03-10       
-!!     
-!! ABSTRACT:
-!!     THIS ROUTINE COMPUTES A SURFACE TO 500MB LIFTED INDEX.
-!!     THE LIFTED PARCEL IS FROM THE FIRST ATMOSPHERIC ETA 
-!!     LAYER (IE, THE ETA LAYER CLOSEST TO THE MODEL GROUND).
-!!     THE LIFTED INDEX IS THE DIFFERENCE BETWEEN THIS PARCEL'S
-!!     TEMPERATURE AT 500MB AND THE AMBIENT 500MB TEMPERATURE.
-!!     
-!! PROGRAM HISTORY LOG:
-!!   ??-??-??  ??? - SUBROUTINE OTLIFT IN ETA MODEL.
-!!   93-03-10  RUSS TREADON - ADAPTED OTLIFT FOR USE WITH NEW POST. 
-!!   98-06-18  T BLACK      - CONVERSION FROM 1-D TO 2-D
-!!   00-01-04  JIM TUCCILLO - MPI VERSION
-!!   01-10-25  H CHUANG - MODIFIED TO PROCESS HYBRID MODEL OUTPUT
-!!   02-06-11  MIKE BALDWIN - WRF VERSION
-!!   11-04-12  GEOFF MANIKIN - USE VIRTUAL TEMPERATURE
-!!   20-11-10  JESSE MENG   - USE UPP_PHYSICS MODULE
-!!     
-!! USAGE:    CALL OTLIFT(SLINDX)
-!!   INPUT ARGUMENT LIST:
-!!
-!!   OUTPUT ARGUMENT LIST: 
-!!     SLINDX   - LIFTED INDEX.
-!!     
-!!   OUTPUT FILES:
-!!     NONE
-!!     
-!!   SUBPROGRAMS CALLED:
-!!     UTILITIES:
-!!       NONE
-!!     LIBRARY:
-!!       COMMON   - CTLBLK
-!!     
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : CRAY C-90
-!!
+!> @brief OTLIFT computes SFC to 500mb lifted index.
+!>
+!> This routine computes a surface to 500mb lifted index.
+!> The lifted parcel is from the first atmpspheric ETA
+!> layer (ie, the ETA layer closest to the model ground).
+!> The lifted index is the difference between this parcel's
+!> temperature at 500mb and the ambient 500mb temperature.
+!>
+!> @param[out] SLINDX lifted index.
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> ????-??-?? | ???           | Subroutine OTLIFT in ETA model.
+!> 1993-03-10 | Russ Treadon  | Adapted OTLIFT for use with new post.
+!> 1998-06-18 | T Black       | Conversion from 1-D to 2-D
+!> 2000-01-04 | Jim Tuccillo  | MPI Version
+!> 2001-10-25 | H Chuang      | Modified to process hybrid model output
+!> 2002-06-11 | Mike Baldwin  | WRF Version
+!> 2011-04-12 | Geoff Manikin | Use virtual temperature
+!> 2020-11-10 | Jesse Meng    | Use UPP_PHYSICS Module
+!>
+!> @author Russ Treadon W/NP2 @date 1993-03-10
       SUBROUTINE OTLIFT(SLINDX)
 
 !     

--- a/sorc/ncep_post.fd/OTLIFT.f
+++ b/sorc/ncep_post.fd/OTLIFT.f
@@ -1,5 +1,5 @@
 !> @file
-!> @brief OTLIFT computes SFC to 500mb lifted index.
+!> @brief otlift() computes SFC to 500mb lifted index.
 !>
 !> This routine computes a surface to 500mb lifted index.
 !> The lifted parcel is from the first atmpspheric ETA

--- a/sorc/ncep_post.fd/PARA_RANGE.f
+++ b/sorc/ncep_post.fd/PARA_RANGE.f
@@ -1,37 +1,21 @@
 !> @file
-!
-!> SUBPROGRAM:    PARA_RANGE  SET UP DECOMPOSITION VALUES
-!!   PRGRMMR: TUCCILLO        ORG: IBM
-!!
-!! ABSTRACT:
-!!     SETS UP DECOMOSITION VALUES
-!!
-!! PROGRAM HISTORY LOG:
-!!   00-01-06  TUCCILLO - ORIGINAL
-!!
-!! USAGE:    CALL PARA_RANGE (N1,N2,NPROCS,IRANK,ISTA,IEND)(A)
-!!   INPUT ARGUMENT LIST:
-!!     N1 - FIRST INTERATE VALUE
-!!     N2 - LAST INTERATE VALUE
-!!     NPROCS - NUMBER OF MPI TASKS
-!!     IRANK - MY TAKS ID
-!!
-!!   OUTPUT ARGUMENT LIST:
-!!     ISTA - FIRST LOOP VALUE
-!!     IEND - LAST LOOP VALUE
-!!
-!!   OUTPUT FILES:
-!!     STDOUT  - RUN TIME STANDARD OUT.
-!!
-!!   SUBPROGRAMS CALLED:
-!!     UTILITIES:
-!!       NONE
-!!     LIBRARY:
-!!
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : IBM RS/6000 SP
-!!
+!> @brief PARA_RANGE sets up decomposition values.
+!>
+!> This subroutine sets up decomposition values.
+!>
+!> @param[in] N1 First interate value.
+!> @param[in] N2 Last interate value.
+!> @param[in] NPROCS Number of MPI tasks.
+!> @param[in] IRANK My taks ID.
+!> @param[out] ISTA First loop value.
+!> @param[out] IEND Last loop value.
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 2000-01-06 | Jim Tuccillo | Initial
+!>
+!> @author Jim Tuccillo IBM @date 2000-01-06
       SUBROUTINE PARA_RANGE (N1,N2,NPROCS,IRANK,ISTA,IEND)
 
       implicit none

--- a/sorc/ncep_post.fd/PARA_RANGE.f
+++ b/sorc/ncep_post.fd/PARA_RANGE.f
@@ -1,5 +1,5 @@
 !> @file
-!> @brief PARA_RANGE sets up decomposition values.
+!> @brief para_range() sets up decomposition values.
 !>
 !> This subroutine sets up decomposition values.
 !>

--- a/sorc/ncep_post.fd/PROCESS.f
+++ b/sorc/ncep_post.fd/PROCESS.f
@@ -1,53 +1,30 @@
 !> @file
-!
-!> SUBPROGRAM:    PROCESS     DRIVER FOR MAJOR POST ROUTINES.
-!!   PRGRMMR: TREADON         ORG: W/NP2      DATE: 92-12-21
-!!
-!! ABSTRACT:
-!!     THIS ROUTINE CALLS THE MAJOR POST PROCESSOR ROUTINES.
-!!     THESE ROUTINES ARE
-!!        MDLFLD  - CALCULATE NMC SLP, SET BELOW SURFACE FIELDS,
-!!                  AND POSTS DATA ON MODEL SURFACES.
-!!        MDL2P   - POSTS DATA ON ISOBARIC SURFACES.
-!!        SURFCE  - POSTS SOUNDING DATA, SURFACE BASED FIELDS,
-!!                  AND STATIC OR FIXED FIELDS.
-!!        CLDRAD  - POST SOUNDING/CLOUD/RADIATION FIELDS.
-!!        MISCLN  - POST MISCELLANEOUS (SPECIAL) FIELDS.
-!!        FIXED   - POST FIXED FIELDS.
-!!
-!! PROGRAM HISTORY LOG:
-!!   92-12-21  RUSS TREADON
-!!   98-06-01  T BLACK - CONVERSION OF POST FROM 1-D TO 2-D
-!!   00-01-05  JIM TUCCILLO - MPI VERSION
-!!   01-10-25  H CHUANG - MODIFIED TO PROCESS HYBRID MODEL OUTPUT
-!!   02-06-19  MIKE BALDWIN - WRF VERSION
-!!   11-02-04  Jun Wang - add grib2 option
-!!
-!! USAGE:    CALL PROCESS
-!!   INPUT ARGUMENT LIST:
-!!     NONE
-!!
-!!   OUTPUT ARGUMENT LIST:
-!!     NONE
-!!
-!!   OUTPUT FILES:
-!!     NONE
-!!
-!!   SUBPROGRAMS CALLED:
-!!     UTILITIES:
-!!       MDLFLD   - POST DATA MDL SURFACES.
-!!       MDL2P    - POST DATA ON PRESSURE SURFACES.
-!!       SURFCE   - POST SURFACE BASED FIELDS.
-!!       CLDRAD   - POST SOUNDING/CLOUD/RADIATION FIELDS.
-!!       MISCLN   - POST MISCELLANEOUS FIELDS.
-!!       FIXED    - POST FIXED FIELDS.
-!!     LIBRARY:
-!!       COMMON   - OUTGRD
-!!
-!!   ATTRIBUTES:
-!!     LANGUAGE: FORTRAN
-!!     MACHINE : CRAY C-90
-!!
+!> @brief PROCESS is a driver for major post routines.
+!>
+!> This routine calls the major post processor routines.
+!> <pre>
+!> These routines are
+!> MDLFLD  - Calculate NMC SLP, set below surface fields,
+!>           and posts data on model surfaces.
+!> MDL2P   - Posts data on isobaric surfaces.
+!> SURFCE  - Posts sounding data  surface based fields,
+!>           and static or fixed fields.
+!> CLDRAD  - Post sounding/cloud/radiation fields.
+!> MISCLN  - Post miscellaneous (special) fields.
+!> FIXED   - Post fixed fields.
+!> </pre>
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1992-12-21 | Russ Treadon | Initial
+!> 1998-06-01 | T Black      | Conversion from 1-D to 2-D
+!> 2000-01-05 | Jim Tuccillo | MPI Version
+!> 2001-10-25 | H CHUANG     | Modified to process hybrid model output
+!> 2002-06-19 | Mike Baldwin | WRF Version
+!> 2011-02-04 | Jun Wang     | Add grib2 option
+!>
+!> @author Russ Treadon W/NP2 @date 1992-12-21
       SUBROUTINE PROCESS(kth,kpv,th,pv,iostatusD3D)
 !
 !----------------------------------------------------------------------------

--- a/sorc/ncep_post.fd/PROCESS.f
+++ b/sorc/ncep_post.fd/PROCESS.f
@@ -1,5 +1,5 @@
 !> @file
-!> @brief PROCESS is a driver for major post routines.
+!> @brief process() is a driver for major post routines.
 !>
 !> This routine calls the major post processor routines.
 !> <pre>

--- a/sorc/ncep_post.fd/retrieve_index.f
+++ b/sorc/ncep_post.fd/retrieve_index.f
@@ -1,31 +1,22 @@
 !> @file
-!                .      .    .                                       .
-!> subprogram:    retrieve_index  get record number of desired variable
-!!   prgmmr: parrish          org: np22                date: 2004-11-29
-!!
-!! abstract: by examining previously generated inventory of wrf binary restart file,
-!!             find record number that contains the header record for variable
-!!             identified by input character variable "string".
-!!
-!! program history log:
-!!   2004-11-29  parrish
-!!
-!!   input argument list:
-!!     string           - mnemonic for variable desired
-!!     varname_all      - list of all mnemonics obtained from inventory of file
-!!     nrecs            - total number of sequential records counted in wrf
-!!                        binary restart file
-!!
-!!   output argument list:
-!!     index            - desired record number
-!!     iret             - return status, set to 0 if variable was found,
-!!                        non-zero if not.
-!!
-!! attributes:
-!!   language: f90
-!!   machine:  ibm RS/6000 SP
-!!
-!!
+!> @brief retrieve_index gets record number of desired variable.
+!>
+!> By examining previously generated inventory of wrf binary restart file,
+!> find record number that contains the header record for variable
+!> identified by input character variable "string".
+!>
+!> @param[in] string Mnemonic for variable desired.
+!> @param[in] varname_all List of all mnemonics obtained from inventory of file.
+!> @param[in] nrecs Total number of sequential records counted in wrf binary restart file.
+!> @param[out] index Desired record number.
+!> @param[out] iret Return status, set to 0 if variable was found, non-zero if not.
+!>
+!> ### Program History Log
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 2004-11-29 | Parrish | Initial
+!>
+!> @author Parrish np22 @date 2004-11-29
       subroutine retrieve_index(index,string,varname_all,nrecs,iret)
 
 

--- a/sorc/ncep_post.fd/retrieve_index.f
+++ b/sorc/ncep_post.fd/retrieve_index.f
@@ -1,5 +1,5 @@
 !> @file
-!> @brief retrieve_index gets record number of desired variable.
+!> @brief retrieve_index() gets record number of desired variable.
 !>
 !> By examining previously generated inventory of wrf binary restart file,
 !> find record number that contains the header record for variable


### PR DESCRIPTION
This is part of Issue #392.

Fix the doxygen warnings in GFSPOSTSIG.F NGMFLD.f OTLFT.f OTLIFT.f PARA_RANGE.f PROCESS.f and retrieve_index.f.

Please take a look at the changes. Thank you.