### PR TITLE
WAFS product IDs updates, and merge RAP UPP code

### DIFF
--- a/parm/post_avblflds.xml
+++ b/parm/post_avblflds.xml
@@ -3924,8 +3924,7 @@
 <!-- 450-451 -->
     <param>
        <post_avblfldidx>450</post_avblfldidx>
-       <shortname>ICIP_ON_ICAO_STD_SFC</shortname>
-       <longname>Total Icing Potential Diagnostic on standard atmospheric isobaric sfc</longname>
+       <shortname>ICIP_ON_ISOBARIC_SFC</shortname>
        <pname>ICIP</pname>
        <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
@@ -4049,10 +4048,10 @@
        <scale>4.0</scale>
     </param>
 
-<!-- 464-466 EDR on STD ISOBARIC_SFC -->
+<!-- 464-466 EDR on ISOBARIC_SFC -->
     <param>
        <post_avblfldidx>464</post_avblfldidx>
-       <shortname>EDPARM_GTG_ON_ICAO_STD_SFC</shortname>
+       <shortname>EDPARM_ON_ISOBARIC_SFC</shortname>
        <pname>EDPARM</pname>
        <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
@@ -4060,7 +4059,7 @@
 
     <param>
        <post_avblfldidx>465</post_avblfldidx>
-       <shortname>CAT_GTG_ON_ICAO_STD_SFC</shortname>
+       <shortname>CAT_ON_ISOBARIC_SFC</shortname>
        <pname>CATEDR</pname>
        <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
@@ -4068,7 +4067,7 @@
 
     <param>
        <post_avblfldidx>466</post_avblfldidx>
-       <shortname>MWTURB_GTG_ON_ICAO_STD_SFC</shortname>
+       <shortname>MWTURB_ON_ISOBARIC_SFC</shortname>
        <pname>MWTURB</pname>
        <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
@@ -4149,10 +4148,10 @@
        <scale>6.0</scale>
     </param>
 
-<!-- 476-478 EDR on ISOBARIC_SFC -->
+<!-- 476-478 EDR on STD ISOBARIC_SFC -->
     <param>
        <post_avblfldidx>476</post_avblfldidx>
-       <shortname>EDPARM_ON_ISOBARIC_SFC</shortname>
+       <shortname>EDPARM_GTG_ON_ICAO_STD_SFC</shortname>
        <pname>EDPARM</pname>
        <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
@@ -4160,7 +4159,7 @@
 
     <param>
        <post_avblfldidx>477</post_avblfldidx>
-       <shortname>CAT_ON_ISOBARIC_SFC</shortname>
+       <shortname>CAT_GTG_ON_ICAO_STD_SFC</shortname>
        <pname>CATEDR</pname>
        <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
@@ -4168,7 +4167,7 @@
 
     <param>
        <post_avblfldidx>478</post_avblfldidx>
-       <shortname>MWTURB_ON_ISOBARIC_SFC</shortname>
+       <shortname>MWTURB_GTG_ON_ICAO_STD_SFC</shortname>
        <pname>MWTURB</pname>
        <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
@@ -4177,14 +4176,6 @@
 <!-- 479-481 -->
     <param>
        <post_avblfldidx>479</post_avblfldidx>
-       <shortname>ICESEV_ON_ISOBARIC_SFC</shortname>
-       <pname>ICESEV</pname>
-       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
-       <scale>1.0</scale>
-    </param>
-
-    <param>
-       <post_avblfldidx>480</post_avblfldidx>
        <shortname>ICESEV_ON_ICAO_STD_SFC</shortname>
        <longname>Icing severity on standard atmospheric isobaric levels</longname>
        <pname>ICESEV</pname>
@@ -4193,8 +4184,17 @@
     </param>
 
     <param>
+       <post_avblfldidx>480</post_avblfldidx>
+       <shortname>ICESEV_ON_ISOBARIC_SFC</shortname>
+       <pname>ICESEV</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
        <post_avblfldidx>481</post_avblfldidx>
-       <shortname>ICIP_ON_ISOBARIC_SFC</shortname>
+       <shortname>ICIP_ON_ICAO_STD_SFC</shortname>
+       <longname>Total Icing Potential Diagnostic on standard atmospheric isobaric sfc</longname>
        <pname>ICIP</pname>
        <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
        <scale>3.0</scale>

--- a/parm/postxconfig-NT-GFS-WAFS.txt
+++ b/parm/postxconfig-NT-GFS-WAFS.txt
@@ -16,7 +16,7 @@ complex_packing_spatial_diff
 2nd_ord_sptdiff
 fltng_pnt
 lossless
-476
+464
 EDPARM_ON_ISOBARIC_SFC
 ?
 1
@@ -53,7 +53,7 @@ isobaric_sfc
 ?
 ?
 ?
-477
+465
 CAT_ON_ISOBARIC_SFC
 ?
 1
@@ -90,7 +90,7 @@ isobaric_sfc
 ?
 ?
 ?
-478
+466
 MWTURB_ON_ISOBARIC_SFC
 ?
 1
@@ -127,7 +127,7 @@ isobaric_sfc
 ?
 ?
 ?
-479
+480
 ICESEV_ON_ISOBARIC_SFC
 ?
 1

--- a/scripts/exgfs_atmos_nceppost.sh
+++ b/scripts/exgfs_atmos_nceppost.sh
@@ -526,9 +526,6 @@ do
 	  export POSTGPVARS="KPO=56,PO=84310.,81200.,78190.,75260.,72430.,69680.,67020.,64440.,61940.,59520.,57180.,54920.,52720.,50600.,48550.,46560.,44650.,42790.,41000.,39270.,37600.,35990.,34430.,32930.,31490.,30090.,28740.,27450.,26200.,25000.,23840.,22730.,21660.,20650.,19680.,18750.,17870.,17040.,16240.,15470.,14750.,14060.,13400.,12770.,12170.,11600.,11050.,10530.,10040.,9570.,9120.,8700.,8280.,7900.,7520.,7170.,popascal=.true.,"
 
 	  # Extend WAFS icing and gtg up to 120 hours
-          export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS.txt
-          export CTLFILE=$PARMpost/postcntrl_gfs_wafs.xml
-
           if [  $fhr -le 48  ] ; then
               export PostFlatFile=$PARMpost/postxconfig-NT-GFS-WAFS.txt
               export CTLFILE=$PARMpost/postcntrl_gfs_wafs.xml

--- a/sorc/ncep_post.fd/MDL2P.f
+++ b/sorc/ncep_post.fd/MDL2P.f
@@ -216,9 +216,9 @@
 ! ADD DUST FIELDS
          (IGET(455) > 0) .OR.      &
 ! Add WAFS hazard fields: Icing and GTG turbulence
-         (IGET(476) > 0) .OR. (IGET(477) > 0) .OR.      &
-         (IGET(478) > 0) .OR. (IGET(479) > 0) .OR.      &
-         (IGET(481) > 0) .OR.                           &
+         (IGET(464) > 0) .OR. (IGET(465) > 0) .OR.      &
+         (IGET(466) > 0) .OR. (IGET(450) > 0) .OR.      &
+         (IGET(480) > 0) .OR.                           &
 ! ADD SMOKE FIELDS
          (IGET(738) > 0) .OR. (IGET(743) > 0) .OR.      &
          (MODELNAME == 'RAPR') .OR.&
@@ -2069,8 +2069,8 @@
 !     
  
 !---  GFIP IN-FLIGHT ICING POTENTIAL: ADDED BY H CHUANG
-        IF(IGET(481) > 0)THEN
-          IF(LVLS(LP,IGET(481)) > 0)THEN                                  
+        IF(IGET(450) > 0)THEN
+          IF(LVLS(LP,IGET(450)) > 0)THEN                                  
 !$omp  parallel do private(i,j)
              DO J=JSTA,JEND
                DO I=ISTA,IEND
@@ -2079,8 +2079,8 @@
              ENDDO
             if(grib == 'grib2') then
               cfld = cfld + 1
-              fld_info(cfld)%ifld=IAVBLFLD(IGET(481))
-              fld_info(cfld)%lvl=LVLSXML(LP,IGET(481))
+              fld_info(cfld)%ifld=IAVBLFLD(IGET(450))
+              fld_info(cfld)%lvl=LVLSXML(LP,IGET(450))
 !$omp parallel do private(i,j,jj)
               do j=1,jend-jsta+1
                 jj = jsta+j-1
@@ -2093,8 +2093,8 @@
           ENDIF
         ENDIF
 !---  GFIP IN-FLIGHT ICING SEVERITY: ADDED BY Y MAO
-        IF(IGET(479) >  0) THEN
-          IF(LVLS(LP,IGET(479)) > 0) THEN
+        IF(IGET(480) >  0) THEN
+          IF(LVLS(LP,IGET(480)) > 0) THEN
 !$omp  parallel do private(i,j)
              DO J=JSTA,JEND
                DO I=ISTA,IEND
@@ -2103,8 +2103,8 @@
              ENDDO
              if(grib == 'grib2') then
               cfld = cfld+1
-              fld_info(cfld)%ifld=IAVBLFLD(IGET(479))
-              fld_info(cfld)%lvl=LVLSXML(LP,IGET(479))
+              fld_info(cfld)%ifld=IAVBLFLD(IGET(480))
+              fld_info(cfld)%lvl=LVLSXML(LP,IGET(480))
 !$omp parallel do private(i,j,jj)
               do j=1,jend-jsta+1
                 jj = jsta+j-1
@@ -2117,8 +2117,8 @@
           ENDIF
         ENDIF
 !---  GTG EDR turbulence: ADDED BY Y. MAO
-        IF(IGET(476) >  0) THEN
-          IF(LVLS(LP,IGET(476)) > 0) THEN
+        IF(IGET(464) >  0) THEN
+          IF(LVLS(LP,IGET(464)) > 0) THEN
 !$omp  parallel do private(i,j)
              DO J=JSTA,JEND
                DO I=ISTA,IEND
@@ -2127,8 +2127,8 @@
              ENDDO
              if(grib == 'grib2') then
               cfld = cfld+1
-              fld_info(cfld)%ifld=IAVBLFLD(IGET(476))
-              fld_info(cfld)%lvl=LVLSXML(LP,IGET(476))
+              fld_info(cfld)%ifld=IAVBLFLD(IGET(464))
+              fld_info(cfld)%lvl=LVLSXML(LP,IGET(464))
 !$omp parallel do private(i,j,jj)
               do j=1,jend-jsta+1
                 jj = jsta+j-1
@@ -2141,8 +2141,8 @@
           ENDIF
         ENDIF
 !---  GTG CAT turbulence: ADDED BY Y. MAO
-        IF(IGET(477) >  0) THEN
-          IF(LVLS(LP,IGET(477)) > 0) THEN
+        IF(IGET(465) >  0) THEN
+          IF(LVLS(LP,IGET(465)) > 0) THEN
 !$omp  parallel do private(i,j)
              DO J=JSTA,JEND
                DO I=ISTA,IEND
@@ -2151,8 +2151,8 @@
              ENDDO
              if(grib == 'grib2') then
               cfld = cfld+1
-              fld_info(cfld)%ifld=IAVBLFLD(IGET(477))
-              fld_info(cfld)%lvl=LVLSXML(LP,IGET(477))
+              fld_info(cfld)%ifld=IAVBLFLD(IGET(465))
+              fld_info(cfld)%lvl=LVLSXML(LP,IGET(465))
 !$omp parallel do private(i,j,jj)
               do j=1,jend-jsta+1
                 jj = jsta+j-1
@@ -2165,8 +2165,8 @@
           ENDIF
         ENDIF
 !---  GTG MWT turbulence: ADDED BY Y. MAO
-        IF(IGET(478) >  0) THEN
-          IF(LVLS(LP,IGET(478)) > 0) THEN
+        IF(IGET(466) >  0) THEN
+          IF(LVLS(LP,IGET(466)) > 0) THEN
 !$omp  parallel do private(i,j)
              DO J=JSTA,JEND
                DO I=ISTA,IEND
@@ -2175,8 +2175,8 @@
              ENDDO
              if(grib == 'grib2') then
               cfld = cfld+1
-              fld_info(cfld)%ifld=IAVBLFLD(IGET(478))
-              fld_info(cfld)%lvl=LVLSXML(LP,IGET(478))
+              fld_info(cfld)%ifld=IAVBLFLD(IGET(466))
+              fld_info(cfld)%lvl=LVLSXML(LP,IGET(466))
 !$omp parallel do private(i,j,jj)
               do j=1,jend-jsta+1
                 jj = jsta+j-1

--- a/sorc/ncep_post.fd/MDL2STD_P.f
+++ b/sorc/ncep_post.fd/MDL2STD_P.f
@@ -62,17 +62,17 @@
 !
 
 !     --------------WAFS block----------------------
-!     450 ICIP
-!     480 ICSEV
-!     464 EDPARM
-!     465 CAT
-!     466 MWTURB
+!     479 ICSEV
+!     481 ICIP
+!     476 EDPARM
+!     477 CAT
+!     478 MWTURB
 !     518 HGT
 !     519 TMP
 !     520 UGRD
 !     521 VGRD
-      IF(IGET(450)>0 .or. IGET(480)>0 .or. &
-         IGET(464)>0 .or. IGET(465)>0 .or. IGET(466)>0 .or. &
+      IF(IGET(479)>0 .or. IGET(481)>0 .or. &
+         IGET(476)>0 .or. IGET(477)>0 .or. IGET(478)>0 .or. &
          IGET(518)>0 .or. IGET(519)>0 .or. IGET(520)>0 .or. &
          IGET(521)>0) then
 
@@ -165,33 +165,33 @@
 
 !        INITIALIZE INPUTS
          nFDS = 0
-         IF(IGET(450) > 0) THEN
+         IF(IGET(479) > 0) THEN
             nFDS = nFDS + 1
-            IDS(nFDS) = 450
+            IDS(nFDS) = 479
             QIN(ISTA:IEND,JSTA:JEND,1:LM,nFDS)=icing_gfip(ISTA:IEND,JSTA:JEND,1:LM)
             QTYPE(nFDS)="O"
          end if
-         IF(IGET(480) > 0) THEN
+         IF(IGET(481) > 0) THEN
             nFDS = nFDS + 1
-            IDS(nFDS) = 480
+            IDS(nFDS) = 481
             QIN(ISTA:IEND,JSTA:JEND,1:LM,nFDS)=icing_gfis(ISTA:IEND,JSTA:JEND,1:LM)
             QTYPE(nFDS)="O"
          end if
-         IF(IGET(464) > 0) THEN
+         IF(IGET(476) > 0) THEN
             nFDS = nFDS + 1
-            IDS(nFDS) = 464
+            IDS(nFDS) = 476
             QIN(ISTA:IEND,JSTA:JEND,1:LM,nFDS)=gtg(ISTA:IEND,JSTA:JEND,1:LM)
             QTYPE(nFDS)="O"
          end if
-         IF(IGET(465) > 0) THEN
+         IF(IGET(477) > 0) THEN
             nFDS = nFDS + 1
-            IDS(nFDS) = 465
+            IDS(nFDS) = 477
             QIN(ISTA:IEND,JSTA:JEND,1:LM,nFDS)=catedr(ISTA:IEND,JSTA:JEND,1:LM)
             QTYPE(nFDS)="O"
          end if
-         IF(IGET(466) > 0) THEN
+         IF(IGET(478) > 0) THEN
             nFDS = nFDS + 1
-            IDS(nFDS) = 466
+            IDS(nFDS) = 478
             QIN(ISTA:IEND,JSTA:JEND,1:LM,nFDS)=mwt(ISTA:IEND,JSTA:JEND,1:LM)
             QTYPE(nFDS)="O"
          end if
@@ -230,7 +230,7 @@
             iID=IDS(N)
 
 !           Icing Potential
-            if(iID==450) then
+            if(iID==481) then
                N1=N
                DO IFD = 1,NFDCTL
                   DO J=JSTA,JEND
@@ -251,7 +251,7 @@
 !              3 = moderate (0.37, 0.67]
 !              4 = severe (0.67, 1]
 !              http://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_table4-207.shtml
-            if(iID==480) then
+            if(iID==479) then
                DO IFD = 1,NFDCTL
                   DO J=JSTA,JEND
                   DO I=ISTA,IEND
@@ -277,7 +277,7 @@
             endif
 
 !           GTG turbulence:  EDRPARM, CAT, MWTURB
-            if(iID==464 .or. iID==465 .or. iID==466) then
+            if(iID==476 .or. iID==477 .or. iID==478) then
                DO IFD = 1,NFDCTL
                   DO J=JSTA,JEND
                   DO I=ISTA,IEND
@@ -365,7 +365,7 @@
 
          ! Relabel the pressure level to reference levels
 !         IDS = 0
-         IDS = (/ 450,480,464,465,466,518,519,520,521,(0,I=10,50) /)
+         IDS = (/ 481,479,476,477,478,518,519,520,521,(0,I=10,50) /)
          do i = 1, NFDMAX
             iID=IDS(i)
             if(iID == 0) exit

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -1206,6 +1206,28 @@
             allocate(GTGFD(ISTA:IEND,JSTA:JEND,NFDCTL))
             call FDLVL_MASS(ITYPEFDLVLCTL,NFDCTL,HTFDCTL,GTG,GTGFD)
 !           print *, "GTG 467 Done GTGFD=",me,GTGFD(IM/2,jend,1:NFDCTL)
+
+            ! Regional GTG has a legend of special defination
+            ! 0 m holds the max value of the whole vertical column
+            DO IFD = 1,NFDCTL
+               if(NINT(HTFDCTL(IFD)) == 0) then
+                  N=IFD
+                  exit
+               endif
+            ENDDO
+            DO IFD = 1,NFDCTL
+               DO J=JSTA,JEND
+               DO I=ISTA,IEND
+                  work1=GTGFD(I,J,IFD)
+                  if(GTGFD(I,J,N)>=SPVAL) then
+                     GTGFD(I,J,N)=work1
+                  elseif(work1<SPVAL) then
+                     if(GTGFD(I,J,N)<work1) GTGFD(I,J,N)=work1
+                  endif
+               ENDDO
+               ENDDO
+            ENDDO
+
             DO IFD = 1,NFDCTL
               IF (LVLS(IFD,IGET(467))>0) THEN
 !$omp parallel do private(i,j)


### PR DESCRIPTION
To solve issue #668:
1. Switch IDs of WAFS products between on ON_ISOBARIC_SFC and ON_ICAO_STD_SFC in parm/post_avblflds.xml. 
2. Regenerated parm/postxconfig-NT-GFS-WAFS.txt
3. The corresponding source code with iget() are updated, including MDL2P.f, MDL2STD_P.f, and MISCLN.f
4. Merge the extra lines of RAP UPP processing max EDR on 0 meter layer into MISCLN.f

A regression test run produce bit-wise identical products.