### PR TITLE
  Clean up shell script style

### DIFF
--- a/jobs/JGLOBAL_ATMOS_NCEPPOST
+++ b/jobs/JGLOBAL_ATMOS_NCEPPOST
@@ -119,7 +119,7 @@ export SLEEP_INT=5
 ###############################################################
 # Run relevant exglobal script
 env
-msg="HAS BEGUN on `hostname`"
+msg="HAS BEGUN on $(hostname)"
 postmsg "$msg"
 $LOGSCRIPT
 

--- a/scripts/exgdas_atmos_nceppost.sh
+++ b/scripts/exgdas_atmos_nceppost.sh
@@ -26,7 +26,7 @@ set -x
 
 cd $DATA
 
-msg="HAS BEGUN on `hostname`"
+msg="HAS BEGUN on $(hostname)"
 postmsg "$msg"
 
 export POSTGPSH=${POSTGPSH:-$USHgfs/gfs_nceppost.sh}
@@ -78,126 +78,109 @@ export IDRT=${IDRT:-0} # IDRT=0 is setting for outputting grib files on lat/lon 
 # Post Analysis Files before starting the Forecast Post
 ############################################################
 # Chuang: modify to process analysis when post_times is 00
-export stime=`echo $post_times | cut -c1-3`
+export stime=$(echo $post_times | cut -c1-3)
 if [ $OUTTYP -eq 4 ] ; then
-   export loganl=$COMIN/${PREFIX}atmanl${SUFFIX}
+  export loganl=$COMIN/${PREFIX}atmanl${SUFFIX}
 else
-   export loganl=$COMIN/${PREFIX}sanl
+  export loganl=$COMIN/${PREFIX}sanl
 fi
 
-#----------------------------------
 if [ ${stime} = "anl" ]; then
-#----------------------------------
+  if [ -f $loganl ]; then
+    # add new environmental variables for running new ncep post
+    # Validation date
 
-if test -f $loganl 
-then
-   
-# add new environmental variables for running new ncep post
-# Validation date
+    export VDATE=${PDY}${cyc}
 
-   export VDATE=${PDY}${cyc}
-   
-# set outtyp to 1 because we need to run chgres in the post before model start running chgres
-# otherwise set to 0, then chgres will not be executed in global_nceppost.sh
-    
-   export OUTTYP=${OUTTYP:-4}
-   
-# specify output file name from chgres which is input file name to nceppost 
-# if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
-# new imported variable for global_nceppost.sh
+    # set outtyp to 1 because we need to run chgres in the post before model start running chgres
+    # otherwise set to 0, then chgres will not be executed in global_nceppost.sh
 
-   export GFSOUT=${RUN}.${cycle}.gfsioanl
+    export OUTTYP=${OUTTYP:-4}
 
-# specify smaller control file for GDAS because GDAS does not
-# produce flux file, the default will be /nwprod/parm/gfs_cntrl.parm
+    # specify output file name from chgres which is input file name to nceppost 
+    # if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
+    # new imported variable for global_nceppost.sh
 
-   if [ $GRIBVERSION = 'grib2' ]; then
-     export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
-     export PostFlatFile=${PostFlatFile:-$PARMpost/postxconfig-NT-GFS-ANL.txt} 
-     export CTLFILE=$PARMpost/postcntrl_gfs_anl.xml
-   fi
+    export GFSOUT=${RUN}.${cycle}.gfsioanl
 
-   [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
-   if [ $OUTTYP -eq 4 ] ; then
+    # specify smaller control file for GDAS because GDAS does not
+    # produce flux file, the default will be /nwprod/parm/gfs_cntrl.parm
+
+    if [ $GRIBVERSION = 'grib2' ]; then
+      export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
+      export PostFlatFile=${PostFlatFile:-$PARMpost/postxconfig-NT-GFS-ANL.txt} 
+      export CTLFILE=$PARMpost/postcntrl_gfs_anl.xml
+    fi
+
+    [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
+    if [ $OUTTYP -eq 4 ] ; then
       ln -fs $COMIN/${PREFIX}atmanl${SUFFIX} nemsfile
       export NEMSINP=nemsfile
       ln -fs $COMIN/${PREFIX}sfcanl${SUFFIX} flxfile
       export FLXINP=flxfile
-   fi
-   export PGBOUT=pgbfile
-   export PGIOUT=pgifile
-   export PGBOUT2=pgbfile.grib2
-   export PGIOUT2=pgifile.grib2.idx
-   export IGEN=$IGEN_ANL
-   export FILTER=0  
+    fi
+    export PGBOUT=pgbfile
+    export PGIOUT=pgifile
+    export PGBOUT2=pgbfile.grib2
+    export PGIOUT2=pgifile.grib2.idx
+    export IGEN=$IGEN_ANL
+    export FILTER=0  
 
- #specify fhr even for analysis because postgp uses it    
-#   export fhr=00
-    
-   $POSTGPSH
-   export err=$?; err_chk
+    # specify fhr even for analysis because postgp uses it    
+    #  export fhr=00
+
+    $POSTGPSH
+    export err=$?; err_chk
 
 
-   if test $GRIBVERSION = 'grib2'
-   then
-     mv $PGBOUT $PGBOUT2
+    if [ $GRIBVERSION = 'grib2' ]; then
+      mv $PGBOUT $PGBOUT2
 
-#Proces pgb files
-     export FH=-1
-     export downset=${downset:-1}
-     $GFSDOWNSH
-     export err=$?; err_chk
+      #Proces pgb files
+      export FH=-1
+      export downset=${downset:-1}
+      $GFSDOWNSH
+      export err=$?; err_chk
 
-     export fhr3=anl
-    
-   fi
+      export fhr3=anl
+    fi
 
-   if test $SENDCOM = 'YES'
-   then
-     export fhr3=anl
-     if [ $GRIBVERSION = 'grib2' ]
-     then
-       MASTERANL=${PREFIX}master.grb2${fhr3}
-##########XXW Accord to Boi, fortran index should use *if${fhr}, wgrib index use .idx
-       #MASTERANLIDX=${RUN}.${cycle}.master.grb2${fhr3}.idx
-       MASTERANLIDX=${PREFIX}master.grb2i${fhr3}
-       cp $PGBOUT2  $COMOUT/${MASTERANL}
-       $GRB2INDEX $PGBOUT2 $COMOUT/${MASTERANLIDX}
-     fi
+    if [ $SENDCOM = 'YES' ]; then
+      export fhr3=anl
+      if [ $GRIBVERSION = 'grib2' ]; then
+        MASTERANL=${PREFIX}master.grb2${fhr3}
+        ##########XXW Accord to Boi, fortran index should use *if${fhr}, wgrib index use .idx
+        #MASTERANLIDX=${RUN}.${cycle}.master.grb2${fhr3}.idx
+        MASTERANLIDX=${PREFIX}master.grb2i${fhr3}
+        cp $PGBOUT2  $COMOUT/${MASTERANL}
+        $GRB2INDEX $PGBOUT2 $COMOUT/${MASTERANLIDX}
+      fi
 
-      if test $SENDDBN = 'YES'
-      then
-        run=`echo $RUN | tr '[a-z]' '[A-Z]'`
-	if [ $GRIBVERSION = 'grib2' ] 
-        then
-	  $DBNROOT/bin/dbn_alert MODEL ${run}_MSC_sfcanl $job $COMOUT/${PREFIX}sfc${fhr3}${SUFFIX}
+      if [ $SENDDBN = 'YES' ]; then
+        run=$(echo $RUN | tr '[a-z]' '[A-Z]')
+        if [ $GRIBVERSION = 'grib2' ]; then
+          $DBNROOT/bin/dbn_alert MODEL ${run}_MSC_sfcanl $job $COMOUT/${PREFIX}sfc${fhr3}${SUFFIX}
           $DBNROOT/bin/dbn_alert MODEL ${run}_SA $job $COMIN/${PREFIX}atm${fhr3}${SUFFIX}
           $DBNROOT/bin/dbn_alert MODEL GDAS_PGA_GB2 $job $COMOUT/${PREFIX}pgrb2.1p00.${fhr3}
           $DBNROOT/bin/dbn_alert MODEL GDAS_PGA_GB2_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.${fhr3}.idx
-	fi
+        fi
       fi
+    fi
+    rm pgbfile.grib2 
+  else
+    #### atmanl file not found need failing job
+    echo " *** FATAL ERROR: No model anl file output "
+    export err=9
+    err_chk
+  fi
+else   ## not_anl if_stimes
+  SLEEP_LOOP_MAX=$(expr $SLEEP_TIME / $SLEEP_INT)
 
-   fi
-   rm pgbfile.grib2 
-else
-  #### atmanl file not found need failing job
-  echo " *** FATAL ERROR: No model anl file output "
-  export err=9
-  err_chk
-fi
+  ############################################################
+  # Loop Through the Post Forecast Files 
+  ############################################################
 
-#----------------------------------
-else   ## not_anl if_stimes 
-#----------------------------------
-
-SLEEP_LOOP_MAX=`expr $SLEEP_TIME / $SLEEP_INT`
-
-############################################################
-# Loop Through the Post Forecast Files 
-############################################################
-
-for fhr in $post_times
-do
+  for fhr in $post_times; do
     ###############################
     # Start Looping for the 
     # existence of the restart files
@@ -205,26 +188,23 @@ do
     set -x
     export pgm="postcheck"
     ic=1
-    while [ $ic -le $SLEEP_LOOP_MAX ]
-    do
-       if test -f ${restart_file}${fhr}.txt
-       then
-          break
-       else
-          ic=`expr $ic + 1`
-          sleep $SLEEP_INT
-       fi
-       ###############################
-       # If we reach this point assume
-       # fcst job never reached restart 
-       # period and error exit
-       ###############################
-       if [ $ic -eq $SLEEP_LOOP_MAX ]
-       then
-          echo " *** FATAL ERROR: No model output in nemsio for f${fhr} "
-          export err=9
-          err_chk
-       fi
+    while [ $ic -le $SLEEP_LOOP_MAX ]; do
+      if [ -f ${restart_file}${fhr}.txt ]; then
+        break
+      else
+        ic=$(expr $ic + 1)
+        sleep $SLEEP_INT
+      fi
+      ###############################
+      # If we reach this point assume
+      # fcst job never reached restart 
+      # period and error exit
+      ###############################
+      if [ $ic -eq $SLEEP_LOOP_MAX ]; then
+        echo " *** FATAL ERROR: No model output in nemsio for f${fhr} "
+        export err=9
+        err_chk
+      fi
     done
     set -x
 
@@ -235,7 +215,8 @@ do
     # Put restart files into /nwges 
     # for backup to start Model Fcst
     ###############################
-    [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
+    [[ -f flxfile ]] && rm flxfile
+    [[ -f nemsfile ]] && rm nemsfile
     if [ $OUTTYP -eq 4 ] ; then
       ln -sf $COMIN/${PREFIX}atmf$fhr${SUFFIX} nemsfile
       export NEMSINP=nemsfile
@@ -243,43 +224,40 @@ do
       export FLXINP=flxfile
     fi
 
-    if test $fhr -gt 0
-    then
-       export IGEN=$IGEN_FCST
+    if [ $fhr -gt 0 ]; then
+      export IGEN=$IGEN_FCST
     else
-       export IGEN=$IGEN_ANL
+      export IGEN=$IGEN_ANL
     fi
-    
-# add new environmental variables for running new ncep post
-# Validation date
 
-    export VDATE=`${NDATE} +${fhr} ${PDY}${cyc}`
-   
-# set to 3 to output lat/lon grid
-     
+    # add new environmental variables for running new ncep post
+    # Validation date
+
+    export VDATE=$(${NDATE} +${fhr} ${PDY}${cyc})
+
+    # set to 3 to output lat/lon grid
+
     export OUTTYP=${OUTTYP:-4}
 
-    if [ $GRIBVERSION = 'grib2' ] ; then
+    if [ $GRIBVERSION = 'grib2' ]; then
       export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
       export PostFlatFile=$PARMpost/postxconfig-NT-GFS.txt
-      if [ $RUN = gfs ] ; then
+      if [ $RUN = gfs ]; then
         export IGEN=$IGEN_GFS
-        if [ $fhr -gt 0 ] ; then export IGEN=$IGEN_FCST ; fi
+        if [ $fhr -gt 0 ]; then export IGEN=$IGEN_FCST ; fi
       else
         export IGEN=$IGEN_GDAS_ANL
-        if [ $fhr -gt 0 ] ; then export IGEN=$IGEN_FCST ; fi
+        if [ $fhr -gt 0 ]; then export IGEN=$IGEN_FCST ; fi
       fi
-      if [[ $RUN = gfs ]] ; then
-        if test $fhr -eq 0
-        then
+      if [[ $RUN = gfs ]]; then
+        if [ $fhr -eq 0 ]; then
           export PostFlatFile=$PARMpost/postxconfig-NT-GFS-F00.txt
           export CTLFILE=$PARMpost/postcntrl_gfs_f00.xml
         else
           export CTLFILE=${CTLFILEGFS:-$PARMpost/postcntrl_gfs.xml}
         fi
       else
-        if test $fhr -eq 0
-        then
+        if [ $fhr -eq 0 ]; then
           export PostFlatFile=$PARMpost/postxconfig-NT-GFS-F00.txt 
           export CTLFILE=${CTLFILEGFS:-$PARMpost/postcntrl_gfs_f00.xml}
         else
@@ -287,7 +265,7 @@ do
         fi
       fi
     fi
-    
+
     export FLXIOUT=flxifile
     export PGBOUT=pgbfile
     export PGIOUT=pgifile
@@ -295,12 +273,10 @@ do
     export PGIOUT2=pgifile.grib2.idx
     export FILTER=0
     export fhr3=$fhr
-    if [ $GRIBVERSION = 'grib2' ]
-    then
+    if [ $GRIBVERSION = 'grib2' ]; then
       MASTERFHR=${PREFIX}master.grb2f${fhr}
       MASTERFHRIDX=${PREFIX}master.grb2if${fhr}
     fi
-    
 
     if [ $INLINE_POST = ".false." ]; then
       $POSTGPSH
@@ -309,30 +285,26 @@ do
     fi
     export err=$?; err_chk
 
-
-    if test $GRIBVERSION = 'grib2'
-    then
+    if [ $GRIBVERSION = 'grib2' ]; then
       mv $PGBOUT $PGBOUT2
     fi
 
     #wm Process pgb files
-    export FH=`expr $fhr + 0`
+    export FH=$(expr $fhr + 0)
     export downset=${downset:-1}
     $GFSDOWNSH
     export err=$?; err_chk
 
-    
     if [ $SENDDBN = YES ]; then
-      run=`echo $RUN | tr '[a-z]' '[A-Z]'`
+      run=$(echo $RUN | tr '[a-z]' '[A-Z]')
       $DBNROOT/bin/dbn_alert MODEL ${run}_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}
       $DBNROOT/bin/dbn_alert MODEL ${run}_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}.idx
       $DBNROOT/bin/dbn_alert MODEL ${run}_PGB_GB2 $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}
       $DBNROOT/bin/dbn_alert MODEL ${run}_PGB_GB2_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}.idx
     fi
-    
- 
-    if test $SENDCOM = 'YES'
-    then
+
+
+    if [ $SENDCOM = 'YES' ]; then
       if [ $GRIBVERSION = 'grib2' ] ; then
         if [ $INLINE_POST = ".false." ]; then 
           cp $PGBOUT2 $COMOUT/${MASTERFHR}
@@ -340,19 +312,18 @@ do
         $GRB2INDEX $PGBOUT2 $COMOUT/${MASTERFHRIDX}
       fi 
 
-# Model generated flux files will be in nemsio after FY17 upgrade
-# use post to generate Grib2 flux files
+      # Model generated flux files will be in nemsio after FY17 upgrade
+      # use post to generate Grib2 flux files
 
       if [ $OUTTYP -eq 4 ] ; then
         export NEMSINP=$COMIN/${PREFIX}atmf${fhr}${SUFFIX}
         export FLXINP=$COMIN/${PREFIX}sfcf${fhr}${SUFFIX}
-        if test $fhr -eq 0
-        then
-         export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX-F00.txt
-         export CTLFILE=$PARMpost/postcntrl_gfs_flux_f00.xml
+        if [ $fhr -eq 0 ]; then
+          export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX-F00.txt
+          export CTLFILE=$PARMpost/postcntrl_gfs_flux_f00.xml
         else
-         export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX.txt
-         export CTLFILE=$PARMpost/postcntrl_gfs_flux.xml
+          export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX.txt
+          export CTLFILE=$PARMpost/postcntrl_gfs_flux.xml
         fi
         export PGBOUT=fluxfile
         export FILTER=0
@@ -361,14 +332,13 @@ do
 
         if [ $INLINE_POST = ".false." ]; then
           $POSTGPSH
-          export err=$?;  err_chk
+          export err=$?; err_chk
           mv fluxfile $COMOUT/${FLUXFL}
         fi
         $WGRIB2 -s $COMOUT/${FLUXFL} > $COMOUT/${FLUXFLIDX}
       fi
 
-      if test "$SENDDBN" = 'YES' -a  \( "$RUN" = 'gdas' \) -a `expr $fhr % 3` -eq 0
-      then
+      if [ "$SENDDBN" = 'YES' -a  \( "$RUN" = 'gdas' \) -a $(expr $fhr % 3) -eq 0 ]; then
         $DBNROOT/bin/dbn_alert MODEL ${run}_SF $job $COMOUT/${PREFIX}atmf${fhr}${SUFFIX}
         $DBNROOT/bin/dbn_alert MODEL ${run}_BF $job $COMOUT/${PREFIX}sfcf${fhr}${SUFFIX}
         $DBNROOT/bin/dbn_alert MODEL ${run}_SGB_GB2 $job $COMOUT/${PREFIX}sfluxgrbf${fhr}.grib2
@@ -376,13 +346,10 @@ do
       fi
     fi 
 
-    [[ -f pgbfile.grib2 ]] && rm pgbfile.grib2 ; [[ -f flxfile ]] && rm flxfile
-
-done 
-
-#----------------------------------
-fi   ## end_if_times   
-#----------------------------------
+    [[ -f pgbfile.grib2 ]] && rm pgbfile.grib2
+    [[ -f flxfile ]] && rm flxfile
+  done
+fi   ## end_if_times
 
 #cat $pgmout
 #msg='ENDED NORMALLY.'

--- a/scripts/exgfs_atmos_nceppost.sh
+++ b/scripts/exgfs_atmos_nceppost.sh
@@ -39,7 +39,7 @@ set -x
 cd $DATA
 
 # specify model output format type: 4 for nemsio, 3 for sigio
-msg="HAS BEGUN on `hostname`"
+msg="HAS BEGUN on $(hostname)"
 postmsg "$msg"
 
 export POSTGPSH=${POSTGPSH:-$USHgfs/gfs_nceppost.sh}
@@ -62,14 +62,14 @@ export IO=${LONB:-1440}
 export JO=${LATB:-721}
 export OUTTYP=${OUTTYP:-4}
 export FLXF=${FLXF:-"YES"}
-export FLXGF=${FLXGF:-"YES"}
+export FLXGF=${FLXGF:-"YES"} 
 export GOESF=${GOESF:-"YES"}
 export WAFSF=${WAFSF:-"NO"}
 export PGBF=${PGBF:-"YES"}
 export TCYC=${TCYC:-".t${cyc}z."}
 export OUTPUT_FILE=${OUTPUT_FILE:-"nemsio"}
 export PREFIX=${PREFIX:-${RUN}${TCYC}}
-if [ $OUTTYP -eq 4 ] ; then
+if [ $OUTTYP -eq 4 ]; then
   if [ $OUTPUT_FILE = "netcdf" ]; then
     export SUFFIX=".nc"
   else
@@ -94,170 +94,149 @@ export IDRT=${IDRT:-0} # IDRT=0 is setting for outputting grib files on lat/lon 
 # Post Analysis Files before starting the Forecast Post
 ############################################################
 # Process analysis when post_times is 00
- export stime=`echo $post_times | cut -c1-3`
-if [ $OUTTYP -eq 4 ] ; then
+export stime=$(echo $post_times | cut -c1-3)
+if [ $OUTTYP -eq 4 ]; then
   export loganl=$COMIN/${PREFIX}atmanl${SUFFIX}
 else
   export loganl=$COMIN/${PREFIX}sanl
 fi
 
-#----------------------------------
 if [ ${stime} = "anl" ]; then
-#----------------------------------
+  if [ -f $loganl ]; then
+    # add new environmental variables for running new ncep post
+    # Validation date
+    export VDATE=${PDY}${cyc}
+    # specify output file name from chgres which is input file name to nceppost
+    # if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
+    # new imported variable for global_nceppost.sh
+    export GFSOUT=${PREFIX}gfsioanl
 
-if test -f $loganl 
-then
-   
-# add new environmental variables for running new ncep post
-# Validation date
-   export VDATE=${PDY}${cyc}
-# specify output file name from chgres which is input file name to nceppost
-# if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
-# new imported variable for global_nceppost.sh
-   export GFSOUT=${PREFIX}gfsioanl
+    # specify smaller control file for GDAS because GDAS does not
+    # produce flux file, the default will be /nwprod/parm/gfs_cntrl.parm
+    if [ $GRIBVERSION = 'grib2' ]; then
+      # use grib2 nomonic table in product g2tmpl directory as default 
+      export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
+      export PostFlatFile=${PostFlatFile:-$PARMpost/postxconfig-NT-GFS-ANL.txt}
+      export CTLFILE=$PARMpost/postcntrl_gfs_anl.xml
+    fi
 
-# specify smaller control file for GDAS because GDAS does not
-# produce flux file, the default will be /nwprod/parm/gfs_cntrl.parm
-   if [ $GRIBVERSION = 'grib2' ]; then
-# use grib2 nomonic table in product g2tmpl directory as default 
-     export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
-     export PostFlatFile=${PostFlatFile:-$PARMpost/postxconfig-NT-GFS-ANL.txt}
-     export CTLFILE=$PARMpost/postcntrl_gfs_anl.xml
-   fi
+    [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
+    if [ $OUTTYP -eq 4 ]; then
+      ln -fs $COMIN/${PREFIX}atmanl${SUFFIX} nemsfile
+      export NEMSINP=nemsfile
+      ln -fs $COMIN/${PREFIX}sfcanl${SUFFIX} flxfile
+      export FLXINP=flxfile
+    fi
 
-   [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
-   if [ $OUTTYP -eq 4 ] ; then
-     ln -fs $COMIN/${PREFIX}atmanl${SUFFIX} nemsfile
-     export NEMSINP=nemsfile
-     ln -fs $COMIN/${PREFIX}sfcanl${SUFFIX} flxfile
-     export FLXINP=flxfile
-   fi
+    export PGBOUT=pgbfile
+    export PGIOUT=pgifile
+    export PGBOUT2=pgbfile.grib2
+    export PGIOUT2=pgifile.grib2.idx
+    export IGEN=$IGEN_ANL
+    export FILTER=0
 
-   export PGBOUT=pgbfile
-   export PGIOUT=pgifile
-   export PGBOUT2=pgbfile.grib2
-   export PGIOUT2=pgifile.grib2.idx
-   export IGEN=$IGEN_ANL
-   export FILTER=0
+    $POSTGPSH
+    export err=$?; err_chk
 
-   $POSTGPSH
-   export err=$?; err_chk
-   
-   if test $GRIBVERSION = 'grib2'
-   then
-     mv $PGBOUT $PGBOUT2
-   fi
+    if [ $GRIBVERSION = 'grib2' ]; then
+      mv $PGBOUT $PGBOUT2
+    fi
 
-#  Process pgb files
-   if test "$PGBF" = 'YES'
-   then
-     export FH=-1
-     export downset=${downset:-2}
-     $GFSDOWNSH
-     export err=$?; err_chk
-   fi
+    #  Process pgb files
+    if [ "$PGBF" = 'YES' ]; then
+      export FH=-1
+      export downset=${downset:-2}
+      $GFSDOWNSH
+      export err=$?; err_chk
+    fi
 
-   if test "$SENDCOM" = 'YES'
-   then
-     export fhr3=anl
-     if [ $GRIBVERSION = 'grib2' ]
-     then
-       MASTERANL=${PREFIX}master.grb2${fhr3}
-       MASTERANLIDX=${PREFIX}master.grb2i${fhr3}
-       cp $PGBOUT2 $COMOUT/${MASTERANL}
-       $GRB2INDEX $PGBOUT2 $COMOUT/${MASTERANLIDX}
-     fi
-
-     if test "$SENDDBN" = 'YES'
-     then
-       $DBNROOT/bin/dbn_alert MODEL GFS_MSC_sfcanl $job $COMOUT/${PREFIX}sfcanl${SUFFIX}
-       $DBNROOT/bin/dbn_alert MODEL GFS_SA $job $COMOUT/${PREFIX}atmanl${SUFFIX}
-#alert removed in v15.0       $DBNROOT/bin/dbn_alert MODEL GFS_MASTER $job $COMOUT/${MASTERANL}
-       if test "$PGBF" = 'YES'
-       then
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25 $job $COMOUT/${PREFIX}pgrb2b.0p25.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p25.anl.idx
-
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5 $job $COMOUT/${PREFIX}pgrb2.0p50.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2.0p50.anl.idx
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5 $job $COMOUT/${PREFIX}pgrb2b.0p50.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p50.anl.idx
-
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0 $job $COMOUT/${PREFIX}pgrb2.1p00.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0 $job $COMOUT/${PREFIX}pgrb2b.1p00.anl
-         $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2b.1p00.anl.idx
-       fi
-     fi 
-
-   fi
-   [[ -f pgbfile.grib2 ]] && rm pgbfile.grib2 
-#   ecflow_client --event release_pgrb2_anl
-
-##########################  WAFS U/V/T analysis start ##########################
-# U/V/T on ICAO standard atmospheric pressure levels for WAFS verification
-  if [ $WAFSF = "YES" ] ; then
-    if [[ $RUN = gfs && $GRIBVERSION = 'grib2' ]] ; then
-      export OUTTYP=${OUTTYP:-4}
-
-      export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS-ANL.txt
-      export CTLFILE=$PARMpost/postcntrl_gfs_wafs_anl.xml
-
-      export PGBOUT=wafsfile
-      export PGIOUT=wafsifile
-
-      $POSTGPSH
-      export err=$?
-
-      if [ $err -ne 0 ] ; then
-	  echo " *** GFS POST WARNING: WAFS output failed for analysis, err=$err"
-      else
-
-        # WAFS package doesn't process this part.
-	# Need to be saved for WAFS U/V/T verification, 
-        # resolution higher than WAFS 1.25 deg for future compatibility
-        wafsgrid="latlon 0:1440:0.25 90:721:-0.25"
-	$WGRIB2 $PGBOUT -set_grib_type same -new_grid_winds earth \
-              -new_grid_interpolation bilinear -set_bitmap 1 \
-	      -new_grid $wafsgrid ${PGBOUT}.tmp
-
-	if test $SENDCOM = "YES"
-	then
-         cp ${PGBOUT}.tmp $COMOUT/${PREFIX}wafs.0p25.anl
-         $WGRIB2 -s ${PGBOUT}.tmp > $COMOUT/${PREFIX}wafs.0p25.anl.idx
-
-#         if [ $SENDDBN = YES ]; then
-#            $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2 $job $COMOUT/${PREFIX}wafs.0p25.anl
-#            $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2__WIDX $job $COMOUT/${PREFIX}wafs.0p25.anl.idx
-#         fi
-	fi
-	rm $PGBOUT ${PGBOUT}.tmp
+    if [ "$SENDCOM" = 'YES' ]; then
+      export fhr3=anl
+      if [ $GRIBVERSION = 'grib2' ]; then
+        MASTERANL=${PREFIX}master.grb2${fhr3}
+        MASTERANLIDX=${PREFIX}master.grb2i${fhr3}
+        cp $PGBOUT2 $COMOUT/${MASTERANL}
+        $GRB2INDEX $PGBOUT2 $COMOUT/${MASTERANLIDX}
       fi
-   fi
+
+      if [ "$SENDDBN" = 'YES' ]; then
+        $DBNROOT/bin/dbn_alert MODEL GFS_MSC_sfcanl $job $COMOUT/${PREFIX}sfcanl${SUFFIX}
+        $DBNROOT/bin/dbn_alert MODEL GFS_SA $job $COMOUT/${PREFIX}atmanl${SUFFIX}
+        #alert removed in v15.0       $DBNROOT/bin/dbn_alert MODEL GFS_MASTER $job $COMOUT/${MASTERANL}
+        if [ "$PGBF" = 'YES' ]; then
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25 $job $COMOUT/${PREFIX}pgrb2b.0p25.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p25.anl.idx
+
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5 $job $COMOUT/${PREFIX}pgrb2.0p50.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2.0p50.anl.idx
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5 $job $COMOUT/${PREFIX}pgrb2b.0p50.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p50.anl.idx
+
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0 $job $COMOUT/${PREFIX}pgrb2.1p00.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0 $job $COMOUT/${PREFIX}pgrb2b.1p00.anl
+          $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2b.1p00.anl.idx
+        fi
+      fi
+    fi
+    [[ -f pgbfile.grib2 ]] && rm pgbfile.grib2 
+    #   ecflow_client --event release_pgrb2_anl
+
+    ##########################  WAFS U/V/T analysis start ##########################
+    # U/V/T on ICAO standard atmospheric pressure levels for WAFS verification
+    if [ $WAFSF = "YES" ]; then
+      if [[ $RUN = gfs && $GRIBVERSION = 'grib2' ]]; then
+        export OUTTYP=${OUTTYP:-4}
+
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS-ANL.txt
+        export CTLFILE=$PARMpost/postcntrl_gfs_wafs_anl.xml
+
+        export PGBOUT=wafsfile
+        export PGIOUT=wafsifile
+
+        $POSTGPSH
+        export err=$?
+        if [ $err -ne 0 ]; then
+          echo " *** GFS POST WARNING: WAFS output failed for analysis, err=$err"
+        else
+          # WAFS package doesn't process this part.
+          # Need to be saved for WAFS U/V/T verification, 
+          # resolution higher than WAFS 1.25 deg for future compatibility
+          wafsgrid="latlon 0:1440:0.25 90:721:-0.25"
+          $WGRIB2 $PGBOUT -set_grib_type same -new_grid_winds earth \
+          -new_grid_interpolation bilinear -set_bitmap 1 \
+          -new_grid $wafsgrid ${PGBOUT}.tmp
+
+          if [ $SENDCOM = "YES" ]; then
+            cp ${PGBOUT}.tmp $COMOUT/${PREFIX}wafs.0p25.anl
+            $WGRIB2 -s ${PGBOUT}.tmp > $COMOUT/${PREFIX}wafs.0p25.anl.idx
+
+            # if [ $SENDDBN = YES ]; then
+            #    $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2 $job $COMOUT/${PREFIX}wafs.0p25.anl
+            #    $DBNROOT/bin/dbn_alert MODEL GFS_WAFS_GB2__WIDX $job $COMOUT/${PREFIX}wafs.0p25.anl.idx
+            # fi
+          fi
+          rm $PGBOUT ${PGBOUT}.tmp
+        fi
+      fi
+    fi
+    ##########################  WAFS U/V/T analysis end  ##########################
+  else
+    #### atmanl file not found need failing job
+    echo " *** FATAL ERROR: No model anl file output "
+    export err=9
+    err_chk
   fi
-##########################  WAFS U/V/T analysis end  ##########################
-else
-  #### atmanl file not found need failing job
-  echo " *** FATAL ERROR: No model anl file output "
-  export err=9
-  err_chk
-fi
-
-#----------------------------------
 else   ## not_anl if_stime
-#----------------------------------
+  SLEEP_LOOP_MAX=$(expr $SLEEP_TIME / $SLEEP_INT)
 
-SLEEP_LOOP_MAX=`expr $SLEEP_TIME / $SLEEP_INT`
+  ############################################################
+  # Loop Through the Post Forecast Files 
+  ############################################################
 
-# Chuang: modify to submit one post job at a time
-############################################################
-# Loop Through the Post Forecast Files 
-############################################################
-
-for fhr in $post_times
-do
+  for fhr in $post_times; do
     echo 'Start processing fhr='$post_times
     ###############################
     # Start Looping for the 
@@ -266,26 +245,23 @@ do
     set -x
     export pgm="postcheck"
     ic=1
-    while [ $ic -le $SLEEP_LOOP_MAX ]
-    do
-       if test -f $restart_file${fhr}.txt
-       then
-          break
-       else
-          ic=`expr $ic + 1`
-          sleep $SLEEP_INT
-       fi
-       ###############################
-       # If we reach this point assume
-       # fcst job never reached restart 
-       # period and error exit
-       ###############################
-       if [ $ic -eq $SLEEP_LOOP_MAX ]
-       then
-          echo " *** FATAL ERROR: No model output in nemsio for f${fhr} "
-          export err=9
-          err_chk
-       fi
+    while [ $ic -le $SLEEP_LOOP_MAX ]; do
+      if [ -f $restart_file${fhr}.txt ]; then
+        break
+      else
+        ic=$(expr $ic + 1)
+        sleep $SLEEP_INT
+      fi
+      ###############################
+      # If we reach this point assume
+      # fcst job never reached restart 
+      # period and error exit
+      ###############################
+      if [ $ic -eq $SLEEP_LOOP_MAX ]; then
+        echo " *** FATAL ERROR: No model output in nemsio for f${fhr} "
+        export err=9
+        err_chk
+      fi
     done
     set -x
 
@@ -297,21 +273,20 @@ do
     # for backup to start Model Fcst
     ###############################
     [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
-    if [ $OUTTYP -eq 4 ] ; then
+    if [ $OUTTYP -eq 4 ]; then
       ln -fs $COMIN/${PREFIX}atmf${fhr}${SUFFIX} nemsfile
       export NEMSINP=nemsfile
       ln -fs $COMIN/${PREFIX}sfcf${fhr}${SUFFIX} flxfile
       export FLXINP=flxfile
     fi
 
-    if test $fhr -gt 0
-    then
+    if [ $fhr -gt 0 ]; then
       export IGEN=$IGEN_FCST
     else
       export IGEN=$IGEN_ANL
     fi
-    
-    export VDATE=`${NDATE} +${fhr} ${PDY}${cyc}`
+
+    export VDATE=$(${NDATE} +${fhr} ${PDY}${cyc})
     export OUTTYP=${OUTTYP:-4}
     export GFSOUT=${PREFIX}gfsio${fhr}
 
@@ -319,24 +294,22 @@ do
       export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
       export PostFlatFile=${PostFlatFile:-$PARMpost/postxconfig-NT-GFS.txt}
 
-      if [ $RUN = gfs ] ; then
+      if [ $RUN = gfs ]; then
         export IGEN=$IGEN_GFS
-        if [ $fhr -gt 0 ] ; then export IGEN=$IGEN_FCST ; fi
+        if [ $fhr -gt 0 ]; then export IGEN=$IGEN_FCST ; fi
       else
         export IGEN=$IGEN_GDAS_ANL
-        if [ $fhr -gt 0 ] ; then export IGEN=$IGEN_FCST ; fi
+        if [ $fhr -gt 0 ]; then export IGEN=$IGEN_FCST ; fi
       fi
-      if [[ $RUN = gfs ]] ; then
-        if test $fhr -eq 0
-        then
+      if [[ $RUN = gfs ]]; then
+        if [ $fhr -eq 0 ]; then
           export PostFlatFile=$PARMpost/postxconfig-NT-GFS-F00.txt
           export CTLFILE=$PARMpost/postcntrl_gfs_f00.xml
         else
           export CTLFILE=${CTLFILEGFS:-$PARMpost/postcntrl_gfs.xml}
         fi
       else
-        if test $fhr -eq 0
-        then
+        if [ $fhr -eq 0 ]; then
           export PostFlatFile=$PARMpost/postxconfig-NT-GFS-F00.txt
           export CTLFILE=${CTLFILEGFS:-$PARMpost/postcntrl_gfs_f00.xml}
         else
@@ -344,7 +317,7 @@ do
         fi
       fi
     fi
-    
+
     export FLXIOUT=flxifile
     export PGBOUT=pgbfile
     export PGIOUT=pgifile
@@ -352,8 +325,8 @@ do
     export PGIOUT2=pgifile.grib2.idx
     export FILTER=0 
     if [ $GRIBVERSION = 'grib2' ]; then
-        MASTERFL=${PREFIX}master.grb2f${fhr}
-        MASTERFLIDX=${PREFIX}master.grb2if${fhr}
+      MASTERFL=${PREFIX}master.grb2f${fhr}
+      MASTERFLIDX=${PREFIX}master.grb2if${fhr}
     fi
 
     if [ $INLINE_POST = ".false." ]; then
@@ -363,90 +336,78 @@ do
     fi
     export err=$?; err_chk
 
-    if test $GRIBVERSION = 'grib2'
-    then
+    if [ $GRIBVERSION = 'grib2' ]; then
       mv $PGBOUT $PGBOUT2
     fi
 
-#  Process pgb files
-   if test "$PGBF" = 'YES'
-   then
-     export FH=`expr $fhr + 0`
-     export downset=${downset:-2}
-     $GFSDOWNSH
-     export err=$?; err_chk
-   fi
+    #  Process pgb files
+    if [ "$PGBF" = 'YES' ]; then
+      export FH=$(expr $fhr + 0)
+      export downset=${downset:-2}
+      $GFSDOWNSH
+      export err=$?; err_chk
+    fi
 
-    if test $SENDCOM = "YES"
-    then
-	if [ $GRIBVERSION = 'grib2' ] ; then
-            if [ $INLINE_POST = ".false." ]; then 
-              cp $PGBOUT2 $COMOUT/${MASTERFL} 
+    if [ $SENDCOM = "YES" ]; then
+      if [ $GRIBVERSION = 'grib2' ]; then
+        if [ $INLINE_POST = ".false." ]; then 
+          cp $PGBOUT2 $COMOUT/${MASTERFL} 
+        fi
+        $GRB2INDEX $PGBOUT2  $COMOUT/${MASTERFLIDX}
+      fi
+
+      if [ "$SENDDBN" = 'YES' ]; then
+        if [ $GRIBVERSION = 'grib2' ]; then
+          if [ "$PGBF" = 'YES' ]; then
+            $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}
+            $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}.idx
+            $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25 $job $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr}
+            $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr}.idx
+
+            if [ -s $COMOUT/${PREFIX}pgrb2.0p50.f${fhr} ]; then
+              $DBNROOT/bin/dbn_alert  MODEL GFS_PGB2_0P5 $job $COMOUT/${PREFIX}pgrb2.0p50.f${fhr}
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2.0p50.f${fhr}.idx
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5 $job $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr}
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr}.idx
             fi
-	    $GRB2INDEX $PGBOUT2  $COMOUT/${MASTERFLIDX}
-	fi
-	
-	if test "$SENDDBN" = 'YES'
-	then
-	    if [ $GRIBVERSION = 'grib2' ] ; then
-#alert removed in v15.0		$DBNROOT/bin/dbn_alert MODEL GFS_MASTER $job $COMOUT/${MASTERFL}
-		if test "$PGBF" = 'YES'
-		then
-		    $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25 $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}
-		    $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2.0p25.f${fhr}.idx
-		    $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25 $job $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr}
-		    $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P25_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr}.idx
-		    
-		    if [ -s $COMOUT/${PREFIX}pgrb2.0p50.f${fhr} ] ; then
-			$DBNROOT/bin/dbn_alert  MODEL GFS_PGB2_0P5 $job $COMOUT/${PREFIX}pgrb2.0p50.f${fhr}
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2.0p50.f${fhr}.idx
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5 $job $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr}
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_0P5_WIDX $job $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr}.idx
-		    fi
-		    
-		    if [ -s $COMOUT/${PREFIX}pgrb2.1p00.f${fhr} ] ; then
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0 $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}.idx
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0 $job $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr}
-			$DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr}.idx
-		    fi
-		fi
-		
-	    fi 
-	fi
-	
-	#      x3=`expr $fhr % 3`
-	# x3=0 ---> Standard 3-hourly or 12-hourly output
-	#           Only master grib files are needed for the hourly files
-	#      if [ $x3 -eq 0 ] ; then
-	export fhr
-	$USHgfs/gfs_transfer.sh
-	#      fi
+
+            if [ -s $COMOUT/${PREFIX}pgrb2.1p00.f${fhr} ]; then
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0 $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2.1p00.f${fhr}.idx
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0 $job $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr}
+              $DBNROOT/bin/dbn_alert MODEL GFS_PGB2B_1P0_WIDX $job $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr}.idx
+            fi
+          fi
+        fi 
+      fi
+
+      export fhr
+      $USHgfs/gfs_transfer.sh
     fi
     [[ -f pgbfile.grib2 ]] && rm pgbfile.grib2
 
-# use post to generate GFS Grib2 Flux file as model generated Flux file
-# will be in nemsio format after FY17 upgrade.
-    if [ $OUTTYP -eq 4 -a $FLXF = "YES" ] ; then
-      if test $fhr -eq 0
-      then
-       export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX-F00.txt
-       export CTLFILE=$PARMpost/postcntrl_gfs_flux_f00.xml
+
+    # use post to generate GFS Grib2 Flux file as model generated Flux file
+    # will be in nemsio format after FY17 upgrade.
+    if [ $OUTTYP -eq 4 -a $FLXF = "YES" ]; then
+      if [ $fhr -eq 0 ]; then
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX-F00.txt
+        export CTLFILE=$PARMpost/postcntrl_gfs_flux_f00.xml
       else
-       export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX.txt
-       export CTLFILE=$PARMpost/postcntrl_gfs_flux.xml
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-FLUX.txt
+        export CTLFILE=$PARMpost/postcntrl_gfs_flux.xml
       fi
       export PGBOUT=fluxfile
       export FILTER=0
-      FLUXFL=${PREFIX}sfluxgrbf${fhr}.grib2
+      export FLUXFL=${PREFIX}sfluxgrbf${fhr}.grib2
       FLUXFLIDX=${PREFIX}sfluxgrbf${fhr}.grib2.idx
 
       #Add extra flux.1p00 file for coupled
       if [ "$FLXGF" = 'YES' ]; then                    
         export FH=$(expr $fhr + 0)     
         $GFSDOWNSHF                  
-        export err=$?; err_chk      
-      fi  
+        export err=$?; err_chk
+      fi   
 
       if [ $INLINE_POST = ".false." ]; then
         $POSTGPSH
@@ -455,127 +416,116 @@ do
       fi
       $WGRIB2 -s $COMOUT/${FLUXFL} > $COMOUT/${FLUXFLIDX}
 
-      if test "$SENDDBN" = 'YES'
-      then
+      if [ "$SENDDBN" = 'YES' ]; then
         $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2 $job $COMOUT/${FLUXFL}
         $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2_WIDX $job $COMOUT/${FLUXFLIDX}
       fi
     fi
 
-# process satellite look alike separately so that master pgb gets out in time    
-# set outtyp to 2 because master post already generates gfs io files
+    # process satellite look alike separately so that master pgb gets out in time    
+    # set outtyp to 2 because master post already generates gfs io files
     if [ $GOESF = "YES" ]; then
+      export OUTTYP=${OUTTYP:-4}     
 
-    export OUTTYP=${OUTTYP:-4}     
-   
-# specify output file name from chgres which is input file name to nceppost 
-# if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
-# new imported variable for global_nceppost.sh
+      # specify output file name from chgres which is input file name to nceppost 
+      # if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
+      # new imported variable for global_nceppost.sh
 
-    export GFSOUT=${PREFIX}gfsio${fhr}     
+      export GFSOUT=${PREFIX}gfsio${fhr}     
 
-    # link satellite coefficients files, use hwrf version as ops crtm 2.0.5
-    # does not new coefficient files used by post
-    export FIXCRTM=${FIXCRTM:-${CRTM_FIX}}
-    $USHgfs/link_crtm_fix.sh $FIXCRTM
+      # link satellite coefficients files, use hwrf version as ops crtm 2.0.5
+      # does not new coefficient files used by post
+      export FIXCRTM=${FIXCRTM:-${CRTM_FIX}}
+      $USHgfs/link_crtm_fix.sh $FIXCRTM
 
-    if [ $GRIBVERSION = 'grib2' ] ; then 
-      export PostFlatFile=$PARMpost/postxconfig-NT-GFS-GOES.txt      
-      export CTLFILE=$PARMpost/postcntrl_gfs_goes.xml
+      if [ $GRIBVERSION = 'grib2' ]; then 
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-GOES.txt      
+        export CTLFILE=$PARMpost/postcntrl_gfs_goes.xml
+      fi
+      export FLXINP=flxfile
+      export FLXIOUT=flxifile
+      export PGBOUT=goesfile
+      export PGIOUT=goesifile
+      export FILTER=0
+      export IO=0
+      export JO=0
+      export IGEN=0
+
+      if [ $NET = gfs ]; then
+        $POSTGPSH
+        export err=$?; err_chk
+      fi
+
+      if [ $GRIBVERSION = 'grib2' ]; then
+        SPECIALFL=${PREFIX}special.grb2
+        SPECIALFLIDX=${PREFIX}special.grb2i
+      fi
+      fhr3=$fhr
+
+      if [ $SENDCOM = "YES" ]; then
+        #       echo "$PDY$cyc$pad$fhr" > $COMOUT/${RUN}.t${cyc}z.master.control
+
+        mv goesfile $COMOUT/${SPECIALFL}f$fhr
+        mv goesifile $COMOUT/${SPECIALFLIDX}f$fhr
+
+        if [ $SENDDBN = YES ]; then
+          $DBNROOT/bin/dbn_alert MODEL GFS_SPECIAL_GB2 $job $COMOUT/${SPECIALFL}f$fhr
+        fi
+      fi
     fi
-    export FLXINP=flxfile
-    export FLXIOUT=flxifile
-    export PGBOUT=goesfile
-    export PGIOUT=goesifile
-    export FILTER=0
-    export IO=0
-    export JO=0
-    export IGEN=0
-    
-    if [ $NET = gfs ]; then
-     $POSTGPSH
-     export err=$?; err_chk
-    fi
+    # end of satellite processing
 
-    if [ $GRIBVERSION = 'grib2' ]; then
-      SPECIALFL=${PREFIX}special.grb2
-      SPECIALFLIDX=${PREFIX}special.grb2i
-    fi
-    fhr3=$fhr
+    ##########################  WAFS start ##########################
+    # Generate WAFS products on ICAO standard level.
+    # Do not need to be sent out to public, WAFS package will process the data.
+    if [[ $WAFSF = "YES"  && $fhr -le 120 ]]; then
+      if [[ $RUN = gfs && $GRIBVERSION = 'grib2' ]]; then
+        export OUTTYP=${OUTTYP:-4}
 
-    if test $SENDCOM = "YES"
-    then
+        # Extend WAFS icing and gtg up to 120 hours
+        export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS.txt
+        export CTLFILE=$PARMpost/postcntrl_gfs_wafs.xml
 
-#       echo "$PDY$cyc$pad$fhr" > $COMOUT/${RUN}.t${cyc}z.master.control
+        # gtg has its own configurations
+        cp $PARMpost/gtg.config.gfs gtg.config
+        cp $PARMpost/gtg_imprintings.txt gtg_imprintings.txt
 
-       mv goesfile $COMOUT/${SPECIALFL}f$fhr
-       mv goesifile $COMOUT/${SPECIALFLIDX}f$fhr
+        export PGBOUT=wafsfile
+        export PGIOUT=wafsifile
 
-       if [ $SENDDBN = YES ]; then
-           $DBNROOT/bin/dbn_alert MODEL GFS_SPECIAL_GB2 $job $COMOUT/${SPECIALFL}f$fhr
-       fi
+        # WAFS data is processed:
+        #   hourly if fhr<=24
+        #   every 3 forecast hour if 24<fhr<=48
+        #   every 6 forecast hour if 48<fhr<=120
+        if [  $fhr -le 24  ]; then
+          $POSTGPSH
+        elif [  $fhr -le 48  ]; then
+          if [  $((10#$fhr%3)) -eq 0  ]; then
+            $POSTGPSH
+          fi
+        elif [  $((10#$fhr%6)) -eq 0  ]; then
+          $POSTGPSH
+        fi
 
-    fi
-    fi
-# end of satellite processing
-
-##########################  WAFS start ##########################
-# Generate WAFS products on ICAO standard level.
-# Do not need to be sent out to public, WAFS package will process the data.
-    if [[ $WAFSF = "YES"  && $fhr -le 120 ]] ; then
-       if [[ $RUN = gfs && $GRIBVERSION = 'grib2' ]] ; then
-          export OUTTYP=${OUTTYP:-4}
-
-	  # Extend WAFS icing and gtg up to 120 hours
-          export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS.txt
-          export CTLFILE=$PARMpost/postcntrl_gfs_wafs.xml
-
-          # gtg has its own configurations
-          cp $PARMpost/gtg.config.gfs gtg.config
-          cp $PARMpost/gtg_imprintings.txt gtg_imprintings.txt
-
-          export PGBOUT=wafsfile
-          export PGIOUT=wafsifile
-
-          # WAFS data is processed:
-          #   hourly if fhr<=24
-          #   every 3 forecast hour if 24<fhr<=48
-          #   every 6 forecast hour if 48<fhr<=120
-	  if [  $fhr -le 24  ] ; then
-             $POSTGPSH
-          elif [  $fhr -le 48  ] ; then
-             if [  $((10#$fhr%3)) -eq 0  ] ; then
-               $POSTGPSH
-             fi
-          elif [  $((10#$fhr%6)) -eq 0  ] ; then
-               $POSTGPSH
-	  fi
-
-          export err=$?
-
-	  if [ $err -ne 0 ] ; then
-              echo " *** GFS POST WARNING: WAFS output failed for f${fhr}, err=$err"
-	  else
-              if [ -e $PGBOUT ]
-              then
-		  if test $SENDCOM = "YES"
-		  then
-		      cp $PGBOUT $COMOUT/${PREFIX}wafs.grb2f$fhr
-		      cp $PGIOUT $COMOUT/${PREFIX}wafs.grb2if$fhr
-		  fi
-              fi
-	  fi
+        export err=$?; err_chk
+        if [ $err -ne 0 ]; then
+          echo " *** GFS POST WARNING: WAFS output failed for f${fhr}, err=$err"
+        else
+          if [ -e $PGBOUT ]; then
+            if [ $SENDCOM = "YES" ]; then
+              cp $PGBOUT $COMOUT/${PREFIX}wafs.grb2f$fhr
+              cp $PGIOUT $COMOUT/${PREFIX}wafs.grb2if$fhr
+            fi
+          fi
+        fi
       fi
       [[ -f wafsfile ]] && rm wafsfile ; [[ -f wafsifile ]] && rm wafsifile
     fi
-###########################  WAFS  end ###########################
+    ###########################  WAFS  end ###########################
+  done
 
-
-done
-
-#----------------------------------
+  #----------------------------------
 fi   ## end_if_stime
-#----------------------------------
 
 #cat $pgmout
 #msg='ENDED NORMALLY.'

--- a/scripts/exgfs_atmos_nceppost.sh
+++ b/scripts/exgfs_atmos_nceppost.sh
@@ -44,6 +44,7 @@ postmsg "$msg"
 
 export POSTGPSH=${POSTGPSH:-$USHgfs/gfs_nceppost.sh}
 export GFSDOWNSH=${GFSDOWNSH:-$USHgfs/fv3gfs_downstream_nems.sh}
+export GFSDOWNSHF=${GFSDOWNSHF:-$USHgfs/inter_flux.sh}
 export GFSDWNSH=${GFSDWNSH:-$USHgfs/fv3gfs_dwn_nems.sh}
 export TRIMRH=${TRIMRH:-$USHgfs/trim_rh.sh}
 export MODICEC=${MODICEC:-$USHgfs/mod_icec.sh}
@@ -61,6 +62,7 @@ export IO=${LONB:-1440}
 export JO=${LATB:-721}
 export OUTTYP=${OUTTYP:-4}
 export FLXF=${FLXF:-"YES"}
+export FLXGF=${FLXGF:-"YES"}
 export GOESF=${GOESF:-"YES"}
 export WAFSF=${WAFSF:-"NO"}
 export PGBF=${PGBF:-"YES"}
@@ -438,6 +440,13 @@ do
       export FILTER=0
       FLUXFL=${PREFIX}sfluxgrbf${fhr}.grib2
       FLUXFLIDX=${PREFIX}sfluxgrbf${fhr}.grib2.idx
+
+      #Add extra flux.1p00 file for coupled
+      if [ "$FLXGF" = 'YES' ]; then                    
+        export FH=$(expr $fhr + 0)     
+        $GFSDOWNSHF                  
+        export err=$?; err_chk      
+      fi  
 
       if [ $INLINE_POST = ".false." ]; then
         $POSTGPSH

--- a/scripts/exglobal_atmos_pmgr.sh
+++ b/scripts/exglobal_atmos_pmgr.sh
@@ -10,69 +10,63 @@ hour=00
 typeset -Z2 hour
 
 case $RUN in
-   gfs) TEND=384
-        TCP=385;;
-  gdas) TEND=9
-        TCP=10;; 
+  gfs)
+    TEND=384
+    TCP=385
+    ;;
+  gdas)
+    TEND=9
+    TCP=10
+    ;; 
 esac
 
 if [ -e posthours ]; then
-   rm -f posthours
+  rm -f posthours
 fi
 
-while [ $hour -lt $TCP ]; 
-do
+while [ $hour -lt $TCP ]; do
   echo $hour >>posthours
-  if [ $hour -lt 120 ]
-  then
-     if [ $hour -eq 99 ]
-     then
-       typeset -Z3 hour
-     fi
-     let "hour=hour+1"
+  if [ $hour -lt 120 ]; then
+    if [ $hour -eq 99 ]; then
+      typeset -Z3 hour
+    fi
+    let "hour=hour+1"
   else
-     let "hour=hour+3"
+    let "hour=hour+3"
   fi
 done
-postjobs=`cat posthours`
+postjobs=$(cat posthours)
 
 #
 # Wait for all fcst hours to finish 
 #
 icnt=1
-while [ $icnt -lt 1000 ]
-do
-  for fhr in $postjobs
-  do 
-    fhr3=`printf "%03d" $fhr`   
-    if [ -s ${COMIN}/${RUN}.${cycle}.logf${fhr}.txt -o  -s ${COMIN}/${RUN}.${cycle}.logf${fhr3}.txt ]
-    then
-      if [ $fhr -eq 0 ]
-      then 
-####        ecflow_client --event release_${RUN}_postanl
+while [ $icnt -lt 1000 ]; do
+  for fhr in $postjobs; do 
+    fhr3=$(printf "%03d" $fhr)   
+    if [ -s ${COMIN}/${RUN}.${cycle}.logf${fhr}.txt -o  -s ${COMIN}/${RUN}.${cycle}.logf${fhr3}.txt ]; then
+      if [ $fhr -eq 0 ]; then 
+        ####        ecflow_client --event release_${RUN}_postanl
         ecflow_client --event release_postanl
       fi    
-####      ecflow_client --event release_${RUN}_post${fhr}
+      ####      ecflow_client --event release_${RUN}_post${fhr}
       ecflow_client --event release_post${fhr3}
       # Remove current fhr from list
-      postjobs=`echo $postjobs | sed "s/${fhr}//"`
+      postjobs=$(echo $postjobs | sed "s/${fhr}//")
     fi
   done
-  
-  result_check=`echo $postjobs | wc -w`
-  if [ $result_check -eq 0 ]
-  then
-     break
+
+  result_check=$(echo $postjobs | wc -w)
+  if [ $result_check -eq 0 ]; then
+    break
   fi
 
   sleep 10
   icnt=$((icnt + 1))
-  if [ $icnt -ge 1080 ]
-  then
+  if [ $icnt -ge 1080 ]; then
     msg="ABORTING after 3 hours of waiting for ${RUN} FCST hours $postjobs."
     err_exit $msg
   fi
-
 done
 
 echo Exiting $0

--- a/scripts/run_upp
+++ b/scripts/run_upp
@@ -115,58 +115,58 @@ export MP_LABELIO=yes
 # Do some checks for directory/executable existence, user input, etc.
 #----------------------------------------------------------------------
 if [ ! -d ${POSTEXEC} ]; then
-  echo "ERROR: POSTEXEC, '${POSTEXEC}', does not exist"
-  exit 1
+	echo "ERROR: POSTEXEC, '${POSTEXEC}', does not exist"
+	exit 1
 fi
 
 if [ ! -x ${POSTEXEC}/upp.x ]; then
-  echo "ERROR: upp.x, '${POSTEXEC}/upp.x', does not exist or is not executable."
-  exit 1
+	echo "ERROR: upp.x, '${POSTEXEC}/upp.x', does not exist or is not executable."
+	exit 1
 fi
 
 # Set tag based on user defined model (GFS or LAM)
 if [ $model = "GFS" ]; then
-   export tag=GFS
+	export tag=GFS
 elif [ $model = "LAM" ]; then
-   export tag=FV3R
+	export tag=FV3R
 else
-   echo "${model} is not supported. Edit script to choose 'GFS' or 'LAM' model."
-   exit
+	echo "${model} is not supported. Edit script to choose 'GFS' or 'LAM' model."
+	exit
 fi
 
 if [ ${model} == "GFS" ]; then
-   if [[ ${inFormat} == "binarynemsiompiio" ]]; then
-      echo "Check: You are using 'model' 'inFormat'!"
-   elif [[ ${inFormat} == "netcdf" ]]; then
-      echo "Check: You are using 'model' 'inFormat'!"
-   else
-      echo "ERROR: 'inFormat' must be 'binarynemsiompiio' or 'netcdf' for GFS model output. Exiting... "
-      exit 1
-   fi
+	if [[ ${inFormat} == "binarynemsiompiio" ]]; then
+		echo "Check: You are using 'model' 'inFormat'!"
+	elif [[ ${inFormat} == "netcdf" ]]; then
+		echo "Check: You are using 'model' 'inFormat'!"
+	else
+		echo "ERROR: 'inFormat' must be 'binarynemsiompiio' or 'netcdf' for GFS model output. Exiting... "
+		exit 1
+	fi
 elif [[ ${model} == "LAM" ]]; then
-   if [[ ${inFormat} != "netcdf" ]]; then
-      echo "ERROR: 'inFormat' must be 'netcdf' for LAM  model output. Exiting... "
-      exit 1
-   fi
+	if [[ ${inFormat} != "netcdf" ]]; then
+		echo "ERROR: 'inFormat' must be 'netcdf' for LAM  model output. Exiting... "
+		exit 1
+	fi
 fi
 
 if [[ ${outFormat} == "grib2" ]]; then
-   if [ ! -e ${txtCntrlFile} ]; then
-      echo "ERROR: 'txtCntrlFile' not found in '${txtCntrlFile}'.  Exiting... "
-      exit 1
-   fi
+	if [ ! -e ${txtCntrlFile} ]; then
+		echo "ERROR: 'txtCntrlFile' not found in '${txtCntrlFile}'.  Exiting... "
+		exit 1
+	fi
 else
-   echo "${outFormat} is not supported. Edit script to choose 'grib2' for 'outFormat'. Exiting... "
+	echo "${outFormat} is not supported. Edit script to choose 'grib2' for 'outFormat'. Exiting... "
 fi
  
 if [ ! -d ${DOMAINPATH}/postprd ]; then
-  echo "ERROR: DOMAINPATH/postprd, '${DOMAINPATH}/postprd', does not exist. Exiting..."
-  exit 1
+	echo "ERROR: DOMAINPATH/postprd, '${DOMAINPATH}/postprd', does not exist. Exiting..."
+	exit 1
 fi
 
 if [ ${incrementhr} -eq 0 ]; then
-  echo "ERROR: increment hour (incrementhr) cannot be zero. Inifinite loop will result. Please modify. Exiting..."
-  exit 1
+	echo "ERROR: increment hour (incrementhr) cannot be zero. Inifinite loop will result. Please modify. Exiting..."
+	exit 1
 fi
 
 #----------------------------------------------------------------------
@@ -180,10 +180,10 @@ fi
 # cd to working directory
 cd ${DOMAINPATH}/postprd
 err1=$?
-if test "$err1" -ne 0; then
-    echo "ERROR: Could not 'cd' to working directory. Did you create directory: '${DOMAINPATH}/postprd'?  \
-    Does '${DOMAINPATH}' exist?  Exiting... "
-    exit 1
+if [ "$err1" -ne 0 ]; then
+	echo "ERROR: Could not 'cd' to working directory. Did you create directory: '${DOMAINPATH}/postprd'?  \
+	Does '${DOMAINPATH}' exist?  Exiting... "
+	exit 1
 fi
 
 # For GRIB2 the code reads a flat text tile to select variables for output.
@@ -193,9 +193,9 @@ fi
 #   program directory - this is true for params_grib2_tbl_new also - a
 #   file which defines the GRIB2 table values
 if [[ ${outFormat} == "grib2" ]]; then
-   ln -fs ${txtCntrlFile} postxconfig-NT.txt
-   ln -fs ${UNIPOST_HOME}/parm/post_avblflds.xml post_avblflds.xml
-   ln -fs ${UNIPOST_HOME}/parm/params_grib2_tbl_new params_grib2_tbl_new
+	ln -fs ${txtCntrlFile} postxconfig-NT.txt
+	ln -fs ${UNIPOST_HOME}/parm/post_avblflds.xml post_avblflds.xml
+	ln -fs ${UNIPOST_HOME}/parm/params_grib2_tbl_new params_grib2_tbl_new
 fi
 
 # Link microphysics tables - code will use based on mp_physics option
@@ -265,124 +265,122 @@ ln -fs $CRTMDIR/SpcCoeff/Big_Endian/ahi_himawari8.SpcCoeff.bin   ./
 
 export NEWDATE=$startdate
 
-YYY=`echo $startdate | cut -c1-4`
-MMM=`echo $startdate | cut -c5-6`
-DDD=`echo $startdate | cut -c7-8`
-HHH=`echo $startdate | cut -c9-10`
+YYY=$(echo $startdate | cut -c1-4)
+MMM=$(echo $startdate | cut -c5-6)
+DDD=$(echo $startdate | cut -c7-8)
+HHH=$(echo $startdate | cut -c9-10)
 
 while [ $((10#${fhr})) -le $((10#${lastfhr})) ]; do
+	# Formatted fhr for filenames
+	fhr=$(printf "%02i" ${fhr#0})
+	fhour=$(printf "%03i" ${fhr##0})
 
-# Formatted fhr for filenames
-fhr=`printf "%02i" ${fhr#0}`
-fhour=`printf "%03i" ${fhr##0}`
+	NEWDATE=$(date '+%Y%m%d%H' --date="$YYY$MMM$DDD $HHH $((10#${fhr})) hour")
 
-NEWDATE=`date '+%Y%m%d%H' --date="$YYY$MMM$DDD $HHH $((10#${fhr})) hour"`
+	YY=$(echo $NEWDATE | cut -c1-4)
+	MM=$(echo $NEWDATE | cut -c5-6)
+	DD=$(echo $NEWDATE | cut -c7-8)
+	HH=$(echo $NEWDATE | cut -c9-10)
+	iHH=$(echo $startdate | cut -c9-10)
 
-YY=`echo $NEWDATE | cut -c1-4`
-MM=`echo $NEWDATE | cut -c5-6`
-DD=`echo $NEWDATE | cut -c7-8`
-HH=`echo $NEWDATE | cut -c9-10`
-iHH=`echo $startdate | cut -c9-10`
+	echo 'NEWDATE' $NEWDATE
+	echo 'YY' $YY
 
-echo 'NEWDATE' $NEWDATE
-echo 'YY' $YY
+	# Create model file name (inFileName)
+	if [ ${model} == "GFS" ]; then
+		if [[ ${inFormat} == "binarynemsiompiio" ]]; then
+			inFileName=${modelDataPath}/atmf${fhour}.nemsio
+			flxFileName=${modelDataPath}/sfcf${fhour}.nemsio
+		elif [ ${inFormat} == "netcdf" ]; then
+			inFileName=${modelDataPath}/atmf${fhour}.nc
+			flxFileName=${modelDataPath}/sfcf${fhour}.nc
+		fi
+	elif [ ${model} == "LAM" ]; then
+		if [ ${inFormat} == "netcdf" ]; then
+			inFileName=${modelDataPath}/dynf${fhour}.nc
+			flxFileName=${modelDataPath}/dynf${fhour}.nc
+		fi
+	fi
 
-# Create model file name (inFileName)
-if [ ${model} == "GFS" ]; then
-   if [[ ${inFormat} == "binarynemsiompiio" ]]; then
-      inFileName=${modelDataPath}/atmf${fhour}.nemsio
-      flxFileName=${modelDataPath}/sfcf${fhour}.nemsio
-   elif [ ${inFormat} == "netcdf" ]; then
-      inFileName=${modelDataPath}/atmf${fhour}.nc
-      flxFileName=${modelDataPath}/sfcf${fhour}.nc
-   fi
-elif [ ${model} == "LAM" ]; then
-   if [ ${inFormat} == "netcdf" ]; then
-      inFileName=${modelDataPath}/dynf${fhour}.nc
-      flxFileName=${modelDataPath}/dynf${fhour}.nc
-   fi
-fi
+	# Check if the files exist
+	if [[ ! -e ${inFileName} ]]; then
+		echo "ERROR: Can't find 'inFileName': ${inFileName}. Directory or file does not exist.  Exiting..."
+		echo "ERROR: Check if 'modelDataPath': ${modelDataPath} exists."
+		exit 1
+	fi
 
-# Check if the files exist
-if [[ ! -e ${inFileName} ]]; then
-   echo "ERROR: Can't find 'inFileName': ${inFileName}. Directory or file does not exist.  Exiting..."
-   echo "ERROR: Check if 'modelDataPath': ${modelDataPath} exists."
-   exit 1
-fi
+	if [[ ! -e ${flxFileName} ]]; then
+		echo "ERROR: Can't find 'flxFileName': ${flxFileName}. Directory or file does not exist.  Exiting..."
+		echo "ERROR: Check if 'modelDataPath': ${modelDataPath} exists."
+		exit 1
+	fi
 
-if [[ ! -e ${flxFileName} ]]; then
-   echo "ERROR: Can't find 'flxFileName': ${flxFileName}. Directory or file does not exist.  Exiting..."
-   echo "ERROR: Check if 'modelDataPath': ${modelDataPath} exists."
-   exit 1
-fi
+	# Create itag based on user provided info. 
+	# Output format now set by user so if-block below uses this
+	# to generate the correct itag. 
 
-# Create itag based on user provided info. 
-# Output format now set by user so if-block below uses this
-# to generate the correct itag. 
+	if [[ ${outFormat} == "grib2" ]]; then
+		if [[ ${model} == "GFS" || ${model} == "LAM" ]]; then
+			cat > itag <<-EOF
+				&model_inputs
+				fileName='${inFileName}'
+				IOFORM='${inFormat}'
+				grib='${outFormat}'
+				DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
+				MODELNAME='${tag}'
+				fileNameFlux='${flxFileName}'
+				fileNameFlat='postxconfig-NT.txt'
+				/
+			EOF
+		fi
+	fi
 
-if [[ ${outFormat} == "grib2" ]]; then
-   if [[ ${model} == "GFS" || ${model} == "LAM" ]]; then
-cat > itag <<EOF
-&model_inputs
-fileName='${inFileName}'
-IOFORM='${inFormat}'
-grib='${outFormat}'
-DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
-MODELNAME='${tag}'
-fileNameFlux='${flxFileName}'
-fileNameFlat='postxconfig-NT.txt'
-/
-EOF
-   fi
-fi
+	#-----------------------------------------------------------------------
+	#   Run UPP.
+	#-----------------------------------------------------------------------
 
-#-----------------------------------------------------------------------
-#   Run UPP.
-#-----------------------------------------------------------------------
+	#----------------------------------------------------------------------
+	# There are two environment variables tmmark and COMSP
+	# RUN the upp.x executable. 
+	#----------------------------------------------------------------------
 
-#----------------------------------------------------------------------
-# There are two environment variables tmmark and COMSP
-# RUN the upp.x executable. 
-#----------------------------------------------------------------------
+	if [[ ${model} == "GFS" || ${model} == "LAM" ]]; then
+		${RUN_COMMAND} > upp.f${fhour}.out 2>&1
+	fi
 
-if [[ ${model} == "GFS" || ${model} == "LAM" ]]; then
-     ${RUN_COMMAND} > upp.f${fhour}.out 2>&1
-fi
+	# The prefixes are given in the postcntrl.xml file datset variable (GRIB2)
 
-# The prefixes are given in the postcntrl.xml file datset variable (GRIB2)
+	if [[ ${model} == "GFS" ]]; then
+		mv GFSPRS.GrbF${fhr} GFSPRS.${fhour}
+	elif [ ${model} == "LAM" ]; then
+		mv NATLEV${fhr}.tm00 NATLEV.${fhour}
+		mv PRSLEV${fhr}.tm00 PRSLEV.${fhour}
+	fi
 
-if [[ ${model} == "GFS" ]]; then
-   mv GFSPRS.GrbF${fhr} GFSPRS.${fhour}
-elif [ ${model} == "LAM" ]; then
-   mv NATLEV${fhr}.tm00 NATLEV.${fhour}
-   mv PRSLEV${fhr}.tm00 PRSLEV.${fhour}
-fi
+	#
+	#----------------------------------------------------------------------
+	#   End of upp job
+	#----------------------------------------------------------------------
 
-#
-#----------------------------------------------------------------------
-#   End of upp job
-#----------------------------------------------------------------------
+	# check to make sure UPP was successful
+	if [[ ${model} == "GFS" ]]; then
+		ls -l GFSPRS.${fhour}
+		err1=$?
+	elif [ ${model} == "LAM" ]; then
+		ls -l NATLEV.${fhour}
+		err1=$? 
+		ls -l PRSLEV.${fhour}
+		err2=$? 
+	fi
 
-# check to make sure UPP was successful
-if [[ ${model} == "GFS" ]]; then
-    ls -l GFSPRS.${fhour}
-    err1=$?
-elif [ ${model} == "LAM" ]; then
-    ls -l NATLEV.${fhour}
-    err1=$? 
-    ls -l PRSLEV.${fhour}
-    err2=$? 
-fi
+	if [[ ${err1} -ne 0 || ${err2} -ne 0 ]]; then
+		echo 'UPP FAILED, EXITTING'
+		exit
+	fi 
 
-if [[ ${err1} -ne 0 || ${err2} -ne 0 ]]; then
-    echo 'UPP FAILED, EXITTING'
-    exit
-fi 
+	fhr=$((10#${fhr}+$((${incrementhr}))))
 
-fhr=$((10#${fhr}+$((${incrementhr}))))
-
-NEWDATE=`date '+%Y%m%d%H' --date="$YYY$MMM$DDD $HHH $((10#${fhr})) hour"`
-
+	NEWDATE=$(date '+%Y%m%d%H' --date="$YYY$MMM$DDD $HHH $((10#${fhr})) hour")
 done
 
 date

--- a/ush/fv3gfs_downstream_nems.sh
+++ b/ush/fv3gfs_downstream_nems.sh
@@ -41,7 +41,7 @@ export COPYGB2=${COPYGB2:-${NWPROD:-/nwprod}/util/exec/copygb2}
 export WGRIB2=${WGRIB2:-${NWPROD:-/nwprod}/util/exec/wgrib2}
 export GRBINDEX=${GRBINDEX:-${NWPROD:-nwprod}/util/exec/grbindex}
 export RUN=${RUN:-"gfs"}
-export cycn=`echo $CDATE |cut -c 9-10`
+export cycn=$(echo $CDATE |cut -c 9-10)
 export TCYC=${TCYC:-".t${cycn}z."}
 export PREFIX=${PREFIX:-${RUN}${TCYC}}
 export PGB1F=${PGB1F:-"NO"}
@@ -80,11 +80,11 @@ elif [ $FH -eq 0 ] ; then
 else
   export paramlist=${paramlist:-$PARMpost/global_1x1_paramlist_g2}
   export paramlistb=${paramlistb:-$PARMpost/global_master-catchup_parmlist_g2}
-  export fhr3=`expr $FH + 0 `
+  export fhr3=$(expr $FH + 0)
   if [ $fhr3 -lt 100 ]; then export fhr3="0$fhr3"; fi
   if [ $fhr3 -lt 10 ];  then export fhr3="0$fhr3"; fi
   if [ $fhr3%${FHOUT_PGB} -eq 0 ]; then
-     export PGBS=YES
+    export PGBS=YES
   fi
 fi
 
@@ -93,257 +93,253 @@ $WGRIB2 $PGBOUT2 | grep -F -f $paramlist | $WGRIB2 -i -grib  tmpfile1_$fhr3 $PGB
 export err=$?; err_chk
 #if [ $machine = WCOSS -o $machine = WCOSS_C -a $downset = 2 ]; then
 if [ $downset = 2 ]; then
-   $WGRIB2 $PGBOUT2 | grep -F -f $paramlistb | $WGRIB2 -i -grib  tmpfile2_$fhr3 $PGBOUT2
-   export err=$?; err_chk
+  $WGRIB2 $PGBOUT2 | grep -F -f $paramlistb | $WGRIB2 -i -grib  tmpfile2_$fhr3 $PGBOUT2
+  export err=$?; err_chk
 fi
 
 #-----------------------------------------------------
 #-----------------------------------------------------
 if [ $machine = WCOSS -o $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 -o $machine = HERA -o $machine = ORION -o $machine = JET -o $machine = S4 -o $machine = WCOSS2 ]; then
-#-----------------------------------------------------
-#-----------------------------------------------------
-export nset=1
-export totalset=2
-if [ $downset = 1 ]; then totalset=1 ; fi
+  #-----------------------------------------------------
+  #-----------------------------------------------------
+  export nset=1
+  export totalset=2
+  if [ $downset = 1 ]; then totalset=1 ; fi
 
-#..............................................
-while [ $nset -le $totalset ]; do
-#..............................................
-  export tmpfile=$(eval echo tmpfile${nset}_${fhr3})
+  #..............................................
+  while [ $nset -le $totalset ]; do
+    #..............................................
+    export tmpfile=$(eval echo tmpfile${nset}_${fhr3})
 
-# split of Grib files to run downstream jobs using MPMD
-  export ncount=`$WGRIB2 $tmpfile |wc -l`
-# export tasks_post=$(eval echo \$tasksp_$nknd)
-  export nproc=${nproc:-${npe_dwn:-24}}
-  if [ $nproc -gt $ncount ]; then
-    echo " *** FATA ERROR: Total number of records in $tmpfile is not right"
-    export err=8
-    err_chk
-  fi
-  export inv=`expr $ncount / $nproc`
-  rm -f $DATA/poescript
-  export iproc=1
-  export end=0
-
-  while [ $iproc -le $nproc ] ; do
-    export start=`expr ${end} + 1`
-    export end=`expr ${start} + ${inv} - 1`
-    if [[ $end -ge $ncount ]] ;then
-      export end=$ncount
+    # split of Grib files to run downstream jobs using MPMD
+    export ncount=$($WGRIB2 $tmpfile |wc -l)
+    # export tasks_post=$(eval echo \$tasksp_$nknd)
+    export nproc=${nproc:-${npe_dwn:-24}}
+    if [ $nproc -gt $ncount ]; then
+      echo " *** FATA ERROR: Total number of records in $tmpfile is not right"
+      export err=8
+      err_chk
     fi
+    export inv=$(expr $ncount / $nproc)
+    rm -f $DATA/poescript
+    export iproc=1
+    export end=0
 
-    # if final record of each piece is ugrd, add vgrd
-    # copygb will only interpolate u and v together
-    #$WGRIB2 -d $end $tmpfile |grep -i ugrd
-    $WGRIB2 -d $end $tmpfile |egrep -i "ugrd|ustm|uflx|u-gwd"
-    export rc=$?
-    if [[ $rc -eq 0 ]] ; then
-      export end=`expr ${end} + 1`
-    fi
-    # if final record is land, add next record icec 
-    $WGRIB2 -d $end $tmpfile |egrep -i "land"
-    export rc=$?
-    if [[ $rc -eq 0 ]] ; then
-      export end=`expr ${end} + 1`
-    fi
-    if [ $iproc -eq $nproc ]; then
-      export end=$ncount
-    fi
+    while [ $iproc -le $nproc ] ; do
+      export start=$(expr ${end} + 1)
+      export end=$(expr ${start} + ${inv} - 1)
+      if [[ $end -ge $ncount ]] ;then
+        export end=$ncount
+      fi
 
-    $WGRIB2 $tmpfile -for ${start}:${end} -grib ${tmpfile}_${iproc}
-    export err=$?; err_chk
-    echo "${GFSDWNSH:-$USHgfs/fv3gfs_dwn_nems.sh} ${tmpfile}_${iproc} $fhr3 $iproc $nset" >> $DATA/poescript
+      # if final record of each piece is ugrd, add vgrd
+      # copygb will only interpolate u and v together
+      #$WGRIB2 -d $end $tmpfile |grep -i ugrd
+      $WGRIB2 -d $end $tmpfile |egrep -i "ugrd|ustm|uflx|u-gwd"
+      export rc=$?
+      if [[ $rc -eq 0 ]] ; then
+        export end=$(expr ${end} + 1)
+      fi
+      # if final record is land, add next record icec 
+      $WGRIB2 -d $end $tmpfile |egrep -i "land"
+      export rc=$?
+      if [[ $rc -eq 0 ]] ; then
+        export end=$(expr ${end} + 1)
+      fi
+      if [ $iproc -eq $nproc ]; then
+        export end=$ncount
+      fi
 
-    # if at final record and have not reached the final processor then write echo's to
-    # poescript for remaining processors
-    if [[ $end -eq $ncount ]] ;then
-      while [[ $iproc -lt $nproc ]];do
-        export iproc=`expr $iproc + 1`
-	echo "/bin/echo $iproc" >> $DATA/poescript
+      $WGRIB2 $tmpfile -for ${start}:${end} -grib ${tmpfile}_${iproc}
+      export err=$?; err_chk
+      echo "${GFSDWNSH:-$USHgfs/fv3gfs_dwn_nems.sh} ${tmpfile}_${iproc} $fhr3 $iproc $nset" >> $DATA/poescript
+
+      # if at final record and have not reached the final processor then write echo's to
+      # poescript for remaining processors
+      if [[ $end -eq $ncount ]] ;then
+        while [[ $iproc -lt $nproc ]];do
+          export iproc=$(expr $iproc + 1)
+          echo "/bin/echo $iproc" >> $DATA/poescript
+        done
+        break
+      fi
+      export iproc=$(expr $iproc + 1)
+    done
+
+    date
+    chmod 775 $DATA/poescript
+    export MP_PGMMODEL=mpmd
+    export MP_CMDFILE=$DATA/poescript
+    launcher=${APRUN_DWN:-"aprun -j 1 -n 24 -N 24 -d 1 cfp"}
+    if [ $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 -o $machine = WCOSS2 ] ; then
+      $launcher $MP_CMDFILE
+    elif [ $machine = HERA -o $machine = ORION -o $machine = JET -o $machine = S4 ] ; then
+      if [ -s $DATA/poescript_srun ]; then rm -f $DATA/poescript_srun; fi
+      touch $DATA/poescript_srun
+      nm=0
+      cat $DATA/poescript | while read line; do
+        echo "$nm  $line" >> $DATA/poescript_srun 
+        nm=$((nm+1))
       done
-      break
+      ${launcher:-"srun --export=ALL"}  -n $nm --multi-prog $DATA/poescript_srun
+    else
+      $launcher
     fi
-    export iproc=`expr $iproc + 1`
-  done
+    export err=$?
+    if [ $err -ne 0 ]; then sh +x $DATA/poescript ; fi
 
-date
-  chmod 775 $DATA/poescript
-  export MP_PGMMODEL=mpmd
-  export MP_CMDFILE=$DATA/poescript
-  launcher=${APRUN_DWN:-"aprun -j 1 -n 24 -N 24 -d 1 cfp"}
-  if [ $machine = WCOSS_C -o $machine = WCOSS_DELL_P3 -o $machine = WCOSS2 ] ; then
-     $launcher $MP_CMDFILE
-  elif [ $machine = HERA -o $machine = ORION -o $machine = JET -o $machine = S4 ] ; then
-     if [ -s $DATA/poescript_srun ]; then rm -f $DATA/poescript_srun; fi
-     touch $DATA/poescript_srun
-     nm=0
-     cat $DATA/poescript | while read line; do
-         echo "$nm  $line" >> $DATA/poescript_srun 
-         nm=$((nm+1))
-     done
-     ${launcher:-"srun --export=ALL"}  -n $nm --multi-prog $DATA/poescript_srun
-  else
-     $launcher
-  fi
-  export err=$?
-  if [ $err -ne 0 ]; then sh +x $DATA/poescript ; fi
+    date
+    export iproc=1
+    while [ $iproc -le $nproc ]; do
+      if [ $nset = 1 ]; then
+        cat pgb2file_${fhr3}_${iproc}_0p25 >> pgb2file_${fhr3}_0p25
+        if [ "$PGBS" = "YES" ]; then
+          cat pgb2file_${fhr3}_${iproc}_0p5  >> pgb2file_${fhr3}_0p5
+          cat pgb2file_${fhr3}_${iproc}_1p0  >> pgb2file_${fhr3}_1p0
+          if [ "$PGB1F" = 'YES' ]; then
+            cat pgbfile_${fhr3}_${iproc}_1p0   >> pgbfile_${fhr3}_1p0
+          fi
+        fi
+      elif [ $nset = 2 ]; then
+        cat pgb2bfile_${fhr3}_${iproc}_0p25 >> pgb2bfile_${fhr3}_0p25
+        if [ "$PGBS" = "YES" ]; then
+          cat pgb2bfile_${fhr3}_${iproc}_0p5 >> pgb2bfile_${fhr3}_0p5
+          cat pgb2bfile_${fhr3}_${iproc}_1p0 >> pgb2bfile_${fhr3}_1p0
+        fi
+      fi
+      export iproc=$(expr $iproc + 1)
+    done
+    date
 
-date
-  export iproc=1
-  while [ $iproc -le $nproc ]; do
+    #Chuang: generate second land mask using bi-linear interpolation and append to the end
+    #      if [ $nset = 1 ]; then
+    #      rm -f land.grb newland.grb newnewland.grb newnewland.grb1
+    #      $WGRIB2 $tmpfile -match "LAND:surface" -grib land.grb
+    ##0p25 degree
+    #      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid0p25 newland.grb
+    #      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
+    #      cat ./newnewland.grb >> pgb2file_${fhr3}_0p25
+    #      $CNVGRIB -g21 newnewland.grb newnewland.grb1 
+    #      cat ./newnewland.grb1 >> pgbfile_${fhr3}_0p25 
+    ##0p5 degree
+    #      rm -f newland.grb newnewland.grb newnewland.grb1
+    #      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid0p5 newland.grb
+    #      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
+    #      cat ./newnewland.grb >> pgb2file_${fhr3}_0p5
+    #1p0
+    #      rm -f newland.grb newnewland.grb newnewland.grb1
+    #      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid1p0 newland.grb
+    #      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
+    #      cat ./newnewland.grb >> pgb2file_${fhr3}_1p0
+    #      $CNVGRIB -g21 newnewland.grb newnewland.grb1
+    #      cat ./newnewland.grb1 >> pgbfile_${fhr3}_1p0
+    #      fi
+
     if [ $nset = 1 ]; then
-     cat pgb2file_${fhr3}_${iproc}_0p25 >> pgb2file_${fhr3}_0p25
-     if [ "$PGBS" = "YES" ]; then
-       cat pgb2file_${fhr3}_${iproc}_0p5  >> pgb2file_${fhr3}_0p5
-       cat pgb2file_${fhr3}_${iproc}_1p0  >> pgb2file_${fhr3}_1p0
-       if [ "$PGB1F" = 'YES' ]; then
-         cat pgbfile_${fhr3}_${iproc}_1p0   >> pgbfile_${fhr3}_1p0
-       fi
-     fi
+      if [ $fhr3 = anl ]; then
+        cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.anl
+        $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
+        if [ "$PGBS" = "YES" ]; then
+          cp pgb2file_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2.0p50.anl
+          cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.anl
+          $WGRIB2 -s pgb2file_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2.0p50.anl.idx
+          $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
+          if [ "$PGB1F" = 'YES' ]; then
+            cp pgbfile_${fhr3}_1p0    $COMOUT/${PREFIX}pgrb.1p00.anl
+            $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.anl $COMOUT/${PREFIX}pgrb.1p00.anl.idx
+          fi
+        fi
+      else
+        cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}
+        $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}.idx
+        if [ "$PGBS" = "YES" ]; then
+          cp pgb2file_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2.0p50.f${fhr3}
+          cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}
+          $WGRIB2 -s pgb2file_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2.0p50.f${fhr3}.idx
+          $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}.idx
+          if [ "$PGB1F" = 'YES' ]; then
+            cp pgbfile_${fhr3}_1p0    $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}
+            $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.f${fhr3} $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}.idx
+          fi
+        fi
+      fi
     elif [ $nset = 2 ]; then
-     cat pgb2bfile_${fhr3}_${iproc}_0p25 >> pgb2bfile_${fhr3}_0p25
-     if [ "$PGBS" = "YES" ]; then
-       cat pgb2bfile_${fhr3}_${iproc}_0p5 >> pgb2bfile_${fhr3}_0p5
-       cat pgb2bfile_${fhr3}_${iproc}_1p0 >> pgb2bfile_${fhr3}_1p0
-     fi
+      if [ $fhr3 = anl ]; then
+        cp pgb2bfile_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2b.0p25.anl
+        $WGRIB2 -s pgb2bfile_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2b.0p25.anl.idx
+        if [ "$PGBS" = "YES" ]; then
+          cp pgb2bfile_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2b.0p50.anl
+          cp pgb2bfile_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2b.1p00.anl
+          $WGRIB2 -s pgb2bfile_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2b.0p50.anl.idx
+          $WGRIB2 -s pgb2bfile_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2b.1p00.anl.idx
+        fi
+      else
+        cp pgb2bfile_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr3}
+        $WGRIB2 -s pgb2bfile_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr3}.idx
+        if [ "$PGBS" = "YES" ]; then
+          cp pgb2bfile_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr3}
+          cp pgb2bfile_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr3}
+          $WGRIB2 -s pgb2bfile_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr3}.idx
+          $WGRIB2 -s pgb2bfile_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr3}.idx
+        fi
+      fi
     fi
-    export iproc=`expr $iproc + 1`
+
+    #..............................................
+    export nset=$(expr $nset + 1 )
   done
-date
-
-#Chuang: generate second land mask using bi-linear interpolation and append to the end
-#      if [ $nset = 1 ]; then
-#      rm -f land.grb newland.grb newnewland.grb newnewland.grb1
-#      $WGRIB2 $tmpfile -match "LAND:surface" -grib land.grb
-##0p25 degree
-#      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid0p25 newland.grb
-#      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
-#      cat ./newnewland.grb >> pgb2file_${fhr3}_0p25
-#      $CNVGRIB -g21 newnewland.grb newnewland.grb1 
-#      cat ./newnewland.grb1 >> pgbfile_${fhr3}_0p25 
-##0p5 degree
-#      rm -f newland.grb newnewland.grb newnewland.grb1
-#      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid0p5 newland.grb
-#      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
-#      cat ./newnewland.grb >> pgb2file_${fhr3}_0p5
-#1p0
-#      rm -f newland.grb newnewland.grb newnewland.grb1
-#      $WGRIB2 land.grb -set_grib_type same -new_grid_interpolation bilinear -new_grid_winds earth -new_grid $grid1p0 newland.grb
-#      $WGRIB2 newland.grb -set_byte 4 11 218 -grib newnewland.grb
-#      cat ./newnewland.grb >> pgb2file_${fhr3}_1p0
-#      $CNVGRIB -g21 newnewland.grb newnewland.grb1
-#      cat ./newnewland.grb1 >> pgbfile_${fhr3}_1p0
-#      fi
+  #..............................................
 
 
-  if [ $nset = 1 ]; then
-   if [ $fhr3 = anl ]; then
-    cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.anl
-    $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
-    if [ "$PGBS" = "YES" ]; then
-      cp pgb2file_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2.0p50.anl
-      cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.anl
-      $WGRIB2 -s pgb2file_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2.0p50.anl.idx
-      $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
-      if [ "$PGB1F" = 'YES' ]; then
-        cp pgbfile_${fhr3}_1p0    $COMOUT/${PREFIX}pgrb.1p00.anl
-        $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.anl $COMOUT/${PREFIX}pgrb.1p00.anl.idx
-      fi
-    fi
-   else
-    cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}
-    $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}.idx
-    if [ "$PGBS" = "YES" ]; then
-      cp pgb2file_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2.0p50.f${fhr3}
-      cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}
-      $WGRIB2 -s pgb2file_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2.0p50.f${fhr3}.idx
-      $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}.idx
-      if [ "$PGB1F" = 'YES' ]; then
-        cp pgbfile_${fhr3}_1p0    $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}
-        $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.f${fhr3} $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}.idx
-      fi
-    fi
-   fi
-
-  elif [ $nset = 2 ]; then
-   
-   if [ $fhr3 = anl ]; then
-    cp pgb2bfile_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2b.0p25.anl
-    $WGRIB2 -s pgb2bfile_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2b.0p25.anl.idx
-    if [ "$PGBS" = "YES" ]; then
-      cp pgb2bfile_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2b.0p50.anl
-      cp pgb2bfile_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2b.1p00.anl
-      $WGRIB2 -s pgb2bfile_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2b.0p50.anl.idx
-      $WGRIB2 -s pgb2bfile_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2b.1p00.anl.idx
-    fi
-
-   else
-    cp pgb2bfile_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr3}
-    $WGRIB2 -s pgb2bfile_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2b.0p25.f${fhr3}.idx
-    if [ "$PGBS" = "YES" ]; then
-      cp pgb2bfile_${fhr3}_0p5   $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr3}
-      cp pgb2bfile_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr3}
-      $WGRIB2 -s pgb2bfile_${fhr3}_0p5  > $COMOUT/${PREFIX}pgrb2b.0p50.f${fhr3}.idx
-      $WGRIB2 -s pgb2bfile_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2b.1p00.f${fhr3}.idx
-    fi
-   fi
-  fi
-
-#..............................................
- export nset=`expr $nset + 1 `
- done
-#..............................................
-
-
-#---------------------------------------------------------------
-#---------------------------------------------------------------
-# R&D machine has no MPDP. Only generate 0.25 and 1 deg files
+  #---------------------------------------------------------------
+  #---------------------------------------------------------------
+  # R&D machine has no MPDP. Only generate 0.25 and 1 deg files
 else
-#---------------------------------------------------------------
-#---------------------------------------------------------------
+  #---------------------------------------------------------------
+  #---------------------------------------------------------------
   $WGRIB2 tmpfile1_$fhr3  $option1 $option21 $option22 $option23 $option24 \
-                          $option25 $option26 $option27 $option28 \
-                                           -new_grid $grid0p25 pgb2file_${fhr3}_0p25 \
-                                           -new_grid $grid0p5  pgb2file_${fhr3}_0p5 \
-                                           -new_grid $grid1p0  pgb2file_${fhr3}_1p0
+  $option25 $option26 $option27 $option28 \
+  -new_grid $grid0p25 pgb2file_${fhr3}_0p25 \
+  -new_grid $grid0p5  pgb2file_${fhr3}_0p5 \
+  -new_grid $grid1p0  pgb2file_${fhr3}_1p0
   export err=$?; err_chk
   #tweak sea ice cover
-  count=`$WGRIB2 pgb2file_${fhr3}_0p25 -match "LAND|ICEC" |wc -l`
+  count=$($WGRIB2 pgb2file_${fhr3}_0p25 -match "LAND|ICEC" |wc -l)
   if [ $count -eq 2 ]; then
     $MODICEC pgb2file_${fhr3}_0p25
     $MODICEC pgb2file_${fhr3}_1p0
   fi
 
-# convert 1 deg files back to Grib1 for verification
+  # convert 1 deg files back to Grib1 for verification
   if [ "$PGB1F" = 'YES' ]; then
     if [ $fhr3 = anl ]; then
-     $CNVGRIB -g21 pgb2file_${fhr3}_1p0  $COMOUT/${PREFIX}pgrb.1p00.anl
-     export err=$?; err_chk
-     $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.anl $COMOUT/${PREFIX}pgrb.1p00.anl.idx
+      $CNVGRIB -g21 pgb2file_${fhr3}_1p0  $COMOUT/${PREFIX}pgrb.1p00.anl
+      export err=$?; err_chk
+      $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.anl $COMOUT/${PREFIX}pgrb.1p00.anl.idx
     else
-     $CNVGRIB -g21 pgb2file_${fhr3}_1p0  $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}
-     export err=$?; err_chk
-     $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.f${fhr3} $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}.idx
+      $CNVGRIB -g21 pgb2file_${fhr3}_1p0  $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}
+      export err=$?; err_chk
+      $GRBINDEX $COMOUT/${PREFIX}pgrb.1p00.f${fhr3} $COMOUT/${PREFIX}pgrb.1p00.f${fhr3}.idx
     fi
   fi
 
-   if [ $fhr3 = anl ]; then
-     $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
-     cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.anl
-     if [ "$PGBS" = "YES" ]; then
-       $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
-       cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.anl
-     fi
-   else
-     $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}.idx
-     cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}
-     if [ "$PGBS" = "YES" ]; then
-       $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}.idx
-       cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}
-     fi
-   fi
+  if [ $fhr3 = anl ]; then
+    $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.anl.idx
+    cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.anl
+    if [ "$PGBS" = "YES" ]; then
+      $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.anl.idx
+      cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.anl
+    fi
+  else
+    $WGRIB2 -s pgb2file_${fhr3}_0p25 > $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}.idx
+    cp pgb2file_${fhr3}_0p25  $COMOUT/${PREFIX}pgrb2.0p25.f${fhr3}
+    if [ "$PGBS" = "YES" ]; then
+      $WGRIB2 -s pgb2file_${fhr3}_1p0  > $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}.idx
+      cp pgb2file_${fhr3}_1p0   $COMOUT/${PREFIX}pgrb2.1p00.f${fhr3}
+    fi
+  fi
 
-#---------------------------------------------------------------
+  #---------------------------------------------------------------
 fi
 echo "!!!!!!CREATION OF SELECT $RUN DOWNSTREAM PRODUCTS COMPLETED FOR FHR = $FH !!!!!!!"
 #---------------------------------------------------------------

--- a/ush/fv3gfs_dwn_nems.sh
+++ b/ush/fv3gfs_dwn_nems.sh
@@ -33,7 +33,7 @@ export opt26=' -set_grib_max_bits 25 -fi -if '
 export opt27=":(APCP|ACPCP|PRATE|CPRAT|DZDT):"
 export opt28=' -new_grid_interpolation budget -fi '
 if [ $machine = "S4" ]; then
-   export optncpu=' -ncpu 1 '
+  export optncpu=' -ncpu 1 '
 fi
 export grid0p25="latlon 0:1440:0.25 90:721:-0.25"
 export grid0p5="latlon 0:720:0.5 90:361:-0.5"
@@ -44,54 +44,54 @@ export PGB1F=${PGB1F:-"NO"}
 export PGBS=${PGBS:-"NO"}
 
 if [ $nset = 1 ]; then
- if [ "$PGBS" = "YES" ]; then
-   $WGRIB2 $optncpu $tmpfile $opt1 $opt21 $opt22 $opt23 $opt24 $opt25 $opt26 $opt27 $opt28 \
-                                      -new_grid $grid0p25 pgb2file_${fhr3}_${iproc}_0p25 \
-                                      -new_grid $grid1p0  pgb2file_${fhr3}_${iproc}_1p0  \
-                                      -new_grid $grid0p5  pgb2file_${fhr3}_${iproc}_0p5   
-   export err=$?; err_chk
-   $TRIMRH pgb2file_${fhr3}_${iproc}_0p25
-   $TRIMRH pgb2file_${fhr3}_${iproc}_0p5
-   $TRIMRH pgb2file_${fhr3}_${iproc}_1p0
-   #tweak sea ice cover 
-   count=`$WGRIB2 $optncpu pgb2file_${fhr3}_${iproc}_0p25 -match "LAND|ICEC" |wc -l`
-   if [ $count -eq 2 ]; then
-     $MODICEC pgb2file_${fhr3}_${iproc}_0p25
-     $MODICEC pgb2file_${fhr3}_${iproc}_0p5
-     $MODICEC pgb2file_${fhr3}_${iproc}_1p0
-   fi
-   #$CNVGRIB -g21 pgb2file_${fhr3}_${iproc}_0p25 pgbfile_${fhr3}_${iproc}_0p25          
-   if [ "$PGB1F" = 'YES' ]; then
-     $CNVGRIB -g21 pgb2file_${fhr3}_${iproc}_1p0 pgbfile_${fhr3}_${iproc}_1p0  
-     export err=$?; err_chk
-   fi
- else
-   $WGRIB2 $optncpu $tmpfile $opt1 $opt21 $opt22 $opt23 $opt24 $opt25 $opt26 $opt27 $opt28 \
-                     -new_grid $grid0p25 pgb2file_${fhr3}_${iproc}_0p25 
-   export err=$?; err_chk
-   $TRIMRH pgb2file_${fhr3}_${iproc}_0p25
-   #tweak sea ice cover
-   count=`$WGRIB2 $optncpu pgb2file_${fhr3}_${iproc}_0p25 -match "LAND|ICEC" |wc -l`
-   if [ $count -eq 2 ]; then
-     $MODICEC pgb2file_${fhr3}_${iproc}_0p25 
-   fi
- fi
+  if [ "$PGBS" = "YES" ]; then
+    $WGRIB2 $optncpu $tmpfile $opt1 $opt21 $opt22 $opt23 $opt24 $opt25 $opt26 $opt27 $opt28 \
+      -new_grid $grid0p25 pgb2file_${fhr3}_${iproc}_0p25 \
+      -new_grid $grid1p0  pgb2file_${fhr3}_${iproc}_1p0  \
+      -new_grid $grid0p5  pgb2file_${fhr3}_${iproc}_0p5   
+    export err=$?; err_chk
+    $TRIMRH pgb2file_${fhr3}_${iproc}_0p25
+    $TRIMRH pgb2file_${fhr3}_${iproc}_0p5
+    $TRIMRH pgb2file_${fhr3}_${iproc}_1p0
+    #tweak sea ice cover 
+    count=$($WGRIB2 $optncpu pgb2file_${fhr3}_${iproc}_0p25 -match "LAND|ICEC" |wc -l)
+    if [ $count -eq 2 ]; then
+      $MODICEC pgb2file_${fhr3}_${iproc}_0p25
+      $MODICEC pgb2file_${fhr3}_${iproc}_0p5
+      $MODICEC pgb2file_${fhr3}_${iproc}_1p0
+    fi
+    #$CNVGRIB -g21 pgb2file_${fhr3}_${iproc}_0p25 pgbfile_${fhr3}_${iproc}_0p25          
+    if [ "$PGB1F" = 'YES' ]; then
+      $CNVGRIB -g21 pgb2file_${fhr3}_${iproc}_1p0 pgbfile_${fhr3}_${iproc}_1p0  
+      export err=$?; err_chk
+    fi
+  else
+    $WGRIB2 $optncpu $tmpfile $opt1 $opt21 $opt22 $opt23 $opt24 $opt25 $opt26 $opt27 $opt28 \
+    -new_grid $grid0p25 pgb2file_${fhr3}_${iproc}_0p25 
+    export err=$?; err_chk
+    $TRIMRH pgb2file_${fhr3}_${iproc}_0p25
+    #tweak sea ice cover
+    count=$($WGRIB2 $optncpu pgb2file_${fhr3}_${iproc}_0p25 -match "LAND|ICEC" |wc -l)
+    if [ $count -eq 2 ]; then
+      $MODICEC pgb2file_${fhr3}_${iproc}_0p25 
+    fi
+  fi
 elif [ $nset = 2 ]; then
- if [ "$PGBS" = "YES" ]; then
-   $WGRIB2 $optncpu $tmpfile $opt1 $opt21 $opt22 $opt23 $opt24 $opt25 $opt26 $opt27 $opt28 \
-                                      -new_grid $grid0p25 pgb2bfile_${fhr3}_${iproc}_0p25 \
-                                      -new_grid $grid1p0  pgb2bfile_${fhr3}_${iproc}_1p0  \
-                                      -new_grid $grid0p5  pgb2bfile_${fhr3}_${iproc}_0p5  
-   export err=$?; err_chk
-   $TRIMRH pgb2bfile_${fhr3}_${iproc}_0p25
-   $TRIMRH pgb2bfile_${fhr3}_${iproc}_0p5
-   $TRIMRH pgb2bfile_${fhr3}_${iproc}_1p0
- else 
-   $WGRIB2 $optncpu $tmpfile $opt1 $opt21 $opt22 $opt23 $opt24 $opt25 $opt26 $opt27 $opt28 \
-            -new_grid $grid0p25 pgb2bfile_${fhr3}_${iproc}_0p25
-   export err=$?; err_chk
-   $TRIMRH pgb2bfile_${fhr3}_${iproc}_0p25
- fi
+  if [ "$PGBS" = "YES" ]; then
+    $WGRIB2 $optncpu $tmpfile $opt1 $opt21 $opt22 $opt23 $opt24 $opt25 $opt26 $opt27 $opt28 \
+      -new_grid $grid0p25 pgb2bfile_${fhr3}_${iproc}_0p25 \
+      -new_grid $grid1p0  pgb2bfile_${fhr3}_${iproc}_1p0  \
+      -new_grid $grid0p5  pgb2bfile_${fhr3}_${iproc}_0p5  
+    export err=$?; err_chk
+    $TRIMRH pgb2bfile_${fhr3}_${iproc}_0p25
+    $TRIMRH pgb2bfile_${fhr3}_${iproc}_0p5
+    $TRIMRH pgb2bfile_${fhr3}_${iproc}_1p0
+  else 
+    $WGRIB2 $optncpu $tmpfile $opt1 $opt21 $opt22 $opt23 $opt24 $opt25 $opt26 $opt27 $opt28 \
+    -new_grid $grid0p25 pgb2bfile_${fhr3}_${iproc}_0p25
+    export err=$?; err_chk
+    $TRIMRH pgb2bfile_${fhr3}_${iproc}_0p25
+  fi
 fi
 
 #----------------------------------------------------------------------------------------------

--- a/ush/gfs_nceppost.sh
+++ b/ush/gfs_nceppost.sh
@@ -188,10 +188,9 @@
 ################################################################################
 #  Set environment.
 export VERBOSE=${VERBOSE:-"NO"}
-if [[ "$VERBOSE" = "YES" ]]
-then
-   echo $(date) EXECUTING $0 $* >&2
-   set -x
+if [[ "$VERBOSE" = "YES" ]]; then
+	echo $(date) EXECUTING $0 $* >&2
+	set -x
 fi
 #  Command line arguments.
 export SIGINP=${1:-${SIGINP}}
@@ -253,10 +252,10 @@ export APRUN=${APRUNP:-${APRUN:-""}}
 
 # exit if NEMSINP does not exist
 if [ ${OUTTYP} -eq 4 ] ; then
- if [ ! -s $NEMSINP -o ! -s $FLXINP  ] ; then
-  echo "model files not found, exitting"
-  exit 111
- fi
+	if [ ! -s $NEMSINP -o ! -s $FLXINP  ] ; then
+		echo "model files not found, exitting"
+		exit 111
+	fi
 fi
 
 export SIGHDR=${SIGHDR:-$NWPROD/exec/global_sighdr} 
@@ -264,14 +263,14 @@ export IDRT=${IDRT:-4}
 
 # run post to read nemsio file if OUTTYP=4
 if [ ${OUTTYP} -eq 4 ] ; then
-  if [ ${OUTPUT_FILE} = "netcdf" ]; then
-    export MODEL_OUT_FORM=${MODEL_OUT_FORM:-netcdfpara}
-  elif [ ${OUTPUT_FILE} = "nemsio" ]; then
-    export MODEL_OUT_FORM=${MODEL_OUT_FORM:-binarynemsiompiio}
-  else
-    export MODEL_OUT_FORM=${MODEL_OUT_FORM:-binarynemsiompiio}
-  fi
- export GFSOUT=${NEMSINP}
+	if [ ${OUTPUT_FILE} = "netcdf" ]; then
+		export MODEL_OUT_FORM=${MODEL_OUT_FORM:-netcdfpara}
+	elif [ ${OUTPUT_FILE} = "nemsio" ]; then
+		export MODEL_OUT_FORM=${MODEL_OUT_FORM:-binarynemsiompiio}
+	else
+		export MODEL_OUT_FORM=${MODEL_OUT_FORM:-binarynemsiompiio}
+	fi
+	export GFSOUT=${NEMSINP}
 fi
 
 # allow threads to use threading in Jim's sp lib
@@ -279,12 +278,11 @@ fi
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 
 pwd=$(pwd)
-if [[ -d $DATA ]]
-then
-   mkdata=NO
+if [[ -d $DATA ]]; then
+	mkdata=NO
 else
-   mkdir -p $DATA
-   mkdata=YES
+	mkdir -p $DATA
+	mkdata=YES
 fi
 cd $DATA||exit 99
 ################################################################################
@@ -292,35 +290,34 @@ cd $DATA||exit 99
 export PGM=$POSTGPEXEC
 export pgm=$PGM
 $LOGSCRIPT
-cat <<EOF >postgp.inp.nml$$
- &NAMPGB
- $POSTGPVARS
+cat <<-EOF >postgp.inp.nml$$
+	&NAMPGB
+	$POSTGPVARS
 EOF
 
-cat <<EOF >>postgp.inp.nml$$
-/
+cat <<-EOF >>postgp.inp.nml$$
+	/
 EOF
 
-if [[ "$VERBOSE" = "YES" ]]
-then
-   cat postgp.inp.nml$$
+if [[ "$VERBOSE" = "YES" ]]; then
+	cat postgp.inp.nml$$
 fi
 
 # making the time stamp format for ncep post
-export YY=`echo $VDATE | cut -c1-4`
-export MM=`echo $VDATE | cut -c5-6`
-export DD=`echo $VDATE | cut -c7-8`
-export HH=`echo $VDATE | cut -c9-10`
+export YY=$(echo $VDATE | cut -c1-4)
+export MM=$(echo $VDATE | cut -c5-6)
+export DD=$(echo $VDATE | cut -c7-8)
+export HH=$(echo $VDATE | cut -c9-10)
 
-cat > itag <<EOF
-&model_inputs
-fileName='${GFSOUT}'
-IOFORM='${MODEL_OUT_FORM}'
-grib='${GRIBVERSION}'
-DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
-MODELNAME='GFS'
-fileNameFlux='${FLXINP}'
-/
+cat > itag <<-EOF
+	&model_inputs
+	fileName='${GFSOUT}'
+	IOFORM='${MODEL_OUT_FORM}'
+	grib='${GRIBVERSION}'
+	DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
+	MODELNAME='GFS'
+	fileNameFlux='${FLXINP}'
+	/
 EOF
 
 cat postgp.inp.nml$$ >> itag
@@ -335,15 +332,14 @@ rm -f fort.*
 
 # change model generating Grib number 
 if [ ${GRIBVERSION} = grib2 ]; then
-  cp ${POSTGRB2TBL} .
-  cp ${PostFlatFile} ./postxconfig-NT.txt
-  if [ ${ens} = "YES" ] ; then
-    sed < ${PostFlatFile} -e "s#negatively_pert_fcst#${ens_pert_type}#" > ./postxconfig-NT.txt
-  fi
-#  cp ${CTLFILE} postcntrl.xml
-
+	cp ${POSTGRB2TBL} .
+	cp ${PostFlatFile} ./postxconfig-NT.txt
+	if [ ${ens} = "YES" ] ; then
+		sed < ${PostFlatFile} -e "s#negatively_pert_fcst#${ens_pert_type}#" > ./postxconfig-NT.txt
+	fi
+	#  cp ${CTLFILE} postcntrl.xml
 fi
-export CTL=`basename $CTLFILE`
+export CTL=$(basename $CTLFILE)
 
 ln -sf griddef.out fort.110
 cp ${PARMpost}/nam_micro_lookup.dat ./eta_micro_lookup.dat
@@ -355,70 +351,70 @@ export ERR=$?
 export err=$ERR
 
 if [ $err -ne 0 ] ; then
-    if [ $PGBOUT = "wafsfile" ] ; then
-        exit $err
-    fi
+	if [ $PGBOUT = "wafsfile" ] ; then
+		exit $err
+	fi
 fi
 $ERRSCRIPT||exit 2
 
 if [ $FILTER = "1" ] ; then
+	# Filter SLP and 500 mb height using copygb, change GRIB ID, and then
+	# cat the filtered fields to the pressure GRIB file, from Iredell
 
-# Filter SLP and 500 mb height using copygb, change GRIB ID, and then
-# cat the filtered fields to the pressure GRIB file, from Iredell
+	if [ $GRIBVERSION = grib2 ]; then
+		if [ ${ens} = YES ] ; then
+			$COPYGB2 -x -i'4,0,80' -k'1 3 0 7*-9999 101 0 0' $PGBOUT tfile
+			export err=$?; err_chk
+		else
+			$COPYGB2 -x -i'4,0,80' -k'0 3 0 7*-9999 101 0 0' $PGBOUT tfile
+			export err=$?; err_chk
+		fi
+		$WGRIB2 tfile -set_byte 4 11 1 -grib prmsl
+		export err=$?; err_chk
+		if [ ${ens} = YES ] ; then
+			$COPYGB2 -x -i'4,1,5' -k'1 3 5 7*-9999 100 0 50000' $PGBOUT tfile
+			export err=$?; err_chk
+		else
+			$COPYGB2 -x -i'4,1,5' -k'0 3 5 7*-9999 100 0 50000' $PGBOUT tfile
+			export err=$?; err_chk
+		fi
+		$WGRIB2 tfile -set_byte 4 11 193 -grib h5wav
+		export err=$?; err_chk
 
-if [ $GRIBVERSION = grib2 ]; then
-  if [ ${ens} = YES ] ; then
-    $COPYGB2 -x -i'4,0,80' -k'1 3 0 7*-9999 101 0 0' $PGBOUT tfile
-    export err=$?; err_chk
-  else
-    $COPYGB2 -x -i'4,0,80' -k'0 3 0 7*-9999 101 0 0' $PGBOUT tfile
-    export err=$?; err_chk
-  fi
-  $WGRIB2 tfile -set_byte 4 11 1 -grib prmsl
-  export err=$?; err_chk
-  if [ ${ens} = YES ] ; then
-    $COPYGB2 -x -i'4,1,5' -k'1 3 5 7*-9999 100 0 50000' $PGBOUT tfile
-    export err=$?; err_chk
-  else
-    $COPYGB2 -x -i'4,1,5' -k'0 3 5 7*-9999 100 0 50000' $PGBOUT tfile
-    export err=$?; err_chk
-  fi
-  $WGRIB2 tfile -set_byte 4 11 193 -grib h5wav
-  export err=$?; err_chk
-
-#cat $PGBOUT prmsl h5wav >> $PGBOUT
-#wm
-#  cat  prmsl h5wav >> $PGBOUT
-[[ -f prmsl ]] && rm prmsl ; [[ -f h5wav ]] && rm h5wav ; [[ -f tfile ]] && rm tfile  
-
-fi
-
+		#cat $PGBOUT prmsl h5wav >> $PGBOUT
+		#wm
+		#  cat  prmsl h5wav >> $PGBOUT
+		[[ -f prmsl ]] && rm prmsl
+		[[ -f h5wav ]] && rm h5wav
+		[[ -f tfile ]] && rm tfile
+	fi
 fi
 
 ################################################################################
 #  Make GRIB index file
-if [[ -n $PGIOUT ]]
-then
-   if [ $GRIBVERSION = grib2 ]; then
-     # JY $GRBINDEX2 $PGBOUT $PGIOUT
-     $GRB2INDEX $PGBOUT $PGIOUT
-   fi
+if [[ -n $PGIOUT ]]; then
+	if [ $GRIBVERSION = grib2 ]; then
+		# JY $GRBINDEX2 $PGBOUT $PGIOUT
+		$GRB2INDEX $PGBOUT $PGIOUT
+	fi
 fi
-if [[ -r $FLXINP && -n $FLXIOUT && $OUTTYP -le 3 ]]
-then
-   $GRBINDEX $FLXINP $FLXIOUT
+if [[ -r $FLXINP && -n $FLXIOUT && $OUTTYP -le 3 ]]; then
+	$GRBINDEX $FLXINP $FLXIOUT
 fi
 ################################################################################
 # generate psi and chi
 echo "GENPSICHI= " $GENPSICHI
 if [ $GENPSICHI = YES ] ; then
-#echo "PGBOUT PGIOUT=" $PGBOUT $PGIOUT
-#echo "YY MM=" $YY $MM
- export psichifile=./psichi.grb
- $GENPSICHIEXE < postgp.inp.nml$$
- rc=$?
- if [[ $rc -ne 0 ]] ; then echo 'Nonzero return code rc= '$rc ; exit 3 ; fi
- cat ./psichi.grb >> $PGBOUT
+	#echo "PGBOUT PGIOUT=" $PGBOUT $PGIOUT
+	#echo "YY MM=" $YY $MM
+	export psichifile=./psichi.grb
+	$GENPSICHIEXE < postgp.inp.nml$$
+	rc=$?
+	if [[ $rc -ne 0 ]] ; then
+		echo 'Nonzero return code rc= '$rc
+		exit 3
+	fi
+	cat ./psichi.grb >> $PGBOUT
 fi
 ################################################################################
 #  Postprocessing
@@ -426,8 +422,7 @@ cd $pwd
 [[ $mkdata = YES ]]&&rmdir $DATA
 $ENDSCRIPT
 set +x
-if [[ "$VERBOSE" = "YES" ]]
-then
-   echo $(date) EXITING $0 with return code $err >&2
+if [[ "$VERBOSE" = "YES" ]]; then
+	echo $(date) EXITING $0 with return code $err >&2
 fi
 exit $err

--- a/ush/gfs_transfer.sh
+++ b/ush/gfs_transfer.sh
@@ -43,7 +43,7 @@ set -xa
 # Convert the sflux file to grib2 format:
 ############################################
 #cp $COMIN/${RUN}.${cycle}.sfluxgrbf$fhr sfluxgrbf$fhr
-#if [ `expr $fhr % 3` -eq 0 ]; then
+#if [ $(expr $fhr % 3) -eq 0 ]; then
 #$CNVGRIB -g12 -p40 $COMIN/${RUN}.${cycle}.sfluxgrbf$fhr sfluxgrbf${fhr}.grib2
 #$WGRIB2 sfluxgrbf${fhr}.grib2 -s> sfluxgrbf${fhr}.grib2.idx
 
@@ -58,25 +58,21 @@ set -xa
 # DBNet Alerts for gfs suite
 #
 
-if test "$SENDDBN" = 'YES' -a "$RUN" = 'gfs' 
-then
-  #if [ `expr $fhr % 3` -eq 0 ]; then
+if [ "$SENDDBN" = 'YES' -a "$RUN" = 'gfs' ]; then
+  #if [ $(expr $fhr % 3) -eq 0 ]; then
   #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGB $job $COMOUT/${RUN}.${cycle}.sfluxgrbf$fhr
   #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGBI $job $COMOUT/${RUN}.${cycle}.sfluxgrbif$fhr
   #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2 $job $COMOUT/${RUN}.${cycle}.sfluxgrbf${fhr}.grib2
   #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2_WIDX $job $COMOUT/${RUN}.${cycle}.sfluxgrbf${fhr}.grib2.idx
   #fi
 
-  fhr=`printf "%03d" $fhr`
+  fhr=$(printf "%03d" $fhr)
   $DBNROOT/bin/dbn_alert MODEL GFS_SF $job $COMOUT/${RUN}.t${cyc}z.atmf$fhr.nc
-
  
-  if [[ $fhr -gt 0  && $fhr -le 84  ]]
-  then
+  if [[ $fhr -gt 0  && $fhr -le 84  ]]; then
      $DBNROOT/bin/dbn_alert MODEL GFS_BF $job $COMOUT/${RUN}.t${cyc}z.sfcf$fhr.nc
   fi
-  if [[ $fhr -eq 120  ]]
-  then
+  if [[ $fhr -eq 120  ]]; then
      $DBNROOT/bin/dbn_alert MODEL GFS_BF $job $COMOUT/${RUN}.t${cyc}z.sfcf$fhr.nc
   fi
 fi

--- a/ush/global_nceppost.sh
+++ b/ush/global_nceppost.sh
@@ -184,10 +184,9 @@
 ################################################################################
 #  Set environment.
 export VERBOSE=${VERBOSE:-"NO"}
-if [[ "$VERBOSE" = "YES" ]]
-then
-   echo $(date) EXECUTING $0 $* >&2
-   set -x
+if [[ "$VERBOSE" = "YES" ]]; then
+	echo $(date) EXECUTING $0 $* >&2
+	set -x
 fi
 #  Command line arguments.
 export SIGINP=${1:-${SIGINP}}
@@ -250,66 +249,65 @@ export APRUN=${APRUNP:-${APRUN:-""}}
 
 # exit if SIGINP does not exist
 if [ ${OUTTYP} -le 3 ] ; then
- if [ ! -s $SIGINP ] ; then
-  echo "sigma file not found, exitting"
-  exit 111
- fi
+	if [ ! -s $SIGINP ] ; then
+		echo "sigma file not found, exitting"
+		exit 111
+	fi
 fi
 
 export SIGHDR=${SIGHDR:-$NWPROD/exec/global_sighdr} 
 export IDRT=${IDRT:-4}
 
 if [ ${OUTTYP} -le 1 ] ; then
- export JCAP=${JCAP:-`echo jcap|$SIGHDR ${SIGINP}`}
- export LEVS=${LEVS:-`echo levs|$SIGHDR ${SIGINP}`}
- export IDVC=${IDVC:-$(echo idvc|$SIGHDR ${SIGINP})}
- export IDVM=${IDVM:-$(echo idvm|$SIGHDR ${SIGINP})}
- export NVCOORD=${NVCOORD:-$(echo nvcoord|$SIGHDR ${SIGINP})}
- export IVSSIG=${IVSSIG:-$(echo ivs|$SIGHDR ${SIGINP})}
- export LATCH=${LATCH:-8}
- if [ ${OUTTYP} -eq 1 ] ; then 
-  export CHGRESVARS="IDVC=$IDVC,IDVM=$IDVM,NVCOORD=$NVCOORD,IVSSIG=$IVSSIG,LATCH=$LATCH,"  
- elif [ ${OUTTYP} -eq 0 ] ; then
-  export CHGRESVARS="LATCH=$LATCH,$CHGRESVARS"
- fi 
- #export SIGLEVEL=${SIGLEVEL:-""}
- export SIGLEVEL=${SIGLEVEL:-"$NWPROD/fix/global_hyblev.l${LEVS}.txt"}
- # specify threads for running chgres
- export OMP_NUM_THREADS=$CHGRESTHREAD 
- export NTHREADS=$OMP_NUM_THREADS
- if [ ${JCAP} -eq 574 -a ${IDRT} -eq 4 ]
- then
-    export NTHSTACK=1024000000
- fi   
- export XLSMPOPTS="parthds=$NTHREADS:stack=$NTHSTACK"
+	export JCAP=${JCAP:-$(echo jcap|$SIGHDR ${SIGINP})}
+	export LEVS=${LEVS:-$(echo levs|$SIGHDR ${SIGINP})}
+	export IDVC=${IDVC:-$(echo idvc|$SIGHDR ${SIGINP})}
+	export IDVM=${IDVM:-$(echo idvm|$SIGHDR ${SIGINP})}
+	export NVCOORD=${NVCOORD:-$(echo nvcoord|$SIGHDR ${SIGINP})}
+	export IVSSIG=${IVSSIG:-$(echo ivs|$SIGHDR ${SIGINP})}
+	export LATCH=${LATCH:-8}
+	if [ ${OUTTYP} -eq 1 ] ; then 
+		export CHGRESVARS="IDVC=$IDVC,IDVM=$IDVM,NVCOORD=$NVCOORD,IVSSIG=$IVSSIG,LATCH=$LATCH,"  
+	elif [ ${OUTTYP} -eq 0 ] ; then
+		export CHGRESVARS="LATCH=$LATCH,$CHGRESVARS"
+	fi 
+	#export SIGLEVEL=${SIGLEVEL:-""}
+	export SIGLEVEL=${SIGLEVEL:-"$NWPROD/fix/global_hyblev.l${LEVS}.txt"}
+	# specify threads for running chgres
+	export OMP_NUM_THREADS=$CHGRESTHREAD 
+	export NTHREADS=$OMP_NUM_THREADS
+	if [ ${JCAP} -eq 574 -a ${IDRT} -eq 4 ]; then
+		export NTHSTACK=1024000000
+	fi   
+	export XLSMPOPTS="parthds=$NTHREADS:stack=$NTHSTACK"
 
- $CHGRESSH
+	$CHGRESSH
 
- export ERR=$?
- export err=$ERR
- $ERRSCRIPT||exit 1
- 
+	export ERR=$?
+	export err=$ERR
+	$ERRSCRIPT||exit 1
+
 # run post to read sigma file directly if OUTTYP=3
 elif [ ${OUTTYP} -eq 3 ] ; then
- export LONB=${LONB:-`echo lonb|$SIGHDR ${SIGINP}`}
- export LATB=${LATB:-`echo latb|$SIGHDR ${SIGINP}`}
- export MODEL_OUT_FORM=sigio
- export GFSOUT=${SIGINP}
+	export LONB=${LONB:-$(echo lonb|$SIGHDR ${SIGINP})}
+	export LATB=${LATB:-$(echo latb|$SIGHDR ${SIGINP})}
+	export MODEL_OUT_FORM=sigio
+	export GFSOUT=${SIGINP}
 
 # run post to read nemsio file if OUTTYP=4
 elif [ ${OUTTYP} -eq 4 ] ; then
- export nemsioget=${nemsioget:-$EXECglobal/nemsio_get}
- export LONB=${LONB:-$($nemsioget $NEMSINP dimx | awk '{print $2}')}
- export LATB=${LATB:-$($nemsioget $NEMSINP dimy | awk '{print $2}')}
- export JCAP=${JCAP:-`expr $LATB - 2`}
-# export LONB=${LONB:-$($nemsioget $NEMSINP lonf |grep -i "lonf" |awk -F"= " '{print $2}' |awk -F" " '{print $1}')}
-# export LATB=${LATB:-$($nemsioget $NEMSINP latg |grep -i "latg" |awk -F"= " '{print $2}' |awk -F" " '{print $1}')}
-# export JCAP=${JCAP:-$($nemsioget $NEMSINP jcap |grep -i "jcap" |awk -F"= " '{print $2}' |awk -F" " '{print $1}')}
+	export nemsioget=${nemsioget:-$EXECglobal/nemsio_get}
+	export LONB=${LONB:-$($nemsioget $NEMSINP dimx | awk '{print $2}')}
+	export LATB=${LATB:-$($nemsioget $NEMSINP dimy | awk '{print $2}')}
+	export JCAP=${JCAP:-$(expr $LATB - 2)}
+	# export LONB=${LONB:-$($nemsioget $NEMSINP lonf |grep -i "lonf" |awk -F"= " '{print $2}' |awk -F" " '{print $1}')}
+	# export LATB=${LATB:-$($nemsioget $NEMSINP latg |grep -i "latg" |awk -F"= " '{print $2}' |awk -F" " '{print $1}')}
+	# export JCAP=${JCAP:-$($nemsioget $NEMSINP jcap |grep -i "jcap" |awk -F"= " '{print $2}' |awk -F" " '{print $1}')}
 
- export MODEL_OUT_FORM=${MODEL_OUT_FORM:-binarynemsiompiio}
- export GFSOUT=${NEMSINP}
- ln -sf $FIXglobal/fix_am/global_lonsperlat.t${JCAP}.${LONB}.${LATB}.txt  ./lonsperlat.dat 
- ln -sf $FIXglobal/fix_am/global_hyblev.l${LEVS}.txt                      ./global_hyblev.txt
+	export MODEL_OUT_FORM=${MODEL_OUT_FORM:-binarynemsiompiio}
+	export GFSOUT=${NEMSINP}
+	ln -sf $FIXglobal/fix_am/global_lonsperlat.t${JCAP}.${LONB}.${LATB}.txt  ./lonsperlat.dat 
+	ln -sf $FIXglobal/fix_am/global_hyblev.l${LEVS}.txt                      ./global_hyblev.txt
 fi
 
 # allow threads to use threading in Jim's sp lib
@@ -317,12 +315,11 @@ fi
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 
 pwd=$(pwd)
-if [[ -d $DATA ]]
-then
-   mkdata=NO
+if [[ -d $DATA ]]; then
+	mkdata=NO
 else
-   mkdir -p $DATA
-   mkdata=YES
+	mkdir -p $DATA
+	mkdata=YES
 fi
 cd $DATA||exit 99
 ################################################################################
@@ -330,33 +327,33 @@ cd $DATA||exit 99
 export PGM=$POSTGPEXEC
 export pgm=$PGM
 $LOGSCRIPT
-cat <<EOF >postgp.inp.nml$$
- &NAMPGB
- $POSTGPVARS
+cat <<-EOF >postgp.inp.nml$$
+	&NAMPGB
+	$POSTGPVARS
 EOF
 
-cat <<EOF >>postgp.inp.nml$$
- /
+cat <<-EOF >>postgp.inp.nml$$
+	/
 EOF
-if [[ "$VERBOSE" = "YES" ]]
-then
-   cat postgp.inp.nml$$
+
+if [[ "$VERBOSE" = "YES" ]]; then
+	cat postgp.inp.nml$$
 fi
 
 # making the time stamp format for ncep post
-export YY=`echo $VDATE | cut -c1-4`
-export MM=`echo $VDATE | cut -c5-6`
-export DD=`echo $VDATE | cut -c7-8`
-export HH=`echo $VDATE | cut -c9-10`
+export YY=$(echo $VDATE | cut -c1-4)
+export MM=$(echo $VDATE | cut -c5-6)
+export DD=$(echo $VDATE | cut -c7-8)
+export HH=$(echo $VDATE | cut -c9-10)
 
-cat > itag <<EOF
-$GFSOUT
-${MODEL_OUT_FORM}
-${GRIBVERSION}
-${YY}-${MM}-${DD}_${HH}:00:00
-GFS
-$FLXINP
-$D3DINP
+cat > itag <<-EOF
+	$GFSOUT
+	${MODEL_OUT_FORM}
+	${GRIBVERSION}
+	${YY}-${MM}-${DD}_${HH}:00:00
+	GFS
+	$FLXINP
+	$D3DINP
 EOF
 
 cat postgp.inp.nml$$ >> itag
@@ -371,28 +368,25 @@ rm -f fort.*
 
 # change model generating Grib number 
 if [ ${GRIBVERSION} = grib1 ]; then
-
-  if [ ${IGEN} -le 9 ] ; then
-   cat ${CTLFILE}|sed s:00082:0000${IGEN}:>./gfs_cntrl.parm
-  elif [ ${IGEN} -le 99 ] ; then
-   cat ${CTLFILE}|sed s:00082:000${IGEN}:>./gfs_cntrl.parm
-  elif [ ${IGEN} -le 999 ] ; then
-   cat ${CTLFILE}|sed s:00082:00${IGEN}:>./gfs_cntrl.parm
-  else
-   ln -sf ${CTLFILE} ./gfs_cntrl.parm
-  fi
-  ln -sf ./gfs_cntrl.parm fort.14
-
+	if [ ${IGEN} -le 9 ] ; then
+		cat ${CTLFILE}|sed s:00082:0000${IGEN}:>./gfs_cntrl.parm
+	elif [ ${IGEN} -le 99 ] ; then
+		cat ${CTLFILE}|sed s:00082:000${IGEN}:>./gfs_cntrl.parm
+	elif [ ${IGEN} -le 999 ] ; then
+		cat ${CTLFILE}|sed s:00082:00${IGEN}:>./gfs_cntrl.parm
+	else
+		ln -sf ${CTLFILE} ./gfs_cntrl.parm
+	fi
+	ln -sf ./gfs_cntrl.parm fort.14
 elif [ ${GRIBVERSION} = grib2 ]; then
-  cp ${POSTGRB2TBL} .
-  cp ${PostFlatFile} ./postxconfig-NT.txt
-  if [ ${ens} = "YES" ] ; then
-    sed < ${PostFlatFile} -e "s#negatively_pert_fcst#${ens_pert_type}#" > ./postxconfig-NT.txt
-  fi
-#  cp ${CTLFILE} postcntrl.xml
-
+	cp ${POSTGRB2TBL} .
+	cp ${PostFlatFile} ./postxconfig-NT.txt
+	if [ ${ens} = "YES" ] ; then
+		sed < ${PostFlatFile} -e "s#negatively_pert_fcst#${ens_pert_type}#" > ./postxconfig-NT.txt
+	fi
+	#  cp ${CTLFILE} postcntrl.xml
 fi
-export CTL=`basename $CTLFILE`
+export CTL=$(basename $CTLFILE)
 
 ln -sf griddef.out fort.110
 cp ${PARMglobal}/nam_micro_lookup.dat ./eta_micro_lookup.dat
@@ -404,93 +398,87 @@ export err=$ERR
 $ERRSCRIPT||exit 2
 
 if [ $FILTER = "1" ] ; then
+	# Filter SLP and 500 mb height using copygb, change GRIB ID, and then
+	# cat the filtered fields to the pressure GRIB file, from Iredell
 
-# Filter SLP and 500 mb height using copygb, change GRIB ID, and then
-# cat the filtered fields to the pressure GRIB file, from Iredell
+	if [ $GRIBVERSION = grib1 ]; then
+		$COPYGB -x -i'4,0,80' -k'4*-1,1,102' $PGBOUT tfile
+		ln -s -f tfile fort.11
+		ln -s -f prmsl fort.51
+		echo 0 2|$OVERPARMEXEC
+		$COPYGB -x -i'4,1,5' -k'4*-1,7,100,500' $PGBOUT tfile
+		ln -s -f tfile fort.11
+		ln -s -f h5wav fort.51
+		echo 0 222|$OVERPARMEXEC
 
-if [ $GRIBVERSION = grib1 ]; then
-  $COPYGB -x -i'4,0,80' -k'4*-1,1,102' $PGBOUT tfile
-  ln -s -f tfile fort.11
-  ln -s -f prmsl fort.51
-  echo 0 2|$OVERPARMEXEC
-  $COPYGB -x -i'4,1,5' -k'4*-1,7,100,500' $PGBOUT tfile
-  ln -s -f tfile fort.11
-  ln -s -f h5wav fort.51
-  echo 0 222|$OVERPARMEXEC
+		#cat $PGBOUT prmsl h5wav >> $PGBOUT
+		cat  prmsl h5wav >> $PGBOUT
+	elif [ $GRIBVERSION = grib2 ]; then
+		if [ ${ens} = YES ] ; then
+			$COPYGB2 -x -i'4,0,80' -k'1 3 0 7*-9999 101 0 0' $PGBOUT tfile
+		else
+			$COPYGB2 -x -i'4,0,80' -k'0 3 0 7*-9999 101 0 0' $PGBOUT tfile
+		fi
+		$WGRIB2 tfile -set_byte 4 11 1 -grib prmsl
+		if [ ${ens} = YES ] ; then
+			$COPYGB2 -x -i'4,1,5' -k'1 3 5 7*-9999 100 0 50000' $PGBOUT tfile
+		else
+			$COPYGB2 -x -i'4,1,5' -k'0 3 5 7*-9999 100 0 50000' $PGBOUT tfile
+		fi
+		$WGRIB2 tfile -set_byte 4 11 193 -grib h5wav
 
-#cat $PGBOUT prmsl h5wav >> $PGBOUT
-  cat  prmsl h5wav >> $PGBOUT
+		#cat $PGBOUT prmsl h5wav >> $PGBOUT
 
-elif [ $GRIBVERSION = grib2 ]; then
-  if [ ${ens} = YES ] ; then
-    $COPYGB2 -x -i'4,0,80' -k'1 3 0 7*-9999 101 0 0' $PGBOUT tfile
-  else
-    $COPYGB2 -x -i'4,0,80' -k'0 3 0 7*-9999 101 0 0' $PGBOUT tfile
-  fi
-  $WGRIB2 tfile -set_byte 4 11 1 -grib prmsl
-  if [ ${ens} = YES ] ; then
-    $COPYGB2 -x -i'4,1,5' -k'1 3 5 7*-9999 100 0 50000' $PGBOUT tfile
-  else
-    $COPYGB2 -x -i'4,1,5' -k'0 3 5 7*-9999 100 0 50000' $PGBOUT tfile
-  fi
-  $WGRIB2 tfile -set_byte 4 11 193 -grib h5wav
-
-#cat $PGBOUT prmsl h5wav >> $PGBOUT
-
-  cat  prmsl h5wav >> $PGBOUT
-
-fi
-
+		cat  prmsl h5wav >> $PGBOUT
+	fi
 fi
 
 ################################################################################
 #  Anomaly concatenation
 #  for now just do anomaly concentration for grib1
 if [ $GRIBVERSION = grib1 ]; then
+	if [[ -x $ANOMCATSH ]]; then
+		if [[ -n $PGIOUT ]]; then
+			$GRBINDEX $PGBOUT $PGIOUT
+		fi
+		export PGM=$ANOMCATSH
+		export pgm=$PGM
+		$LOGSCRIPT
 
- if [[ -x $ANOMCATSH ]]
- then
-   if [[ -n $PGIOUT ]]
-   then
-     $GRBINDEX $PGBOUT $PGIOUT
-   fi
-   export PGM=$ANOMCATSH
-   export pgm=$PGM
-   $LOGSCRIPT
+		eval $ANOMCATSH $PGBOUT $PGIOUT
 
-   eval $ANOMCATSH $PGBOUT $PGIOUT
-
-   export ERR=$?
-   export err=$ERR
-   $ERRSCRIPT||exit 3
- fi
+		export ERR=$?
+		export err=$ERR
+		$ERRSCRIPT||exit 3
+	fi
 fi
 ################################################################################
 #  Make GRIB index file
-if [[ -n $PGIOUT ]]
-then
-   if [ $GRIBVERSION = grib2 ]; then
-     # JY $GRBINDEX2 $PGBOUT $PGIOUT
-     $GRB2INDEX $PGBOUT $PGIOUT
-   else
-     $GRBINDEX $PGBOUT $PGIOUT
-   fi
+if [[ -n $PGIOUT ]]; then
+	if [ $GRIBVERSION = grib2 ]; then
+		# JY $GRBINDEX2 $PGBOUT $PGIOUT
+		$GRB2INDEX $PGBOUT $PGIOUT
+	else
+		$GRBINDEX $PGBOUT $PGIOUT
+	fi
 fi
-if [[ -r $FLXINP && -n $FLXIOUT && $OUTTYP -le 3 ]]
-then
-   $GRBINDEX $FLXINP $FLXIOUT
+if [[ -r $FLXINP && -n $FLXIOUT && $OUTTYP -le 3 ]]; then
+	$GRBINDEX $FLXINP $FLXIOUT
 fi
 ################################################################################
 # generate psi and chi
 echo "GENPSICHI= " $GENPSICHI
 if [ $GENPSICHI = YES ] ; then
-#echo "PGBOUT PGIOUT=" $PGBOUT $PGIOUT
-#echo "YY MM=" $YY $MM
- export psichifile=./psichi.grb
- $GENPSICHIEXE < postgp.inp.nml$$
- rc=$?
- if [[ $rc -ne 0 ]] ; then echo 'Nonzero return code rc= '$rc ; exit 3 ; fi
- cat ./psichi.grb >> $PGBOUT
+	#echo "PGBOUT PGIOUT=" $PGBOUT $PGIOUT
+	#echo "YY MM=" $YY $MM
+	export psichifile=./psichi.grb
+	$GENPSICHIEXE < postgp.inp.nml$$
+	rc=$?
+	if [[ $rc -ne 0 ]] ; then
+		echo 'Nonzero return code rc= '$rc
+		exit 3
+	fi
+	cat ./psichi.grb >> $PGBOUT
 fi
 ################################################################################
 #  Postprocessing
@@ -498,8 +486,7 @@ cd $pwd
 [[ $mkdata = YES ]]&&rmdir $DATA
 $ENDSCRIPT
 set +x
-if [[ "$VERBOSE" = "YES" ]]
-then
-   echo $(date) EXITING $0 with return code $err >&2
+if [[ "$VERBOSE" = "YES" ]]; then
+	echo $(date) EXITING $0 with return code $err >&2
 fi
 exit $err

--- a/ush/inter_flux.sh
+++ b/ush/inter_flux.sh
@@ -1,0 +1,69 @@
+#!/bin/ksh
+set -x
+
+#-----------------------------------------------------------------------
+#-Wen Meng, 03/2019:  First version.
+#  This scripts is for interpolating flux file from model native grid
+#  into lat-lon grids.
+#-----------------------------------------------------------------------
+
+
+echo "!!!!!CREATING $RUN FLUX PRODUCTS FOR FH = $FH !!!!!!"
+
+export CNVGRIB=${CNVGRIB:-${NWPROD:-/nwprod}/util/exec/cnvgrib21}
+export COPYGB2=${COPYGB2:-${NWPROD:-/nwprod}/util/exec/copygb2}
+export WGRIB2=${WGRIB2:-${NWPROD:-/nwprod}/util/exec/wgrib2}
+export GRBINDEX=${GRBINDEX:-${NWPROD:-nwprod}/util/exec/grbindex}
+export RUN=${RUN:-"gfs"}
+export cycn=$(echo $CDATE |cut -c 9-10)
+export TCYC=${TCYC:-".t${cycn}z."}
+export PREFIX=${PREFIX:-${RUN}${TCYC}}
+export PGB1F=${PGB1F:-"NO"}
+
+#--wgrib2 regrid parameters
+export option1=' -set_grib_type same -new_grid_winds earth '
+export option21=' -new_grid_interpolation bilinear  -if '
+export option22=":(LAND|CRAIN|CICEP|CFRZR|CSNOW|ICSEV):"
+export option23=' -new_grid_interpolation neighbor -fi '
+export option24=' -set_bitmap 1 -set_grib_max_bits 16 -if '
+export option25=":(APCP|ACPCP|PRATE|CPRAT):"
+export option26=' -set_grib_max_bits 25 -fi -if '
+export option27=":(APCP|ACPCP|PRATE|CPRAT|DZDT):"
+export option28=' -new_grid_interpolation budget -fi '
+export grid0p25="latlon 0:1440:0.25 90:721:-0.25"
+export grid0p5="latlon 0:720:0.5 90:361:-0.5"
+export grid1p0="latlon 0:360:1.0 90:181:-1.0"
+export grid2p5="latlon 0:144:2.5 90:73:-2.5"
+
+
+if [ $FH -eq 0 ] ; then
+  export fhr3=000
+else
+  export fhr3=$(expr $FH + 0 )
+  if [ $fhr3 -lt 100 ]; then export fhr3="0$fhr3"; fi
+  if [ $fhr3 -lt 10 ];  then export fhr3="0$fhr3"; fi
+fi
+
+#---------------------------------------------------------------
+
+  if [ $INLINE_POST = ".false." ]; then
+    $WGRIB2 $PGBOUT $option1 $option21 $option22 $option23 $option24 \
+                          $option25 $option26 $option27 $option28 \
+                          -new_grid $grid1p0  fluxfile_${fhr3}_1p00
+  else 
+    $WGRIB2 $COMOUT/${FLUXFL} $option1 $option21 $option22 $option23 $option24 \
+                          $option25 $option26 $option27 $option28 \
+                          -new_grid $grid1p0  fluxfile_${fhr3}_1p00
+  fi
+  export err=$?; err_chk
+
+
+  $WGRIB2 -s fluxfile_${fhr3}_1p00 > $COMOUT/${PREFIX}flux.1p00.f${fhr3}.idx
+  cp fluxfile_${fhr3}_1p00  $COMOUT/${PREFIX}flux.1p00.f${fhr3}
+
+#---------------------------------------------------------------
+echo "!!!!!CREATION OF SELECT $RUN FLUX PRODUCTS COMPLETED FOR FHR = $FH !!!!!"
+#---------------------------------------------------------------
+
+
+exit 0

--- a/ush/link_crtm_fix.sh
+++ b/ush/link_crtm_fix.sh
@@ -7,29 +7,29 @@
 FIXCRTM="${1:-${FIXCRTM:-MISSING}}"
 
 if [[ "$FIXCRTM" == "MISSING" ]] ; then
-    echo "Please specify CRTM fix location.  Giving up." 1>&2
-    exit 19
+	echo "Please specify CRTM fix location.  Giving up." 1>&2
+	exit 19
 fi
 if [[ ! -d "$FIXCRTM" ]] ; then
-    echo "$FIXCRTM: \$FIXCRTM is not a directory.  Giving up." 1>&2
-    exit 38
+	echo "$FIXCRTM: \$FIXCRTM is not a directory.  Giving up." 1>&2
+	exit 38
 fi
 
 for what in "amsre_aqua" "imgr_g11" "imgr_g12" "imgr_g13" \
-    "imgr_g15" "imgr_mt1r" "imgr_mt2" "seviri_m10" \
-    "ssmi_f13" "ssmi_f14" "ssmi_f15" "ssmis_f16" \
-    "ssmis_f17" "ssmis_f18" "ssmis_f19" "ssmis_f20" \
-    "tmi_trmm" "v.seviri_m10" "imgr_insat3d" "abi_gr" "ahi_himawari8" ; do
-    ln -s "$FIXCRTM/$what.TauCoeff.bin" .
-    ln -s "$FIXCRTM/$what.SpcCoeff.bin" .
+	"imgr_g15" "imgr_mt1r" "imgr_mt2" "seviri_m10" \
+	"ssmi_f13" "ssmi_f14" "ssmi_f15" "ssmis_f16" \
+	"ssmis_f17" "ssmis_f18" "ssmis_f19" "ssmis_f20" \
+	"tmi_trmm" "v.seviri_m10" "imgr_insat3d" "abi_gr" "ahi_himawari8" ; do
+	ln -s "$FIXCRTM/$what.TauCoeff.bin" .
+	ln -s "$FIXCRTM/$what.SpcCoeff.bin" .
 done
 
 for what in 'Aerosol' 'Cloud' ; do
-    ln -s "$FIXCRTM/${what}Coeff.bin" .
+	ln -s "$FIXCRTM/${what}Coeff.bin" .
 done
 
 for what in  $FIXCRTM/*Emis* ; do
-   ln -s $what .
+	ln -s $what .
 done
 
 exit 0


### PR DESCRIPTION
 Standardizes and/or updates some of the style inconsistencies in shell scripts:
  - All scripts re-indented properly
  - All backticks replaced with $( ) for subshells
  - All test statements replaced with [ ]
  - If/then and while/do now all appear on same line
  - Heredocs now use <<- instead of << to allow proper indentation
    - These files had to be converted to tab indentation, the only kind recognized by <<-
 
There should be no functional change with this PR, but it needs testing.