### PR TITLE
Add POC from EPIC to codeowners for public docs and run script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 *       @WenMeng-NOAA 
 
 
-# DTC support for public releases and documentation 
-docs/*  @hertneky @fossell
-scripts/run_upp @hertneky @fossell
+# Support for public releases and documentation 
+docs/*  @hertneky @fossell @camshe
+scripts/run_upp @hertneky @fossell @camshe
 


### PR DESCRIPTION
Adding @camshe to codeowners file for public docs and scripts.