### PR TITLE
bug fixes needed for running with libIFI

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -38,14 +38,14 @@ jobs:
     steps:
       - name: checkout-upp  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@V3
         with:
             path: UPP
 
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@V3
         with:
           path: |
             spack
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: checkout-upp
-        uses: actions/checkout@v2
+        uses: actions/checkout@V3
         with:
             path: UPP
 
@@ -95,7 +95,7 @@ jobs:
 
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@V3
         with:
           path: |
             spack

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: install-intel
         run: |
+          sudo mv /usr/local/ /usr_local_mv
           echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
 
       - name: cache-env

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -91,7 +91,6 @@ jobs:
 
       - name: install-intel
         run: |
-          sudo mv /usr/local/ /usr_local_mv
           echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
 
       - name: cache-env
@@ -106,6 +105,7 @@ jobs:
 
       - name: build-upp
         run: |
+          sudo mv /usr/local/ /usr_local_mv
           source spack/share/spack/setup-env.sh
           spack env activate upp-env
           export CC=mpiicc

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -38,14 +38,14 @@ jobs:
     steps:
       - name: checkout-upp  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
-        uses: actions/checkout@V3
+        uses: actions/checkout@v3
         with:
             path: UPP
 
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@V3
+        uses: actions/cache@v3
         with:
           path: |
             spack
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: checkout-upp
-        uses: actions/checkout@V3
+        uses: actions/checkout@v3
         with:
             path: UPP
 
@@ -95,7 +95,7 @@ jobs:
 
       - name: cache-env
         id: cache-env
-        uses: actions/cache@V3
+        uses: actions/cache@v3
         with:
           path: |
             spack

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -104,7 +104,6 @@ jobs:
 
       - name: build-upp
         run: |
-          sudo mv /usr/local/ /usr_local_mv
           source spack/share/spack/setup-env.sh
           spack env activate upp-env
           export CC=mpiicc

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout-upp  # This is for getting spack.yaml
@@ -81,7 +81,7 @@ jobs:
 
   build:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout-upp

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -38,14 +38,14 @@ jobs:
     steps:
       - name: checkout-upp  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
             path: UPP
 
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v3
+        uses: actions/cache@v2
         with:
           path: |
             spack
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: checkout-upp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
             path: UPP
 
@@ -94,7 +94,7 @@ jobs:
 
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v3
+        uses: actions/cache@v2
         with:
           path: |
             spack

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -66,7 +66,6 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          sudo mv /usr/local/ /usr_local_mv
           git clone -c feature.manyFiles=true https://github.com/NOAA-EMC/spack.git
           source spack/share/spack/setup-env.sh
           spack env create upp-env UPP/ci/spack.yaml

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -6687,7 +6687,7 @@
       character(len=256), intent(in) :: compfile
       integer, intent(in) :: igetfld,fcst
       integer :: trange,invstat
-      real, dimension(IM,JM) :: outgrid
+      real, dimension(ista:iend,jsta:jend) :: outgrid
 
       real, allocatable, dimension(:,:) :: mscValue
 
@@ -6699,6 +6699,8 @@
       logical :: file_exists
 
       integer :: i, j, k, ii, jj
+
+      outgrid = 0
 
 !     Read in reference grid.
       INQUIRE(FILE=compfile, EXIST=file_exists)
@@ -6750,13 +6752,9 @@
                   outgrid(I,J) = 1.0
                ELSE IF (fcst .GT. 1 .AND. AVGPREC_CONT(I,J)*FLOAT(IFHR)*3600.*1000./DTQ2 .GT. mscValue(I,J)) THEN
                   outgrid(I,J) = 1.0
-               ELSE
-                  outgrid(I,J) = 0.0
                ENDIF
             ENDDO
          ENDDO
-       ELSE
-         outgrid = 0.0*AVGPREC
        ENDIF
       ENDIF
 !      write(*,*) 'FFG MAX, MIN:', &

--- a/tests/compile_upp.sh
+++ b/tests/compile_upp.sh
@@ -30,7 +30,7 @@ wrfio_opt=" -DBUILD_WITH_WRFIO=ON"
 compiler="intel"
 verbose_opt=""
 debug_opt=""
-while getopts ":p:gwc:vhiI:d" opt; do
+while getopts ":p:gwc:vhiId" opt; do
   case $opt in
     p)
       prefix=$OPTARG


### PR DESCRIPTION
Fixes #647, fixes #648, and fixes #641

1. Standalone UPP build script can't build libIFI internally due to an error in compile_upp.sh discovered by @WenMeng-NOAA (#647)
2. An indexing error in qpf_comp in SURFCE.f causes a segfault when libIFI is used in inline post. This error is unrelated to libIFI, but somehow affects it at runtime. (#648)
3. Fix from @WenMeng-NOAA to update the version of ubuntu to run github checks (#641)