### PR TITLE
Urgent bug fix: libIFI changes broke inline post due to missing deallocates

### DIFF
--- a/sorc/ncep_post.fd/DEALLOCATE.f
+++ b/sorc/ncep_post.fd/DEALLOCATE.f
@@ -139,6 +139,9 @@
       deallocate(stc)
       deallocate(sh2o)
       deallocate(SLDPTH)
+      deallocate(CAPE)
+      deallocate(CIN)
+      deallocate(IFI_APCP)
       deallocate(RTDPTH)
       deallocate(SLLEVEL)
 !

--- a/sorc/ncep_post.fd/IFI.F
+++ b/sorc/ncep_post.fd/IFI.F
@@ -21,6 +21,9 @@ contains !==============================================================
 
     ! Bogus fill value for flight levels to prevent a crash
     ifi_nflight = 60
+    if(allocated(ifi_flight_levels)) then
+      deallocate(ifi_flight_levels)
+    endif
     allocate(ifi_flight_levels(ifi_nflight))
     do i=1,ifi_nflight
       ifi_flight_levels(i) = 500*i
@@ -176,10 +179,27 @@ contains !==============================================================
 ! 929 format('Rank ',I0,' ista=',I0,' jsta=',I0)
 !     print 929,grid_rank,ista,jsta
 
+    if(allocated(ista_grid)) then
+      deallocate(ista_grid)
+      deallocate(jsta_grid)
+      deallocate(rearrange)
+      deallocate(rearrange_row1d)
+      deallocate(rearrange_row2d)
+      deallocate(row_ista)
+      deallocate(row_iend)
+      deallocate(row_comm_count)
+      deallocate(row_comm_displ)
+      deallocate(col_jsta)
+      deallocate(col_jend)
+      deallocate(col_comm_count)
+      deallocate(col_comm_displ)
+    endif
+
     ! Get the start locations on every rank. We need this for the key,
     ! and for determining root ranks.
     allocate(ista_grid(size))
     allocate(jsta_grid(size))
+
     ista_grid=-1
     jsta_grid=-1
     call MPI_Allgather(ista,1,MPI_INTEGER,ista_grid,1,MPI_INTEGER,mpi_comm_comp,ierr)
@@ -508,6 +528,9 @@ contains !==============================================================
 
     ! Convert from integer to real:
     ifi_nflight = size(config_flight_levels_feet)
+    if(allocated(ifi_flight_levels)) then
+      deallocate(ifi_flight_levels)
+    endif
     allocate(ifi_flight_levels(ifi_nflight))
     ifi_flight_levels = config_flight_levels_feet
 

--- a/sorc/ncep_post.fd/IFI.F
+++ b/sorc/ncep_post.fd/IFI.F
@@ -199,7 +199,6 @@ contains !==============================================================
     ! and for determining root ranks.
     allocate(ista_grid(size))
     allocate(jsta_grid(size))
-
     ista_grid=-1
     jsta_grid=-1
     call MPI_Allgather(ista,1,MPI_INTEGER,ista_grid,1,MPI_INTEGER,mpi_comm_comp,ierr)


### PR DESCRIPTION
My changes to connect libIFI to the post do not deallocate some arrays after each iteration of libpost. This causes the model to abort at runtime due to allocating an array that is already allocated.

Fixes #622

This has been applied to #620 as well, but I strongly recommend this PR be merged first.