### PR TITLE
Clean spack caches after installation

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -62,6 +62,7 @@ jobs:
           spack add mpich@3.4.2
           spack concretize
           spack install -v --fail-fast --dirty
+          spack clean --all
 
   build:
     needs: setup

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -77,6 +77,7 @@ jobs:
           spack add intel-oneapi-mpi
           spack concretize
           spack install --dirty -v --fail-fast
+          spack clean --all
 
   build:
     needs: setup


### PR DESCRIPTION
This PR adds "spack clean --all" after the CI spack installation in order to clean up various cached files (downloaded tar files, source/build directories, etc.) which are not needed for building UPP. This reduces the cache usage for one CI cycle from over 8GB to less than 3GB. h/t to @aerorahul for identifying this improvement.