### PR TITLE
Read instant top of atmosphere ULWRF from model

### DIFF
--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -18,6 +18,7 @@
 !> 2022-03-22 | Wen Meng      | Read PWAT from model
 !> 2022-04-08 | Bo Cui        | 2D decomposition for unified fv3 read interfaces
 !> 2022-06-05 | Hui-Ya Chuang | Modify dx/dy computation for RRFS domain over north pole
+!> 2022-07-18 | Wen Meng      | Read instant top of atmos ULWRF from model
 !>
 !> @author Hui-Ya Chuang @date 2016-03-04
       SUBROUTINE INITPOST_NETCDF(ncid2d,ncid3d)
@@ -2575,7 +2576,6 @@
           acfrst(i,j) = spval ! GFS does not output time averaged cloud fraction, set acfrst to spval, ncfrst to 1
           ncfrst(i,j) = 1.0
           bgroff(i,j) = spval ! GFS does not have UNDERGROUND RUNOFF
-          rlwtoa(i,j) = spval ! GFS does not have inst model top outgoing longwave
         enddo
       enddo
 !     trdlw(i,j)  = 6.0
@@ -2615,6 +2615,12 @@
       call read_netcdf_2d_para(ncid2d,ista,ista_2l,iend,iend_2u,jsta,jsta_2l,jend,jend_2u, &
       spval,VarName,alwtoa)
 !     if(debugprint)print*,'sample l',VarName,' = ',1,alwtoa(isa,jsa)
+
+! instant outgoing model top longwave
+      VarName='ulwrf_toa'
+      call read_netcdf_2d_para(ncid2d,ista,ista_2l,iend,iend_2u,jsta,jsta_2l,jend,jend_2u, &
+      spval,VarName,rlwtoa)
+!     if(debugprint)print*,'sample l',VarName,' = ',1,rlwtoa(isa,jsa)
       
 ! GFS incoming sfc longwave has been averaged, set ARDLW to 1
       ardsw=1.0


### PR DESCRIPTION
Per the request from HAFS development, reading instant top of atmoshere ULWRF from FV3 based model.