### PR TITLE
Update to EPIC hpc-stack location

### DIFF
--- a/modulefiles/hera.lua
+++ b/modulefiles/hera.lua
@@ -5,9 +5,9 @@ Load environment to build post on hera
 cmake_ver=os.getenv("cmake_ver") or "3.20.1"
 load(pathJoin("cmake", cmake_ver))
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/modulefiles/stack")
 
-hpc_ver=os.getenv("hpc_ver") or "1.1.0"
+hpc_ver=os.getenv("hpc_ver") or "1.2.0"
 load(pathJoin("hpc", hpc_ver))
 
 hpc_intel_ver=os.getenv("hpc_intel_ver") or "2022.1.2"

--- a/modulefiles/orion.lua
+++ b/modulefiles/orion.lua
@@ -5,7 +5,7 @@ Load environment to build post on orion
 cmake_ver=os.getenv("cmake_ver") or "3.22.1"
 load(pathJoin("cmake", cmake_ver))
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/work/noaa/epic-ps/role-epic-ps/hpc-stack/libs/intel-2022.1.2/modulefiles/stack")
 
 hpc_ver=os.getenv("hpc_ver") or "1.2.0"
 load(pathJoin("hpc", hpc_ver))


### PR DESCRIPTION
This PR updates the hpc-stack locations to the EPIC locations used in the UFS WM on Hera and Orion.

Related to #660

Regression tests have passed on Hera and Orion with no changes to results