### PR TITLE
Fix an out-of-bounds access in CALCAPE2

### DIFF
--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -998,6 +998,7 @@
 !> 2015-??-?? | S Moorthi     | Optimization and threading
 !> 2021-09-03 | J Meng        | Modified to add 0-3km CAPE/CINS, LFC, effective helicity, downdraft CAPE, dendritic growth layer depth, ESP
 !> 2021-09-01 | E Colon       | Equivalent level height index for RTMA
+!> 2022-08-27 | S Trahan      | Fixed bug in CALCAPE2 where extreme atmospheric conditions cause an out-of-bounds access
 !>
 !> @author Russ Treadon W/NP2 @date 1993-02-10
       SUBROUTINE CALCAPE2(ITYPE,DPBND,P1D,T1D,Q1D,L1D,    &  

--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -1399,6 +1399,10 @@
         ENDDO
       ENDDO
 !
+!Ensure later calculations do not access LM+1
+!
+      LEND=MIN(LEND,LM-1)
+!
 !reverse L order from bottom up for ESRH calculation
 !
       ESRHH = LCL


### PR DESCRIPTION
When the LCL is above the model top, CALCAPE2 will access beyond the bounds of the TPAR array. This happened in an RRFS run by @EricJames-NOAA and it might be the cause of sporadic failures seen in other RRFS workflows.

Fixes #556 

The error:

```
1411:   DO L=LEND,LBEG,-1
   ...
1457:      ESATP2  = min(FPVSNEW(TPAR(I,J,L+1)),PRESK2)
   ...
1481:   ENDDO
```

The fix is to apply bounds to the LEND index:

```
!                                                                                                                                                                                                                                            
!Ensure later calculations do not access LM+1                                                                                                                                                                                                
!                                                                                                                                                                                                                                            
      LEND=MIN(LEND,LM-1)
```