### PR TITLE
read in dx/dy instead of calculating them

### DIFF
--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -11,7 +11,7 @@
 !   March, 2015    Lin Gan    Replace XML file with flat file implementation
 !                              with parameter marshalling
 !   July,  2021    Jesse Meng 2D decomsition
-!   June,  2011    Lin Zhu change the dx/dy to reading in from calculating for latlon grid
+!   June,  2022    Lin Zhu change the dx/dy to reading in from calculating for latlon grid
 !------------------------------------------------------------------------
   use xml_perl_data, only: param_t,paramset_t
 !

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -11,6 +11,7 @@
 !   March, 2015    Lin Gan    Replace XML file with flat file implementation
 !                              with parameter marshalling
 !   July,  2021    Jesse Meng 2D decomsition
+!   June,  2011    Lin Zhu change the dx/dy to reading in from calculating for latlon grid
 !------------------------------------------------------------------------
   use xml_perl_data, only: param_t,paramset_t
 !

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -1779,13 +1779,15 @@
        ifield3(15) = latlast
        ifield3(16) = lonlast
 !       ifield3(17) = NINT(360./(IM)*1.0E6)
-       ifield3(17) = abs(lonlast-lonstart)/(IM-1)
+!       ifield3(17) = abs(lonlast-lonstart)/(IM-1)
+       ifield3(17) = DXVAL
 !       if(mod(jm,2) == 0 ) then
 !        ifield3(18) = NINT(180./JM*1.0E6) 
 !       else
 !        ifield3(18) = NINT(180./(JM-1)*1.0E6)
-        ifield3(18) = abs(latlast-latstart)/(JM-1)
+!        ifield3(18) = abs(latlast-latstart)/(JM-1)
 !       endif
+       ifield3(18) = DYVAL
        if( latstart < latlast ) then
         ifield3(19) = 64      !for SN scan   
        else


### PR DESCRIPTION
The odd dx/dy for the HAFS domain cross Greenwich meridian. So, we update the dx/dy by reading in instead of calculating them. The following code is updated.

sorc/ncep_post.fd/grib2_module.f