### PR TITLE
Read RRFS effective radii

### DIFF
--- a/sorc/ncep_post.fd/ALLOCATE_ALL.f
+++ b/sorc/ncep_post.fd/ALLOCATE_ALL.f
@@ -22,6 +22,7 @@
 !! -  22-09-22  Li(Kate) Zhang - Initializing NASA GOCART tracers of Nitrate, NH4,and their column burden.
 !! -  22-11-08  Kai Wang - Replace acfcmaq_on with aqf_on
 !! -  23-01-24  Sam Trahan - CAPE, CIN, and IFI_APCP varibles for input to IFI
+!! -  23-03-22  WM Lewis - Adding effective radius arrays
 !!
 !!   OUTPUT FILES:
 !!   - STDOUT  - RUN TIME STANDARD OUT.
@@ -157,6 +158,9 @@
       allocate(EXTCOF55(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QC_BL(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(CFR(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
+      allocate(EFFRI(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
+      allocate(EFFRL(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
+      allocate(EFFRS(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(CFR_RAW(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(DBZ(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(DBZR(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
@@ -189,6 +193,9 @@
             EXTCOF55(i,j,l)=0.
             QC_BL(i,j,l)=spval
             CFR(i,j,l)=spval
+            EFFRI(i,j,l)=spval
+            EFFRL(i,j,l)=spval
+            EFFRS(i,j,l)=spval
             CFR_RAW(i,j,l)=spval
             DBZ(i,j,l)=spval
             DBZR(i,j,l)=spval

--- a/sorc/ncep_post.fd/CALRAD_WCLOUD_newcrtm.f
+++ b/sorc/ncep_post.fd/CALRAD_WCLOUD_newcrtm.f
@@ -18,12 +18,13 @@
 !> 2021-09-02 | Bo Cui         | Decompose UPP in X direction          
 !> 2022-05-26 | WM Lewis       | added support for GOES-18 ABI IR Channels 7-16
 !> 2022-09-12 | Wen Meng       | Added cloud fraction changes for crtm/2.4.0
+!> 2023-03-22 | WM Lewis       | Added support for using effective radius arrays from RRFS
 !>
 !> @author Chuang @date 2007-01-17       
       SUBROUTINE CALRAD_WCLOUD
 
   use vrbls3d, only: o3, pint, pmid, t, q, qqw, qqi, qqr, f_rimef, nlice, nrain, qqs, qqg, &
-                     qqnr, qqni, qqnw, cfr
+                     qqnr, qqni, qqnw, cfr, effri, effrl, effrs
   use vrbls2d, only: czen, ivgtyp, sno, pctsno, ths, vegfrc, si, u10h, v10h, u10,&
        v10, smstot, hbot, htop, cnvcfr
   use masks, only: gdlat, gdlon, sm, lmh, sice
@@ -1656,18 +1657,31 @@
                              atmosphere(1)%cloud(3)%water_content(k)=max(0.,qqr(i,j,k)*dpovg)
                              atmosphere(1)%cloud(4)%water_content(k)=max(0.,qqs(i,j,k)*dpovg)
                              atmosphere(1)%cloud(5)%water_content(k)=max(0.,qqg(i,j,k)*dpovg)
-                             atmosphere(1)%cloud(1)%effective_radius(k)=effr(pmid(i,j,k),t(i,j,k), &
-                             q(i,j,k),qqw(i,j,k),qqi(i,j,k),qqr(i,j,k),f_rimef(i,j,k),nlice(i,j,k), &
-                             nrain(i,j,k),qqs(i,j,k),qqg(i,j,k),qqnr(i,j,k),qqni(i,j,k),qqnw(i,j,k),imp_physics,'C')
-                             atmosphere(1)%cloud(2)%effective_radius(k)=effr(pmid(i,j,k),t(i,j,k), &
-                             q(i,j,k),qqw(i,j,k),qqi(i,j,k),qqr(i,j,k),f_rimef(i,j,k),nlice(i,j,k), &
-                             nrain(i,j,k),qqs(i,j,k),qqg(i,j,k),qqnr(i,j,k),qqni(i,j,k),qqnw(i,j,k),imp_physics,'I')
+!                            use the effective radii output directly by the model where possible
+                             if(effrl(i,j,k)/=spval)then
+                              atmosphere(1)%cloud(1)%effective_radius(k)=min(max(effrl(i,j,k),2.5),50.)
+                             else
+                              atmosphere(1)%cloud(1)%effective_radius(k)=effr(pmid(i,j,k),t(i,j,k), &
+                              q(i,j,k),qqw(i,j,k),qqi(i,j,k),qqr(i,j,k),f_rimef(i,j,k),nlice(i,j,k), &
+                              nrain(i,j,k),qqs(i,j,k),qqg(i,j,k),qqnr(i,j,k),qqni(i,j,k),qqnw(i,j,k),imp_physics,'C')
+                             endif
+                             if(effri(i,j,k)/=spval)then
+                              atmosphere(1)%cloud(2)%effective_radius(k)=min(max(effri(i,j,k),2.5),125.)
+                             else
+                              atmosphere(1)%cloud(2)%effective_radius(k)=effr(pmid(i,j,k),t(i,j,k), &
+                              q(i,j,k),qqw(i,j,k),qqi(i,j,k),qqr(i,j,k),f_rimef(i,j,k),nlice(i,j,k), &
+                              nrain(i,j,k),qqs(i,j,k),qqg(i,j,k),qqnr(i,j,k),qqni(i,j,k),qqnw(i,j,k),imp_physics,'I')
+                             endif
+                             if(effrs(i,j,k)/=spval)then
+                              atmosphere(1)%cloud(4)%effective_radius(k)=min(max(effrs(i,j,k),2.5),1000.)
+                             else
+                              atmosphere(1)%cloud(4)%effective_radius(k)=effr(pmid(i,j,k),t(i,j,k), &
+                              q(i,j,k),qqw(i,j,k),qqi(i,j,k),qqr(i,j,k),f_rimef(i,j,k),nlice(i,j,k), &
+                              nrain(i,j,k),qqs(i,j,k),qqg(i,j,k),qqnr(i,j,k),qqni(i,j,k),qqnw(i,j,k),imp_physics,'S')
+                             endif
                              atmosphere(1)%cloud(3)%effective_radius(k)=effr(pmid(i,j,k),t(i,j,k), &
                              q(i,j,k),qqw(i,j,k),qqi(i,j,k),qqr(i,j,k),f_rimef(i,j,k),nlice(i,j,k), &
                              nrain(i,j,k),qqs(i,j,k),qqg(i,j,k),qqnr(i,j,k),qqni(i,j,k),qqnw(i,j,k),imp_physics,'R')
-                             atmosphere(1)%cloud(4)%effective_radius(k)=effr(pmid(i,j,k),t(i,j,k), &
-                             q(i,j,k),qqw(i,j,k),qqi(i,j,k),qqr(i,j,k),f_rimef(i,j,k),nlice(i,j,k), &
-                             nrain(i,j,k),qqs(i,j,k),qqg(i,j,k),qqnr(i,j,k),qqni(i,j,k),qqnw(i,j,k),imp_physics,'S')
                              atmosphere(1)%cloud(5)%effective_radius(k)=effr(pmid(i,j,k),t(i,j,k), &
                              q(i,j,k),qqw(i,j,k),qqi(i,j,k),qqr(i,j,k),f_rimef(i,j,k),nlice(i,j,k), &
                              nrain(i,j,k),qqs(i,j,k),qqg(i,j,k),qqnr(i,j,k),qqni(i,j,k),qqnw(i,j,k),imp_physics,'G')
@@ -1721,7 +1735,7 @@
                           if(i==ii.and.j==jj) then
                              do n=1,channelinfo(sensorindex)%n_channels
  3303                           format('Sample rtsolution(',I0,',',I0,') in CALRAD = ',F0.3)
-                                print 3303,n,1,rtsolution(n,1)%brightness_temperature
+!                               print 3303,n,1,rtsolution(n,1)%brightness_temperature
                              enddo
                              do n=1,channelinfo(sensorindex)%n_channels
  3304                           format('Sample tb(',I0,',',I0,',',I0,') in CALRAD = ',F0.3)

--- a/sorc/ncep_post.fd/DEALLOCATE.f
+++ b/sorc/ncep_post.fd/DEALLOCATE.f
@@ -10,6 +10,7 @@
 !> 2001-10-25 | H Chuang     | Modified to process hybrid model output
 !> 2002-06-19 | Mike Baldwin | WRF version
 !> 2022-11-08 | Kai Wang     | Replace aqfcmaq_on with aqf_on
+!> 2023-03-22 | WM Lewis     | Add effective radius arrays
 !>
 !> @author Jim Tuccillo IBM @date 2000-01-06
       SUBROUTINE DE_ALLOCATE
@@ -84,6 +85,9 @@
       deallocate(EXTCOF55)
       deallocate(QC_BL)
       deallocate(CFR)
+      deallocate(EFFRI)
+      deallocate(EFFRL)
+      deallocate(EFFRS)
       deallocate(CFR_RAW)
       deallocate(DBZ)
       deallocate(DBZR)

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -30,6 +30,7 @@
 !> 2023-01-30 | Sam Trahan    | Read cldfra or cldfra_bl, whichever is available
 !> 2023-02-23 | Eric James    | Read coarse PM and aodtot from RRFS
 !> 2023-03-02 | Sam Trahan    | Read lightning threat index fields
+!> 2023-03-22 | WM Lewis      | Read RRFS effective radii (EFFRL, EFFRI, EFFRS)
 !>
 !> @author Hui-Ya Chuang @date 2016-03-04
       SUBROUTINE INITPOST_NETCDF(ncid2d,ncid3d)
@@ -45,7 +46,8 @@
               vdiffmacce, mgdrag, cnvctvmmixing, ncnvctcfrac, cnvctumflx, cnvctdmflx,           &
               cnvctzgdrag, sconvmois, cnvctmgdrag, cnvctdetmflx, duwt, duem, dusd, dudp,        &
               dusv,ssem,sssd,ssdp,sswt,sssv,bcem,bcsd,bcdp,bcwt,bcsv,ocem,ocsd,ocdp,ocwt,ocsv, &
-              wh, qqg, ref_10cm, qqnifa, qqnwfa, avgpmtf, avgozcon, aextc55, taod5503d
+              wh, qqg, ref_10cm, qqnifa, qqnwfa, avgpmtf, avgozcon, aextc55, taod5503d,         &
+              effri, effrl, effrs
 
       use vrbls2d, only: f, pd, fis, pblh, ustar, z0, ths, qs, twbs, qwbs, avgcprate,           &
               cprate, avgprec, prec, lspa, sno, sndepac, si, cldefi, th10, q10, tshltr, pshltr, &
@@ -919,6 +921,21 @@
 !       if(debugprint)print*,'sample ',VarName,'isa,jsa,l =' &
 !          ,cfr(isa,jsa,l),isa,jsa,l
 !      enddo
+
+!     WL add cieffr for Thompson scheme cloud ice effective radius
+      VarName='cieffr'
+      call read_netcdf_3d_para(ncid2d,im,jm,ista,ista_2l,iend,iend_2u,jsta,jsta_2l,jend,jend_2u, &
+      spval,VarName,effri(ista_2l,jsta_2l,1),lm)
+
+!     WL add cleffr for Thompson scheme cloud water effective radius
+      VarName='cleffr'
+      call read_netcdf_3d_para(ncid2d,im,jm,ista,ista_2l,iend,iend_2u,jsta,jsta_2l,jend,jend_2u, &
+      spval,VarName,effrl(ista_2l,jsta_2l,1),lm)
+
+!     WL add cseffr for Thompson scheme snow effective radius
+      VarName='cseffr'
+      call read_netcdf_3d_para(ncid2d,im,jm,ista,ista_2l,iend,iend_2u,jsta,jsta_2l,jend,jend_2u, &
+      spval,VarName,effrs(ista_2l,jsta_2l,1),lm)
 
 !=====================================
 ! For AQF Hourly average field PM2.5

--- a/sorc/ncep_post.fd/MPI_FIRST.f
+++ b/sorc/ncep_post.fd/MPI_FIRST.f
@@ -15,6 +15,7 @@
 !!   12-01-07  SARAH LU - MODIFIED TO INITIALIZE AIR DENSITY/LAYER THICKNESS
 !!   21-07-07  JESSE MENG - 2D DECOMPOSITION
 !!   22-09-22  Li(Kate) Zhang - Add new aerosols fields for UFS-Aerosols
+!!   23-03-22  WM LEWIS: ADDED EFFRI, EFFRS, EFFRL
 !!
 !! USAGE:    CALL MPI_FIRST
 !!   INPUT ARGUMENT LIST:
@@ -49,7 +50,8 @@
               mgdrag, cnvctvmmixing, ncnvctcfrac, cnvctumflx, cnvctdmflx, cnvctdetmflx,&
               cnvctzgdrag, cnvctmgdrag, icing_gfip, asy, ssa, duem, dusd, dudp,        &
               duwt, suem, susd, sudp, suwt, ocem, ocsd, ocdp, ocwt, bcem, bcsd,        &
-              bcdp, bcwt, ssem, sssd, ssdp, sswt, ext, dpres, rhomid
+              bcdp, bcwt, ssem, sssd, ssdp, sswt, ext, dpres, rhomid, effri, effrl,    &
+              effrs
       use vrbls2d, only: wspd10max, w_up_max, w_dn_max, w_mean, refd_max, up_heli_max, &
               prate_max, fprate_max, swupt,                                            &
               up_heli_max16, grpl_max, up_heli, up_heli16, ltg1_max, ltg2_max,         &

--- a/sorc/ncep_post.fd/VRBLS3D_mod.f
+++ b/sorc/ncep_post.fd/VRBLS3D_mod.f
@@ -4,6 +4,7 @@
 !   11-12-15  SARAH LU - MODIFIED TO INCLUDE AEROSOL DIAG FIELDS
 !   12-01-06  SARAH LU - MODIFIED TO INCLUDE AIR DENSITY AND LAYER THICKNESS
 !   15-07-02  SARAH LU - MODIFIED TO INCLUDE SCATTERING AEROSOL OPTICAL THICKNESS
+!   23-03-22  WM LEWIS - ADDED EFFECTIVE RADIUS ARRAYS
       module vrbls3d
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
        implicit none
@@ -22,7 +23,7 @@
       ,EXCH_H(:,:,:),TRAIN(:,:,:),TCUCN(:,:,:),EL_PBL(:,:,:)         &
       ,MCVG(:,:,:),EXTCOF55(:,:,:),NLICE(:,:,:),CFR_RAW(:,:,:)       &
 !! Wm Lewis: added
-      ,NRAIN(:,:,:)                                                  &
+      ,NRAIN(:,:,:),EFFRI(:,:,:), EFFRL(:,:,:), EFFRS(:,:,:)         &
       ,radius_cloud(:,:,:),radius_ice(:,:,:),radius_snow(:,:,:)      &
 ! KRS Add HWRF fields     
       ,REFL_10CM(:,:,:)             &


### PR DESCRIPTION
This PR allows reading in the effective radii variables from RRFS, which are used in the calculation of GOES simulated brightness temperatures.  

There are no additional output variables, so no changes to the XML files are needed.  The new code slightly changes the output for the GOES simulated brightness temperature variables.  

The code was tested for the RRFS_CONUS_3km system on Jet.  The code was developed by Will Lewis (Univ of Wisconsin).