### PR TITLE
Update global post scripts for coupled

### DIFF
--- a/scripts/exgfs_atmos_nceppost.sh
+++ b/scripts/exgfs_atmos_nceppost.sh
@@ -39,11 +39,12 @@ set -x
 cd $DATA
 
 # specify model output format type: 4 for nemsio, 3 for sigio
-msg="HAS BEGUN on `hostname`"
+msg="HAS BEGUN on $(hostname)"
 postmsg "$msg"
 
 export POSTGPSH=${POSTGPSH:-$USHgfs/gfs_nceppost.sh}
 export GFSDOWNSH=${GFSDOWNSH:-$USHgfs/fv3gfs_downstream_nems.sh}
+export GFSDOWNSHF=${GFSDOWNSHF:-$USHgfs/inter_flux.sh}
 export GFSDWNSH=${GFSDWNSH:-$USHgfs/fv3gfs_dwn_nems.sh}
 export TRIMRH=${TRIMRH:-$USHgfs/trim_rh.sh}
 export MODICEC=${MODICEC:-$USHgfs/mod_icec.sh}
@@ -61,13 +62,14 @@ export IO=${LONB:-1440}
 export JO=${LATB:-721}
 export OUTTYP=${OUTTYP:-4}
 export FLXF=${FLXF:-"YES"}
+export FLXGF=${FLXGF:-"YES"} 
 export GOESF=${GOESF:-"YES"}
 export WAFSF=${WAFSF:-"NO"}
 export PGBF=${PGBF:-"YES"}
 export TCYC=${TCYC:-".t${cyc}z."}
 export OUTPUT_FILE=${OUTPUT_FILE:-"nemsio"}
 export PREFIX=${PREFIX:-${RUN}${TCYC}}
-if [ $OUTTYP -eq 4 ] ; then
+if [ $OUTTYP -eq 4 ]; then
   if [ $OUTPUT_FILE = "netcdf" ]; then
     export SUFFIX=".nc"
   else
@@ -92,170 +94,148 @@ export IDRT=${IDRT:-0} # IDRT=0 is setting for outputting grib files on lat/lon 
 # Post Analysis Files before starting the Forecast Post
 ############################################################
 # Process analysis when post_times is 00
- export stime=`echo $post_times | cut -c1-3`
-if [ $OUTTYP -eq 4 ] ; then
+export stime=$(echo $post_times | cut -c1-3)
+if [ $OUTTYP -eq 4 ]; then
   export loganl=$COMIN/${PREFIX}atmanl${SUFFIX}
 else
   export loganl=$COMIN/${PREFIX}sanl
 fi
 
-#----------------------------------
 if [ ${stime} = "anl" ]; then
-#----------------------------------
+  if [ -f $loganl ]; then
+    # add new environmental variables for running new ncep post
+    # Validation date
+    export VDATE=${PDY}${cyc}
+    # specify output file name from chgres which is input file name to nceppost
+    # if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
+    # new imported variable for global_nceppost.sh
+    export GFSOUT=${PREFIX}gfsioanl
 
-if test -f $loganl 
-then
-   
-# add new environmental variables for running new ncep post
-# Validation date
-   export VDATE=${PDY}${cyc}
-# specify output file name from chgres which is input file name to nceppost
-# if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
-# new imported variable for global_nceppost.sh
-   export GFSOUT=${PREFIX}gfsioanl
+    # specify smaller control file for GDAS because GDAS does not
+    # produce flux file, the default will be /nwprod/parm/gfs_cntrl.parm
+    if [ $GRIBVERSION = 'grib2' ]; then
+      # use grib2 nomonic table in product g2tmpl directory as default 
+      export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
+      export PostFlatFile=${PostFlatFile:-$PARMpost/postxconfig-NT-GFS-ANL.txt}
+      export CTLFILE=$PARMpost/postcntrl_gfs_anl.xml
+    fi
 
-# specify smaller control file for GDAS because GDAS does not
-# produce flux file, the default will be /nwprod/parm/gfs_cntrl.parm
-   if [ $GRIBVERSION = 'grib2' ]; then
-# use grib2 nomonic table in product g2tmpl directory as default 
-     export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
-     export PostFlatFile=${PostFlatFile:-$PARMpost/postxconfig-NT-GFS-ANL.txt}
-     export CTLFILE=$PARMpost/postcntrl_gfs_anl.xml
-   fi
+    [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
+    if [ $OUTTYP -eq 4 ]; then
+      ln -fs $COMIN/${PREFIX}atmanl${SUFFIX} nemsfile
+      export NEMSINP=nemsfile
+      ln -fs $COMIN/${PREFIX}sfcanl${SUFFIX} flxfile
+      export FLXINP=flxfile
+    fi
 
-   [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
-   if [ $OUTTYP -eq 4 ] ; then
-     ln -fs $COMIN/${PREFIX}atmanl${SUFFIX} nemsfile
-     export NEMSINP=nemsfile
-     ln -fs $COMIN/${PREFIX}sfcanl${SUFFIX} flxfile
-     export FLXINP=flxfile
-   fi
+    export PGBOUT=pgbfile
+    export PGIOUT=pgifile
+    export PGBOUT2=pgbfile.grib2
+    export PGIOUT2=pgifile.grib2.idx
+    export IGEN=$IGEN_ANL
+    export FILTER=0
 
-   export PGBOUT=pgbfile
-   export PGIOUT=pgifile
-   export PGBOUT2=pgbfile.grib2
-   export PGIOUT2=pgifile.grib2.idx
-   export IGEN=$IGEN_ANL
-   export FILTER=0
+    $POSTGPSH
+    export err=$?; err_chk
 
-   $POSTGPSH
-   export err=$?; err_chk
-   
-   if test $GRIBVERSION = 'grib2'
-   then
-     mv $PGBOUT $PGBOUT2
-   fi
+    if [ $GRIBVERSION = 'grib2' ]; then
+      mv $PGBOUT $PGBOUT2
+    fi
 
-#  Process pgb files
-   if test "$PGBF" = 'YES'
-   then
-     export FH=-1
-     export downset=${downset:-2}
-     $GFSDOWNSH
-     export err=$?; err_chk
-   fi
+    #  Process pgb files
+    if [ "$PGBF" = 'YES' ]; then
+      export FH=-1
+      export downset=${downset:-2}
+      $GFSDOWNSH
+      export err=$?; err_chk
+    fi
 
-   if test "$SENDCOM" = 'YES'
-   then
-     export fhr3=anl
-     if [ $GRIBVERSION = 'grib2' ]
-     then
-       MASTERANL=${PREFIX}master.grb2${fhr3}
-       MASTERANLIDX=${PREFIX}master.grb2i${fhr3}
-       cp $PGBOUT2 $COMOUT/${MASTERANL}
-       $GRB2INDEX $PGBOUT2 $COMOUT/${MASTERANLIDX}
-     fi
-
-     if test "$SENDDBN" = 'YES'
-     then
-       $DBNROOT/bin/dbn_alert MODEL GFS_MSC_sfcanl $job $COMOUT/${PREFIX}sfcanl${SUFFIX}
-       $DBNROOT/bin/dbn_alert MODEL GFS_SA $job $COMOUT/${PREFIX}atmanl${SUFFIX}
-#alert removed in v15.0       $DBNROOT/bin/dbn_alert MODEL GFS_MASTER $job $COMOUT/${MASTERANL}
-       if test "$PGBF" = 'YES'
-       then
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25 $job $COMOUT/${PREFIX}pgrb2b.0p25.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p25.anl.idx
-
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5 $job $COMOUT/${PREFIX}pgrb2.0p50.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2.0p50.anl.idx
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5 $job $COMOUT/${PREFIX}pgrb2b.0p50.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p50.anl.idx
-
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0 $job $COMOUT/${PREFIX}pgrb2.1p00.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0 $job $COMOUT/${PREFIX}pgrb2b.1p00.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2b.1p00.anl.idx
-       fi
-     fi 
-
-   fi
-   [[ -f pgbfile.grib2 ]] && rm pgbfile.grib2 
-#   ecflow_client --event release_pgrb2_anl
-
-##########################  WAFS U/V/T analysis start ##########################
-# U/V/T on ICAO standard atmospheric pressure levels for WAFS verification
-  if [ $WAFSF = "YES" ] ; then
-    if [[ $RUN = gfs && $GRIBVERSION = 'grib2' ]] ; then
-      export OUTTYP=${OUTTYP:-4}
-
-      export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS-ANL.txt
-      export CTLFILE=$PARMpost/postcntrl_gfs_wafs_anl.xml
-
-      export PGBOUT=wafsfile
-      export PGIOUT=wafsifile
-
-      $POSTGPSH
-      export err=$?
-
-      if [ $err -ne 0 ] ; then
-	  echo " *** GFS POST WARNING: WAFS output failed for analysis, err=$err"
-      else
-
-        # WAFS package doesn't process this part.
-	# Need to be saved for WAFS U/V/T verification, 
-        # resolution higher than WAFS 1.25 deg for future compatibility
-        wafsgrid="latlon 0:1440:0.25 90:721:-0.25"
-	$WGRIB2 $PGBOUT -set_grib_type same -new_grid_winds earth \
-              -new_grid_interpolation bilinear -set_bitmap 1 \
-	      -new_grid $wafsgrid ${PGBOUT}.tmp
-
-	if test $SENDCOM = "YES"
-	then
-         cp ${PGBOUT}.tmp $COMOUT/${PREFIX}wafs.0p25.anl
-         $WGRIB2 -s ${PGBOUT}.tmp > $COMOUT/${PREFIX}wafs.0p25.anl.idx
-
-#         if [ $SENDDBN = YES ]; then
-#            $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2 $job $COMOUT/${PREFIX}wafs.0p25.anl
-#            $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2__WIDX $job $COMOUT/${PREFIX}wafs.0p25.anl.idx
-#         fi
-	fi
-	rm $PGBOUT ${PGBOUT}.tmp
+    if [ "$SENDCOM" = 'YES' ]; then
+      export fhr3=anl
+      if [ $GRIBVERSION = 'grib2' ]; then
+        MASTERANL=${PREFIX}master.grb2${fhr3}
+        MASTERANLIDX=${PREFIX}master.grb2i${fhr3}
+        cp $PGBOUT2 $COMOUT/${MASTERANL}
+        $GRB2INDEX $PGBOUT2 $COMOUT/${MASTERANLIDX}
       fi
-   fi
+
+      if [ "$SENDDBN" = 'YES' ]; then
+        $DBNROOT/bin/dbn_alert MODEL GFS_MSC_sfcanl $job $COMOUT/${PREFIX}sfcanl${SUFFIX}
+        $DBNROOT/bin/dbn_alert MODEL GFS_SA $job $COMOUT/${PREFIX}atmanl${SUFFIX}
+        if [ "$PGBF" = 'YES' ]; then
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25 $job $COMOUT/${PREFIX}pgrb2b.0p25.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p25.anl.idx
+
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5 $job $COMOUT/${PREFIX}pgrb2.0p50.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2.0p50.anl.idx
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5 $job $COMOUT/${PREFIX}pgrb2b.0p50.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p50.anl.idx
+
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0 $job $COMOUT/${PREFIX}pgrb2.1p00.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0 $job $COMOUT/${PREFIX}pgrb2b.1p00.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2b.1p00.anl.idx
+        fi
+      fi
+    fi
+    [[ -f pgbfile.grib2 ]] && rm pgbfile.grib2 
+    #   ecflow_client --event release_pgrb2_anl
+
+    ##########################  WAFS U/V/T analysis start ##########################
+    # U/V/T on ICAO standard atmospheric pressure levels for WAFS verification
+    if [ $WAFSF = "YES" ]; then
+      if [[ $RUN = gfs && $GRIBVERSION = 'grib2' ]]; then
+        export OUTTYP=${OUTTYP:-4}
+
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS-ANL.txt
+        export CTLFILE=$PARMpost/postcntrl_gfs_wafs_anl.xml
+
+        export PGBOUT=wafsfile
+        export PGIOUT=wafsifile
+
+        $POSTGPSH
+        export err=$?
+        if [ $err -ne 0 ]; then
+          echo " *** GFS POST WARNING: WAFS output failed for analysis, err=$err"
+        else
+          # WAFS package doesn't process this part.
+          # Need to be saved for WAFS U/V/T verification, 
+          # resolution higher than WAFS 1.25 deg for future compatibility
+          wafsgrid="latlon 0:1440:0.25 90:721:-0.25"
+          $WGRIB2 $PGBOUT -set_grib_type same -new_grid_winds earth \
+          -new_grid_interpolation bilinear -set_bitmap 1 \
+          -new_grid $wafsgrid ${PGBOUT}.tmp
+
+          if [ $SENDCOM = "YES" ]; then
+            cp ${PGBOUT}.tmp $COMOUT/${PREFIX}wafs.0p25.anl
+            $WGRIB2 -s ${PGBOUT}.tmp > $COMOUT/${PREFIX}wafs.0p25.anl.idx
+
+            # if [ $SENDDBN = YES ]; then
+            #    $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2 $job $COMOUT/${PREFIX}wafs.0p25.anl
+            #    $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2__WIDX $job $COMOUT/${PREFIX}wafs.0p25.anl.idx
+            # fi
+          fi
+          rm $PGBOUT ${PGBOUT}.tmp
+        fi
+      fi
+    fi
+    ##########################  WAFS U/V/T analysis end  ##########################
+  else
+    #### atmanl file not found need failing job
+    echo " *** FATAL ERROR: No model anl file output "
+    export err=9
+    err_chk
   fi
-##########################  WAFS U/V/T analysis end  ##########################
-else
-  #### atmanl file not found need failing job
-  echo " *** FATAL ERROR: No model anl file output "
-  export err=9
-  err_chk
-fi
-
-#----------------------------------
 else   ## not_anl if_stime
-#----------------------------------
+  SLEEP_LOOP_MAX=$(expr $SLEEP_TIME / $SLEEP_INT)
 
-SLEEP_LOOP_MAX=`expr $SLEEP_TIME / $SLEEP_INT`
+  ############################################################
+  # Loop Through the Post Forecast Files 
+  ############################################################
 
-# Chuang: modify to submit one post job at a time
-############################################################
-# Loop Through the Post Forecast Files 
-############################################################
-
-for fhr in $post_times
-do
+  for fhr in $post_times; do
     echo 'Start processing fhr='$post_times
     ###############################
     # Start Looping for the 
@@ -264,26 +244,23 @@ do
     set -x
     export pgm="postcheck"
     ic=1
-    while [ $ic -le $SLEEP_LOOP_MAX ]
-    do
-       if test -f $restart_file${fhr}.txt
-       then
-          break
-       else
-          ic=`expr $ic + 1`
-          sleep $SLEEP_INT
-       fi
-       ###############################
-       # If we reach this point assume
-       # fcst job never reached restart 
-       # period and error exit
-       ###############################
-       if [ $ic -eq $SLEEP_LOOP_MAX ]
-       then
-          echo " *** FATAL ERROR: No model output in nemsio for f${fhr} "
-          export err=9
-          err_chk
-       fi
+    while [ $ic -le $SLEEP_LOOP_MAX ]; do
+      if [ -f $restart_file${fhr}.txt ]; then
+        break
+      else
+        ic=$(expr $ic + 1)
+        sleep $SLEEP_INT
+      fi
+      ###############################
+      # If we reach this point assume
+      # fcst job never reached restart 
+      # period and error exit
+      ###############################
+      if [ $ic -eq $SLEEP_LOOP_MAX ]; then
+        echo " *** FATAL ERROR: No model output in nemsio for f${fhr} "
+        export err=9
+        err_chk
+      fi
     done
     set -x
 
@@ -295,21 +272,20 @@ do
     # for backup to start Model Fcst
     ###############################
     [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
-    if [ $OUTTYP -eq 4 ] ; then
+    if [ $OUTTYP -eq 4 ]; then
       ln -fs $COMIN/${PREFIX}atmf${fhr}${SUFFIX} nemsfile
       export NEMSINP=nemsfile
       ln -fs $COMIN/${PREFIX}sfcf${fhr}${SUFFIX} flxfile
       export FLXINP=flxfile
     fi
 
-    if test $fhr -gt 0
-    then
+    if [ $fhr -gt 0 ]; then
       export IGEN=$IGEN_FCST
     else
       export IGEN=$IGEN_ANL
     fi
-    
-    export VDATE=`${NDATE} +${fhr} ${PDY}${cyc}`
+
+    export VDATE=$(${NDATE} +${fhr} ${PDY}${cyc})
     export OUTTYP=${OUTTYP:-4}
     export GFSOUT=${PREFIX}gfsio${fhr}
 
@@ -317,24 +293,22 @@ do
       export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
       export PostFlatFile=${PostFlatFile:-$PARMpost/postxconfig-NT-GFS.txt}
 
-      if [ $RUN = gfs ] ; then
+      if [ $RUN = gfs ]; then
         export IGEN=$IGEN_GFS
-        if [ $fhr -gt 0 ] ; then export IGEN=$IGEN_FCST ; fi
+        if [ $fhr -gt 0 ]; then export IGEN=$IGEN_FCST ; fi
       else
         export IGEN=$IGEN_GDAS_ANL
-        if [ $fhr -gt 0 ] ; then export IGEN=$IGEN_FCST ; fi
+        if [ $fhr -gt 0 ]; then export IGEN=$IGEN_FCST ; fi
       fi
-      if [[ $RUN = gfs ]] ; then
-        if test $fhr -eq 0
-        then
+      if [[ $RUN = gfs ]]; then
+        if [ $fhr -eq 0 ]; then
           export PostFlatFile=$PARMpost/postxconfig-NT-GFS-F00.txt
           export CTLFILE=$PARMpost/postcntrl_gfs_f00.xml
         else
           export CTLFILE=${CTLFILEGFS:-$PARMpost/postcntrl_gfs.xml}
         fi
       else
-        if test $fhr -eq 0
-        then
+        if [ $fhr -eq 0 ]; then
           export PostFlatFile=$PARMpost/postxconfig-NT-GFS-F00.txt
           export CTLFILE=${CTLFILEGFS:-$PARMpost/postcntrl_gfs_f00.xml}
         else
@@ -342,7 +316,7 @@ do
         fi
       fi
     fi
-    
+
     export FLXIOUT=flxifile
     export PGBOUT=pgbfile
     export PGIOUT=pgifile
@@ -350,8 +324,8 @@ do
     export PGIOUT2=pgifile.grib2.idx
     export FILTER=0 
     if [ $GRIBVERSION = 'grib2' ]; then
-        MASTERFL=${PREFIX}master.grb2f${fhr}
-        MASTERFLIDX=${PREFIX}master.grb2if${fhr}
+      MASTERFL=${PREFIX}master.grb2f${fhr}
+      MASTERFLIDX=${PREFIX}master.grb2if${fhr}
     fi
 
     if [ $INLINE_POST = ".false." ]; then
@@ -361,83 +335,78 @@ do
     fi
     export err=$?; err_chk
 
-    if test $GRIBVERSION = 'grib2'
-    then
+    if [ $GRIBVERSION = 'grib2' ]; then
       mv $PGBOUT $PGBOUT2
     fi
 
-#  Process pgb files
-   if test "$PGBF" = 'YES'
-   then
-     export FH=`expr $fhr + 0`
-     export downset=${downset:-2}
-     $GFSDOWNSH
-     export err=$?; err_chk
-   fi
+    #  Process pgb files
+    if [ "$PGBF" = 'YES' ]; then
+      export FH=$(expr $fhr + 0)
+      export downset=${downset:-2}
+      $GFSDOWNSH
+      export err=$?; err_chk
+    fi
 
-    if test $SENDCOM = "YES"
-    then
-	if [ $GRIBVERSION = 'grib2' ] ; then
-            if [ $INLINE_POST = ".false." ]; then 
-              cp $PGBOUT2 $COMOUT/${MASTERFL} 
+    if [ $SENDCOM = "YES" ]; then
+      if [ $GRIBVERSION = 'grib2' ]; then
+        if [ $INLINE_POST = ".false." ]; then 
+          cp $PGBOUT2 $COMOUT/${MASTERFL} 
+        fi
+        $GRB2INDEX $PGBOUT2  $COMOUT/${MASTERFLIDX}
+      fi
+
+      if [ "$SENDDBN" = 'YES' ]; then
+        if [ $GRIBVERSION = 'grib2' ]; then
+          if [ "$PGBF" = 'YES' ]; then
+            $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}
+            $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}.idx
+            $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25 $job $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr}
+            $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr}.idx
+
+            if [ -s $COMOUT/${PREFIX}pgrb2.0p50.f${fhr} ]; then
+              $DBNROOT/bin/dbn_alert  MODEL GFS_PGB2_0P5 $job $COMOUT/${PREFIX}pgrb2.0p50.f${fhr}
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2.0p50.f${fhr}.idx
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5 $job $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr}
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr}.idx
             fi
-	    $GRB2INDEX $PGBOUT2  $COMOUT/${MASTERFLIDX}
-	fi
-	
-	if test "$SENDDBN" = 'YES'
-	then
-	    if [ $GRIBVERSION = 'grib2' ] ; then
-#alert removed in v15.0		$DBNROOT/bin/dbn_alert MODEL GFS_MASTER $job $COMOUT/${MASTERFL}
-		if test "$PGBF" = 'YES'
-		then
-		    $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}
-		    $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}.idx
-		    $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25 $job $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr}
-		    $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr}.idx
-		    
-		    if [ -s $COMOUT/${PREFIX}pgrb2.0p50.f${fhr} ] ; then
-			$DBNROOT/bin/dbn_alert  MODEL GFS_PGB2_0P5 $job $COMOUT/${PREFIX}pgrb2.0p50.f${fhr}
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2.0p50.f${fhr}.idx
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5 $job $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr}
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr}.idx
-		    fi
-		    
-		    if [ -s $COMOUT/${PREFIX}pgrb2.1p00.f${fhr} ] ; then
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0 $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}.idx
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0 $job $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr}
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr}.idx
-		    fi
-		fi
-		
-	    fi 
-	fi
-	
-	#      x3=`expr $fhr % 3`
-	# x3=0 ---> Standard 3-hourly or 12-hourly output
-	#           Only master grib files are needed for the hourly files
-	#      if [ $x3 -eq 0 ] ; then
-	export fhr
-	$USHgfs/gfs_transfer.sh
-	#      fi
+
+            if [ -s $COMOUT/${PREFIX}pgrb2.1p00.f${fhr} ]; then
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0 $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}.idx
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0 $job $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr}
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr}.idx
+            fi
+          fi
+        fi 
+      fi
+
+      export fhr
+      $USHgfs/gfs_transfer.sh
     fi
     [[ -f pgbfile.grib2 ]] && rm pgbfile.grib2
 
-# use post to generate GFS Grib2 Flux file as model generated Flux file
-# will be in nemsio format after FY17 upgrade.
-    if [ $OUTTYP -eq 4 -a $FLXF = "YES" ] ; then
-      if test $fhr -eq 0
-      then
-       export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX-F00.txt
-       export CTLFILE=$PARMpost/postcntrl_gfs_flux_f00.xml
+
+    # use post to generate GFS Grib2 Flux file as model generated Flux file
+    # will be in nemsio format after FY17 upgrade.
+    if [ $OUTTYP -eq 4 -a $FLXF = "YES" ]; then
+      if [ $fhr -eq 0 ]; then
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX-F00.txt
+        export CTLFILE=$PARMpost/postcntrl_gfs_flux_f00.xml
       else
-       export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX.txt
-       export CTLFILE=$PARMpost/postcntrl_gfs_flux.xml
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX.txt
+        export CTLFILE=$PARMpost/postcntrl_gfs_flux.xml
       fi
       export PGBOUT=fluxfile
       export FILTER=0
-      FLUXFL=${PREFIX}sfluxgrbf${fhr}.grib2
+      export FLUXFL=${PREFIX}sfluxgrbf${fhr}.grib2
       FLUXFLIDX=${PREFIX}sfluxgrbf${fhr}.grib2.idx
+
+      #Add extra flux.1p00 file for coupled
+      if [ "$FLXGF" = 'YES' ]; then                    
+        export FH=$(expr $fhr + 0)     
+        $GFSDOWNSHF                  
+        export err=$?; err_chk
+      fi   
 
       if [ $INLINE_POST = ".false." ]; then
         $POSTGPSH
@@ -446,127 +415,116 @@ do
       fi
       $WGRIB2 -s $COMOUT/${FLUXFL} > $COMOUT/${FLUXFLIDX}
 
-      if test "$SENDDBN" = 'YES'
-      then
+      if [ "$SENDDBN" = 'YES' ]; then
         $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2 $job $COMOUT/${FLUXFL}
         $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2_WIDX $job $COMOUT/${FLUXFLIDX}
       fi
     fi
 
-# process satellite look alike separately so that master pgb gets out in time    
-# set outtyp to 2 because master post already generates gfs io files
+    # process satellite look alike separately so that master pgb gets out in time    
+    # set outtyp to 2 because master post already generates gfs io files
     if [ $GOESF = "YES" ]; then
+      export OUTTYP=${OUTTYP:-4}     
 
-    export OUTTYP=${OUTTYP:-4}     
-   
-# specify output file name from chgres which is input file name to nceppost 
-# if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
-# new imported variable for global_nceppost.sh
+      # specify output file name from chgres which is input file name to nceppost 
+      # if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
+      # new imported variable for global_nceppost.sh
 
-    export GFSOUT=${PREFIX}gfsio${fhr}     
+      export GFSOUT=${PREFIX}gfsio${fhr}     
 
-    # link satellite coefficients files, use hwrf version as ops crtm 2.0.5
-    # does not new coefficient files used by post
-    export FIXCRTM=${FIXCRTM:-${CRTM_FIX}}
-    $USHgfs/link_crtm_fix.sh $FIXCRTM
+      # link satellite coefficients files, use hwrf version as ops crtm 2.0.5
+      # does not new coefficient files used by post
+      export FIXCRTM=${FIXCRTM:-${CRTM_FIX}}
+      $USHgfs/link_crtm_fix.sh $FIXCRTM
 
-    if [ $GRIBVERSION = 'grib2' ] ; then 
-      export PostFlatFile=$PARMpost/postxconfig-NT-GFS-GOES.txt      
-      export CTLFILE=$PARMpost/postcntrl_gfs_goes.xml
+      if [ $GRIBVERSION = 'grib2' ]; then 
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-GOES.txt      
+        export CTLFILE=$PARMpost/postcntrl_gfs_goes.xml
+      fi
+      export FLXINP=flxfile
+      export FLXIOUT=flxifile
+      export PGBOUT=goesfile
+      export PGIOUT=goesifile
+      export FILTER=0
+      export IO=0
+      export JO=0
+      export IGEN=0
+
+      if [ $NET = gfs ]; then
+        $POSTGPSH
+        export err=$?; err_chk
+      fi
+
+      if [ $GRIBVERSION = 'grib2' ]; then
+        SPECIALFL=${PREFIX}special.grb2
+        SPECIALFLIDX=${PREFIX}special.grb2i
+      fi
+      fhr3=$fhr
+
+      if [ $SENDCOM = "YES" ]; then
+        #       echo "$PDY$cyc$pad$fhr" > $COMOUT/${RUN}.t${cyc}z.master.control
+
+        mv goesfile $COMOUT/${SPECIALFL}f$fhr
+        mv goesifile $COMOUT/${SPECIALFLIDX}f$fhr
+
+        if [ $SENDDBN = YES ]; then
+          $DBNROOT/bin/dbn_alert MODEL GFS_SPECIAL_GB2 $job $COMOUT/${SPECIALFL}f$fhr
+        fi
+      fi
     fi
-    export FLXINP=flxfile
-    export FLXIOUT=flxifile
-    export PGBOUT=goesfile
-    export PGIOUT=goesifile
-    export FILTER=0
-    export IO=0
-    export JO=0
-    export IGEN=0
-    
-    if [ $NET = gfs ]; then
-     $POSTGPSH
-     export err=$?; err_chk
-    fi
+    # end of satellite processing
 
-    if [ $GRIBVERSION = 'grib2' ]; then
-      SPECIALFL=${PREFIX}special.grb2
-      SPECIALFLIDX=${PREFIX}special.grb2i
-    fi
-    fhr3=$fhr
+    ##########################  WAFS start ##########################
+    # Generate WAFS products on ICAO standard level.
+    # Do not need to be sent out to public, WAFS package will process the data.
+    if [[ $WAFSF = "YES"  && $fhr -le 120 ]]; then
+      if [[ $RUN = gfs && $GRIBVERSION = 'grib2' ]]; then
+        export OUTTYP=${OUTTYP:-4}
 
-    if test $SENDCOM = "YES"
-    then
+        # Extend WAFS icing and gtg up to 120 hours
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS.txt
+        export CTLFILE=$PARMpost/postcntrl_gfs_wafs.xml
 
-#       echo "$PDY$cyc$pad$fhr" > $COMOUT/${RUN}.t${cyc}z.master.control
+        # gtg has its own configurations
+        cp $PARMpost/gtg.config.gfs gtg.config
+        cp $PARMpost/gtg_imprintings.txt gtg_imprintings.txt
 
-       mv goesfile $COMOUT/${SPECIALFL}f$fhr
-       mv goesifile $COMOUT/${SPECIALFLIDX}f$fhr
+        export PGBOUT=wafsfile
+        export PGIOUT=wafsifile
 
-       if [ $SENDDBN = YES ]; then
-           $DBNROOT/bin/dbn_alert MODEL GFS_SPECIAL_GB2 $job $COMOUT/${SPECIALFL}f$fhr
-       fi
+        # WAFS data is processed:
+        #   hourly if fhr<=24
+        #   every 3 forecast hour if 24<fhr<=48
+        #   every 6 forecast hour if 48<fhr<=120
+        if [  $fhr -le 24  ]; then
+          $POSTGPSH
+        elif [  $fhr -le 48  ]; then
+          if [  $((10#$fhr%3)) -eq 0  ]; then
+            $POSTGPSH
+          fi
+        elif [  $((10#$fhr%6)) -eq 0  ]; then
+          $POSTGPSH
+        fi
 
-    fi
-    fi
-# end of satellite processing
-
-##########################  WAFS start ##########################
-# Generate WAFS products on ICAO standard level.
-# Do not need to be sent out to public, WAFS package will process the data.
-    if [[ $WAFSF = "YES"  && $fhr -le 120 ]] ; then
-       if [[ $RUN = gfs && $GRIBVERSION = 'grib2' ]] ; then
-          export OUTTYP=${OUTTYP:-4}
-
-	  # Extend WAFS icing and gtg up to 120 hours
-          export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS.txt
-          export CTLFILE=$PARMpost/postcntrl_gfs_wafs.xml
-
-          # gtg has its own configurations
-          cp $PARMpost/gtg.config.gfs gtg.config
-          cp $PARMpost/gtg_imprintings.txt gtg_imprintings.txt
-
-          export PGBOUT=wafsfile
-          export PGIOUT=wafsifile
-
-          # WAFS data is processed:
-          #   hourly if fhr<=24
-          #   every 3 forecast hour if 24<fhr<=48
-          #   every 6 forecast hour if 48<fhr<=120
-	  if [  $fhr -le 24  ] ; then
-             $POSTGPSH
-          elif [  $fhr -le 48  ] ; then
-             if [  $((10#$fhr%3)) -eq 0  ] ; then
-               $POSTGPSH
-             fi
-          elif [  $((10#$fhr%6)) -eq 0  ] ; then
-               $POSTGPSH
-	  fi
-
-          export err=$?
-
-	  if [ $err -ne 0 ] ; then
-              echo " *** GFS POST WARNING: WAFS output failed for f${fhr}, err=$err"
-	  else
-              if [ -e $PGBOUT ]
-              then
-		  if test $SENDCOM = "YES"
-		  then
-		      cp $PGBOUT $COMOUT/${PREFIX}wafs.grb2f$fhr
-		      cp $PGIOUT $COMOUT/${PREFIX}wafs.grb2if$fhr
-		  fi
-              fi
-	  fi
+        export err=$?; err_chk
+        if [ $err -ne 0 ]; then
+          echo " *** GFS POST WARNING: WAFS output failed for f${fhr}, err=$err"
+        else
+          if [ -e $PGBOUT ]; then
+            if [ $SENDCOM = "YES" ]; then
+              cp $PGBOUT $COMOUT/${PREFIX}wafs.grb2f$fhr
+              cp $PGIOUT $COMOUT/${PREFIX}wafs.grb2if$fhr
+            fi
+          fi
+        fi
       fi
       [[ -f wafsfile ]] && rm wafsfile ; [[ -f wafsifile ]] && rm wafsifile
     fi
-###########################  WAFS  end ###########################
+    ###########################  WAFS  end ###########################
+  done
 
-
-done
-
-#----------------------------------
+  #----------------------------------
 fi   ## end_if_stime
-#----------------------------------
 
 #cat $pgmout
 #msg='ENDED NORMALLY.'

--- a/ush/fv3gfs_downstream_nems.sh
+++ b/ush/fv3gfs_downstream_nems.sh
@@ -41,7 +41,7 @@ export COPYGB2=${COPYGB2:-${NWPROD:-/nwprod}/util/exec/copygb2}
 export WGRIB2=${WGRIB2:-${NWPROD:-/nwprod}/util/exec/wgrib2}
 export GRBINDEX=${GRBINDEX:-${NWPROD:-nwprod}/util/exec/grbindex}
 export RUN=${RUN:-"gfs"}
-export cycn=`echo $CDATE |cut -c 9-10`
+export cycn=$(echo $CDATE |cut -c 9-10)
 export TCYC=${TCYC:-".t${cycn}z."}
 export PREFIX=${PREFIX:-${RUN}${TCYC}}
 export PGB1F=${PGB1F:-"NO"}
@@ -64,7 +64,6 @@ export grid0p5="latlon 0:720:0.5 90:361:-0.5"
 export grid1p0="latlon 0:360:1.0 90:181:-1.0"
 export grid2p5="latlon 0:144:2.5 90:73:-2.5"
 
-
 unset paramlist paramlistb
 if [ $FH -eq -1 ] ; then
   #export paramlist=/global/save/Hui-Ya.Chuang/gfs_trunk/sib/fix/global_1x1_paramlist_g2.anl
@@ -80,11 +79,11 @@ elif [ $FH -eq 0 ] ; then
 else
   export paramlist=${paramlist:-$PARMpost/global_1x1_paramlist_g2}
   export paramlistb=${paramlistb:-$PARMpost/global_master-catchup_parmlist_g2}
-  export fhr3=`expr $FH + 0 `
+  export fhr3=$(expr $FH + 0 )
   if [ $fhr3 -lt 100 ]; then export fhr3="0$fhr3"; fi
   if [ $fhr3 -lt 10 ];  then export fhr3="0$fhr3"; fi
   if [ $fhr3%${FHOUT_PGB} -eq 0 ]; then
-     export PGBS=YES
+    export PGBS=YES
   fi
 fi
 
@@ -93,13 +92,13 @@ $WGRIB2 $PGBOUT2 | grep -F -f $paramlist | $WGRIB2 -i -grib  tmpfile1_$fhr3 $PGB
 export err=$?; err_chk
 #if [ $machine = WCOSS -o $machine = WCOSS_C -a $downset = 2 ]; then
 if [ $downset = 2 ]; then
-   $WGRIB2 $PGBOUT2 | grep -F -f $paramlistb | $WGRIB2 -i -grib  tmpfile2_$fhr3 $PGBOUT2
-   export err=$?; err_chk
+  $WGRIB2 $PGBOUT2 | grep -F -f $paramlistb | $WGRIB2 -i -grib  tmpfile2_$fhr3 $PGBOUT2
+  export err=$?; err_chk
 fi
 
 #-----------------------------------------------------
 #-----------------------------------------------------
-if [ $machine = WCOSS -o $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 -o $machine = HERA -o $machine = ORION -o $machine = JET -o $machine = S4 -o $machine = WCOSS2 ]; then
+#if [ $machine = WCOSS -o $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 ]; then
 #-----------------------------------------------------
 #-----------------------------------------------------
 export nset=1
@@ -108,26 +107,26 @@ if [ $downset = 1 ]; then totalset=1 ; fi
 
 #..............................................
 while [ $nset -le $totalset ]; do
-#..............................................
+  #..............................................
   export tmpfile=$(eval echo tmpfile${nset}_${fhr3})
 
-# split of Grib files to run downstream jobs using MPMD
-  export ncount=`$WGRIB2 $tmpfile |wc -l`
-# export tasks_post=$(eval echo \$tasksp_$nknd)
+  # split of Grib files to run downstream jobs using MPMD
+  export ncount=$($WGRIB2 $tmpfile |wc -l)
+  # export tasks_post=$(eval echo \$tasksp_$nknd)
   export nproc=${nproc:-${npe_dwn:-24}}
   if [ $nproc -gt $ncount ]; then
     echo " *** FATA ERROR: Total number of records in $tmpfile is not right"
     export err=8
     err_chk
   fi
-  export inv=`expr $ncount / $nproc`
+  export inv=$(expr $ncount / $nproc)
   rm -f $DATA/poescript
   export iproc=1
   export end=0
 
   while [ $iproc -le $nproc ] ; do
-    export start=`expr ${end} + 1`
-    export end=`expr ${start} + ${inv} - 1`
+    export start=$(expr ${end} + 1)
+    export end=$(expr ${start} + ${inv} - 1)
     if [[ $end -ge $ncount ]] ;then
       export end=$ncount
     fi
@@ -138,13 +137,13 @@ while [ $nset -le $totalset ]; do
     $WGRIB2 -d $end $tmpfile |egrep -i "ugrd|ustm|uflx|u-gwd"
     export rc=$?
     if [[ $rc -eq 0 ]] ; then
-      export end=`expr ${end} + 1`
+      export end=$(expr ${end} + 1)
     fi
     # if final record is land, add next record icec 
     $WGRIB2 -d $end $tmpfile |egrep -i "land"
     export rc=$?
     if [[ $rc -eq 0 ]] ; then
-      export end=`expr ${end} + 1`
+      export end=$(expr ${end} + 1)
     fi
     if [ $iproc -eq $nproc ]; then
       export end=$ncount
@@ -158,193 +157,136 @@ while [ $nset -le $totalset ]; do
     # poescript for remaining processors
     if [[ $end -eq $ncount ]] ;then
       while [[ $iproc -lt $nproc ]];do
-        export iproc=`expr $iproc + 1`
-	echo "/bin/echo $iproc" >> $DATA/poescript
+        export iproc=$(expr $iproc + 1)
+        echo "/bin/echo $iproc" >> $DATA/poescript
       done
       break
     fi
-    export iproc=`expr $iproc + 1`
+    export iproc=$(expr $iproc + 1)
   done
 
-date
+  date
   chmod 775 $DATA/poescript
   export MP_PGMMODEL=mpmd
   export MP_CMDFILE=$DATA/poescript
   launcher=${APRUN_DWN:-"aprun -j 1 -n 24 -N 24 -d 1 cfp"}
   if [ $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 -o $machine = WCOSS2 ] ; then
-     $launcher $MP_CMDFILE
+    $launcher $MP_CMDFILE
   elif [ $machine = HERA -o $machine = ORION -o $machine = JET -o $machine = S4 ] ; then
-     if [ -s $DATA/poescript_srun ]; then rm -f $DATA/poescript_srun; fi
-     touch $DATA/poescript_srun
-     nm=0
-     cat $DATA/poescript | while read line; do
-         echo "$nm  $line" >> $DATA/poescript_srun 
-         nm=$((nm+1))
-     done
-     ${launcher:-"srun --export=ALL"}  -n $nm --multi-prog $DATA/poescript_srun
+    if [ -s $DATA/poescript_srun ]; then rm -f $DATA/poescript_srun; fi
+    touch $DATA/poescript_srun
+    nm=0
+    cat $DATA/poescript | while read line; do
+      echo "$nm $line" >> $DATA/poescript_srun 
+      nm=$((nm+1))
+    done
+    ${launcher:-"srun --export=ALL"} -n $nm --multi-prog $DATA/poescript_srun
   else
-     $launcher
+    $launcher
   fi
   export err=$?
   if [ $err -ne 0 ]; then sh +x $DATA/poescript ; fi
 
-date
+  date
   export iproc=1
   while [ $iproc -le $nproc ]; do
     if [ $nset = 1 ]; then
-     cat pgb2file_${fhr3}_${iproc}_0p25 >> pgb2file_${fhr3}_0p25
-     if [ "$PGBS" = "YES" ]; then
-       cat pgb2file_${fhr3}_${iproc}_0p5  >> pgb2file_${fhr3}_0p5
-       cat pgb2file_${fhr3}_${iproc}_1p0  >> pgb2file_${fhr3}_1p0
-       if [ "$PGB1F" = 'YES' ]; then
-         cat pgbfile_${fhr3}_${iproc}_1p0   >> pgbfile_${fhr3}_1p0
-       fi
-     fi
+      cat pgb2file_${fhr3}_${iproc}_0p25 >> pgb2file_${fhr3}_0p25
+      if [ "$PGBS" = "YES" ]; then
+        # cat pgb2file_${fhr3}_${iproc}_0p5  >> pgb2file_${fhr3}_0p5
+        cat pgb2file_${fhr3}_${iproc}_1p0  >> pgb2file_${fhr3}_1p0
+        if [ "$PGB1F" = 'YES' ]; then
+          cat pgbfile_${fhr3}_${iproc}_1p0   >> pgbfile_${fhr3}_1p0
+        fi
+      fi
     elif [ $nset = 2 ]; then
-     cat pgb2bfile_${fhr3}_${iproc}_0p25 >> pgb2bfile_${fhr3}_0p25
-     if [ "$PGBS" = "YES" ]; then
-       cat pgb2bfile_${fhr3}_${iproc}_0p5 >> pgb2bfile_${fhr3}_0p5
-       cat pgb2bfile_${fhr3}_${iproc}_1p0 >> pgb2bfile_${fhr3}_1p0
-     fi
+      cat pgb2bfile_${fhr3}_${iproc}_0p25 >> pgb2bfile_${fhr3}_0p25
+      if [ "$PGBS" = "YES" ]; then
+        # cat pgb2bfile_${fhr3}_${iproc}_0p5 >> pgb2bfile_${fhr3}_0p5
+        cat pgb2bfile_${fhr3}_${iproc}_1p0 >> pgb2bfile_${fhr3}_1p0
+      fi
     fi
-    export iproc=`expr $iproc + 1`
+    export iproc=$(expr $iproc + 1)
   done
-date
+  date
 
-#Chuang: generate second land mask using bi-linear interpolation and append to the end
-#      if [ $nset = 1 ]; then
-#      rm -f land.grb newland.grb newnewland.grb newnewland.grb1
-#      $WGRIB2 $tmpfile -match "LAND:surface" -grib land.grb
-##0p25 degree
-#      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid0p25 newland.grb
-#      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
-#      cat ./newnewland.grb >> pgb2file_${fhr3}_0p25
-#      $CNVGRIB -g21 newnewland.grb newnewland.grb1 
-#      cat ./newnewland.grb1 >> pgbfile_${fhr3}_0p25 
-##0p5 degree
-#      rm -f newland.grb newnewland.grb newnewland.grb1
-#      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid0p5 newland.grb
-#      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
-#      cat ./newnewland.grb >> pgb2file_${fhr3}_0p5
-#1p0
-#      rm -f newland.grb newnewland.grb newnewland.grb1
-#      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid1p0 newland.grb
-#      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
-#      cat ./newnewland.grb >> pgb2file_${fhr3}_1p0
-#      $CNVGRIB -g21 newnewland.grb newnewland.grb1
-#      cat ./newnewland.grb1 >> pgbfile_${fhr3}_1p0
-#      fi
-
+  #Chuang: generate second land mask using bi-linear interpolation and append to the end
+  # if [ $nset = 1 ]; then
+  # rm -f land.grb newland.grb newnewland.grb newnewland.grb1
+  # $WGRIB2 $tmpfile -match "LAND:surface" -grib land.grb
+  ##0p25 degree
+  # $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid0p25 newland.grb
+  # $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
+  # cat ./newnewland.grb >> pgb2file_${fhr3}_0p25
+  # $CNVGRIB -g21 newnewland.grb newnewland.grb1 
+  # cat ./newnewland.grb1 >> pgbfile_${fhr3}_0p25 
+  ##0p5 degree
+  # rm -f newland.grb newnewland.grb newnewland.grb1
+  # $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid0p5 newland.grb
+  # $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
+  # cat ./newnewland.grb >> pgb2file_${fhr3}_0p5
+  #1p0
+  # rm -f newland.grb newnewland.grb newnewland.grb1
+  # $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid1p0 newland.grb
+  # $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
+  # cat ./newnewland.grb >> pgb2file_${fhr3}_1p0
+  # $CNVGRIB -g21 newnewland.grb newnewland.grb1
+  # cat ./newnewland.grb1 >> pgbfile_${fhr3}_1p0
+  # fi
 
   if [ $nset = 1 ]; then
-   if [ $fhr3 = anl ]; then
-    cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.anl
-    $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
-    if [ "$PGBS" = "YES" ]; then
-      cp pgb2file_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2.0p50.anl
-      cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.anl
-      $WGRIB2 -s pgb2file_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2.0p50.anl.idx
-      $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
-      if [ "$PGB1F" = 'YES' ]; then
-        cp pgbfile_${fhr3}_1p0    $COMOUT/${PREFIX}pgrb.1p00.anl
-        $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.anl $COMOUT/${PREFIX}pgrb.1p00.anl.idx
-      fi
-    fi
-   else
-    cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}
-    $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}.idx
-    if [ "$PGBS" = "YES" ]; then
-      cp pgb2file_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2.0p50.f${fhr3}
-      cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}
-      $WGRIB2 -s pgb2file_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2.0p50.f${fhr3}.idx
-      $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}.idx
-      if [ "$PGB1F" = 'YES' ]; then
-        cp pgbfile_${fhr3}_1p0    $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}
-        $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.f${fhr3} $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}.idx
-      fi
-    fi
-   fi
-
-  elif [ $nset = 2 ]; then
-   
-   if [ $fhr3 = anl ]; then
-    cp pgb2bfile_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2b.0p25.anl
-    $WGRIB2 -s pgb2bfile_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2b.0p25.anl.idx
-    if [ "$PGBS" = "YES" ]; then
-      cp pgb2bfile_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2b.0p50.anl
-      cp pgb2bfile_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2b.1p00.anl
-      $WGRIB2 -s pgb2bfile_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2b.0p50.anl.idx
-      $WGRIB2 -s pgb2bfile_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2b.1p00.anl.idx
-    fi
-
-   else
-    cp pgb2bfile_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr3}
-    $WGRIB2 -s pgb2bfile_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr3}.idx
-    if [ "$PGBS" = "YES" ]; then
-      cp pgb2bfile_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr3}
-      cp pgb2bfile_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr3}
-      $WGRIB2 -s pgb2bfile_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr3}.idx
-      $WGRIB2 -s pgb2bfile_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr3}.idx
-    fi
-   fi
-  fi
-
-#..............................................
- export nset=`expr $nset + 1 `
- done
-#..............................................
-
-
-#---------------------------------------------------------------
-#---------------------------------------------------------------
-# R&D machine has no MPDP. Only generate 0.25 and 1 deg files
-else
-#---------------------------------------------------------------
-#---------------------------------------------------------------
-  $WGRIB2 tmpfile1_$fhr3  $option1 $option21 $option22 $option23 $option24 \
-                          $option25 $option26 $option27 $option28 \
-                                           -new_grid $grid0p25 pgb2file_${fhr3}_0p25 \
-                                           -new_grid $grid0p5  pgb2file_${fhr3}_0p5 \
-                                           -new_grid $grid1p0  pgb2file_${fhr3}_1p0
-  export err=$?; err_chk
-  #tweak sea ice cover
-  count=`$WGRIB2 pgb2file_${fhr3}_0p25 -match "LAND|ICEC" |wc -l`
-  if [ $count -eq 2 ]; then
-    $MODICEC pgb2file_${fhr3}_0p25
-    $MODICEC pgb2file_${fhr3}_1p0
-  fi
-
-# convert 1 deg files back to Grib1 for verification
-  if [ "$PGB1F" = 'YES' ]; then
     if [ $fhr3 = anl ]; then
-     $CNVGRIB -g21 pgb2file_${fhr3}_1p0  $COMOUT/${PREFIX}pgrb.1p00.anl
-     export err=$?; err_chk
-     $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.anl $COMOUT/${PREFIX}pgrb.1p00.anl.idx
+      cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.anl
+      $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
+      if [ "$PGBS" = "YES" ]; then
+        cp pgb2file_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2.0p50.anl
+        cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.anl
+        $WGRIB2 -s pgb2file_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2.0p50.anl.idx
+        $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
+        if [ "$PGB1F" = 'YES' ]; then 
+          cp pgbfile_${fhr3}_1p0    $COMOUT/${PREFIX}pgrb.1p00.anl
+          $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.anl $COMOUT/${PREFIX}pgrb.1p00.anl.idx
+        fi
+      fi
     else
-     $CNVGRIB -g21 pgb2file_${fhr3}_1p0  $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}
-     export err=$?; err_chk
-     $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.f${fhr3} $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}.idx
+      cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}
+      $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}.idx
+      if [ "$PGBS" = "YES" ]; then
+        cp pgb2file_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2.0p50.f${fhr3}
+        cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}
+        $WGRIB2 -s pgb2file_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2.0p50.f${fhr3}.idx
+        $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}.idx
+        if [ "$PGB1F" = 'YES' ]; then
+          cp pgbfile_${fhr3}_1p0    $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}
+          $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.f${fhr3} $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}.idx
+        fi
+      fi
+    fi
+  elif [ $nset = 2 ]; then
+    if [ $fhr3 = anl ]; then
+      cp pgb2bfile_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2b.0p25.anl
+      $WGRIB2 -s pgb2bfile_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2b.0p25.anl.idx
+      if [ "$PGBS" = "YES" ]; then
+        cp pgb2bfile_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2b.0p50.anl
+        cp pgb2bfile_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2b.1p00.anl
+        $WGRIB2 -s pgb2bfile_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2b.0p50.anl.idx
+        $WGRIB2 -s pgb2bfile_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2b.1p00.anl.idx
+      fi
+    else
+      cp pgb2bfile_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr3}
+      $WGRIB2 -s pgb2bfile_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr3}.idx
+      if [ "$PGBS" = "YES" ]; then
+        cp pgb2bfile_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr3}
+        cp pgb2bfile_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr3}
+        $WGRIB2 -s pgb2bfile_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr3}.idx
+        $WGRIB2 -s pgb2bfile_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr3}.idx
+      fi
     fi
   fi
 
-   if [ $fhr3 = anl ]; then
-     $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
-     cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.anl
-     if [ "$PGBS" = "YES" ]; then
-       $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
-       cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.anl
-     fi
-   else
-     $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}.idx
-     cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}
-     if [ "$PGBS" = "YES" ]; then
-       $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}.idx
-       cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}
-     fi
-   fi
+  export nset=$(expr $nset + 1 )
+done
 
-#---------------------------------------------------------------
-fi
 echo "!!!!!!CREATION OF SELECT $RUN DOWNSTREAM PRODUCTS COMPLETED FOR FHR = $FH !!!!!!!"
 #---------------------------------------------------------------
 

--- a/ush/inter_flux.sh
+++ b/ush/inter_flux.sh
@@ -1,0 +1,69 @@
+#!/bin/ksh
+set -x
+
+#-----------------------------------------------------------------------
+#-Wen Meng, 03/2019:  First version.
+#  This scripts is for interpolating flux file from model native grid
+#  into lat-lon grids.
+#-----------------------------------------------------------------------
+
+
+echo "!!!!!CREATING $RUN FLUX PRODUCTS FOR FH = $FH !!!!!!"
+
+export CNVGRIB=${CNVGRIB:-${NWPROD:-/nwprod}/util/exec/cnvgrib21}
+export COPYGB2=${COPYGB2:-${NWPROD:-/nwprod}/util/exec/copygb2}
+export WGRIB2=${WGRIB2:-${NWPROD:-/nwprod}/util/exec/wgrib2}
+export GRBINDEX=${GRBINDEX:-${NWPROD:-nwprod}/util/exec/grbindex}
+export RUN=${RUN:-"gfs"}
+export cycn=$(echo $CDATE |cut -c 9-10)
+export TCYC=${TCYC:-".t${cycn}z."}
+export PREFIX=${PREFIX:-${RUN}${TCYC}}
+export PGB1F=${PGB1F:-"NO"}
+
+#--wgrib2 regrid parameters
+export option1=' -set_grib_type same -new_grid_winds earth '
+export option21=' -new_grid_interpolation bilinear  -if '
+export option22=":(LAND|CRAIN|CICEP|CFRZR|CSNOW|ICSEV):"
+export option23=' -new_grid_interpolation neighbor -fi '
+export option24=' -set_bitmap 1 -set_grib_max_bits 16 -if '
+export option25=":(APCP|ACPCP|PRATE|CPRAT):"
+export option26=' -set_grib_max_bits 25 -fi -if '
+export option27=":(APCP|ACPCP|PRATE|CPRAT|DZDT):"
+export option28=' -new_grid_interpolation budget -fi '
+export grid0p25="latlon 0:1440:0.25 90:721:-0.25"
+export grid0p5="latlon 0:720:0.5 90:361:-0.5"
+export grid1p0="latlon 0:360:1.0 90:181:-1.0"
+export grid2p5="latlon 0:144:2.5 90:73:-2.5"
+
+
+if [ $FH -eq 0 ] ; then
+  export fhr3=000
+else
+  export fhr3=$(expr $FH + 0 )
+  if [ $fhr3 -lt 100 ]; then export fhr3="0$fhr3"; fi
+  if [ $fhr3 -lt 10 ];  then export fhr3="0$fhr3"; fi
+fi
+
+#---------------------------------------------------------------
+
+  if [ $INLINE_POST = ".false." ]; then
+    $WGRIB2 $PGBOUT $option1 $option21 $option22 $option23 $option24 \
+                          $option25 $option26 $option27 $option28 \
+                          -new_grid $grid1p0  fluxfile_${fhr3}_1p00
+  else 
+    $WGRIB2 $COMOUT/${FLUXFL} $option1 $option21 $option22 $option23 $option24 \
+                          $option25 $option26 $option27 $option28 \
+                          -new_grid $grid1p0  fluxfile_${fhr3}_1p00
+  fi
+  export err=$?; err_chk
+
+
+  $WGRIB2 -s fluxfile_${fhr3}_1p00 > $COMOUT/${PREFIX}flux.1p00.f${fhr3}.idx
+  cp fluxfile_${fhr3}_1p00  $COMOUT/${PREFIX}flux.1p00.f${fhr3}
+
+#---------------------------------------------------------------
+echo "!!!!!CREATION OF SELECT $RUN FLUX PRODUCTS COMPLETED FOR FHR = $FH !!!!!"
+#---------------------------------------------------------------
+
+
+exit 0


### PR DESCRIPTION
Updates global post to handle extra atm output for coupled runs (post for other components is still handled separately). This mirrors the same change to global-workflow which also brings these two scripts under g-w control (see NOAA-EMC/global-workflow/pull/766)