### PR TITLE
Upgrade crtm to 2.4.0 on WCOSS2 for GFS V16.3.0 Implementation

### DIFF
--- a/modulefiles/post/post_wcoss2.lua
+++ b/modulefiles/post/post_wcoss2.lua
@@ -30,7 +30,7 @@ bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 gfsio_ver=os.getenv("gfsio_ver") or "1.4.1"
 ip_ver=os.getenv("ip_ver") or "3.3.3"
 sp_ver=os.getenv("sp_ver") or "2.3.3"
-crtm_ver=os.getenv("crtm_ver") or "2.3.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0"
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("g2", g2_ver))
 load(pathJoin("g2tmpl", g2tmpl_ver))

--- a/modulefiles/upp/upp_wcoss2.lua
+++ b/modulefiles/upp/upp_wcoss2.lua
@@ -30,7 +30,7 @@ bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 gfsio_ver=os.getenv("gfsio_ver") or "1.4.1"
 ip_ver=os.getenv("ip_ver") or "3.3.3"
 sp_ver=os.getenv("sp_ver") or "2.3.3"
-crtm_ver=os.getenv("crtm_ver") or "2.3.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0"
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("g2", g2_ver))
 load(pathJoin("g2tmpl", g2tmpl_ver))

--- a/sorc/ncep_post.fd/CALRAD_WCLOUD_newcrtm.f
+++ b/sorc/ncep_post.fd/CALRAD_WCLOUD_newcrtm.f
@@ -34,7 +34,7 @@ SUBROUTINE CALRAD_WCLOUD
   !     MACHINE : IBM
   !$$$  
   use vrbls3d, only: o3, pint, pmid, t, q, qqw, qqi, qqr, f_rimef, nlice, nrain, qqs, qqg, &
-                     qqnr, qqni
+                     qqnr, qqni, cfr
   use vrbls2d, only: czen, ivgtyp, sno, pctsno, ths, vegfrc, si, u10h, v10h, u10,&
        v10, smstot, hbot, htop, cnvcfr
   use masks, only: gdlat, gdlon, sm, lmh, sice
@@ -884,6 +884,7 @@ SUBROUTINE CALRAD_WCLOUD
                        !       CRTM counts from top down just as post does
                        if(i==ii.and.j==jj.and.debugprint)print*,'TOA= ',atmosphere(1)%level_pressure(0)
                        do k = 1,lm
+                          atmosphere(1)%cloud_fraction(k) = min(max(cfr(i,j,k),0.),1.)
                           atmosphere(1)%level_pressure(k) = pint(i,j,k+1)/r100
                           atmosphere(1)%pressure(k)       = pmid(i,j,k)/r100
                           atmosphere(1)%temperature(k)    = t(i,j,k)
@@ -1476,6 +1477,7 @@ SUBROUTINE CALRAD_WCLOUD
                        !       CRTM counts from top down just as post does
                        if(i==ii.and.j==jj)print*,'TOA= ',atmosphere(1)%level_pressure(0)
                        do k = 1,lm
+                          atmosphere(1)%cloud_fraction(k) = min(max(cfr(i,j,k),0.),1.)
                           atmosphere(1)%level_pressure(k) = pint(i,j,k+1)/r100
                           atmosphere(1)%pressure(k)       = pmid(i,j,k)/r100
                           atmosphere(1)%temperature(k)    = t(i,j,k)

--- a/sorc/ncep_post.fd/build_upp_lib.sh
+++ b/sorc/ncep_post.fd/build_upp_lib.sh
@@ -1,6 +1,6 @@
 SHELL=/bin/sh
 
-module purge
+module reset
 set -x
 mac=$(hostname | cut -c1-1)
 mac2=$(hostname | cut -c1-2)
@@ -31,6 +31,7 @@ export version=${1:-"v8.1.0"}
 
 moduledir=`dirname $(readlink -f ../../modulefiles/upp)`
 if [ $machine = wcoss2 ] ; then
+module reset
 module use ${moduledir}/upp
 module load upp_${machine}
 elif [ $machine = hera -o $machine = orion ] ; then

--- a/sorc/ncep_post.fd/build_upp_lib.sh
+++ b/sorc/ncep_post.fd/build_upp_lib.sh
@@ -1,6 +1,5 @@
 SHELL=/bin/sh
 
-module reset
 set -x
 mac=$(hostname | cut -c1-1)
 mac2=$(hostname | cut -c1-2)


### PR DESCRIPTION
Upgrade crtm to 2.4.0 to support GFS V16.3.0 implementation.