### PR TITLE
Bug fix for gfs.v16.3 WAFS

### DIFF
--- a/sorc/ncep_post.fd/MDL2STD_P.f
+++ b/sorc/ncep_post.fd/MDL2STD_P.f
@@ -466,7 +466,7 @@
 
          ! Relabel the pressure level to reference levels
 !         IDS = 0
-         IDS = (/ 450,480,464,465,466,518,519,520,521,522,(0,I=11,50) /)
+         IDS = (/ 450,480,464,465,466,518,519,520,521,(0,I=10,50) /)
          do i = 1, NFDMAX
             iID=IDS(i)
             if(iID == 0) exit


### PR DESCRIPTION
Removed RH on ICAO_STD_SFC from IDS when calling 'relabel'