### PR TITLE
GSL precip type fix

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,7 +9,7 @@ defaults:
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel2  # The number (#) following the cache_key "intel" is to flush Action cache.
+  cache_key: intel3  # The number (#) following the cache_key "intel" is to flush Action cache.
   CC: icc
   FC: ifort
   CXX: icpc
@@ -45,7 +45,7 @@ jobs:
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             spack

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             spack

--- a/parm/fv3lam_rrfs.xml
+++ b/parm/fv3lam_rrfs.xml
@@ -2416,28 +2416,28 @@
        </param>
 
        <param>
-       <shortname>INST_CRAIN_ON_SURFACE</shortname>
+       <shortname>GSD_INST_CRAIN_ON_SURFACE</shortname>
        <pname>CRAIN</pname>
        <table_info>NCEP</table_info>
         <scale>1.0</scale>
        </param>
 
        <param>
-       <shortname>CSNOW_ON_SURFACE</shortname>
+       <shortname>GSD_CSNOW_ON_SURFACE</shortname>
        <pname>CSNOW</pname>
        <table_info>NCEP</table_info>
        <scale>1.0</scale>
         </param>
 
        <param>
-       <shortname>CICEP_ON_SURFACE</shortname>
+       <shortname>GSD_CICEP_ON_SURFACE</shortname>
        <pname>CICEP</pname>
        <table_info>NCEP</table_info>
        <scale>1.0</scale>
         </param>
 
        <param>
-       <shortname>CFRZR_ON_SURFACE</shortname>
+       <shortname>GSD_CFRZR_ON_SURFACE</shortname>
        <pname>CFRZR</pname>
        <table_info>NCEP</table_info>
        <scale>1.0</scale>

--- a/parm/postxconfig-NT-fv3lam_rrfs.txt
+++ b/parm/postxconfig-NT-fv3lam_rrfs.txt
@@ -13132,9 +13132,9 @@ surface
 ?
 ?
 ?
-160
-INST_CRAIN_ON_SURFACE
-?
+407
+GSD_INST_CRAIN_ON_SURFACE
+GSD_instant precipitation type on surface
 1
 tmpl4_0
 CRAIN
@@ -13169,9 +13169,9 @@ surface
 ?
 ?
 ?
-551
-CSNOW_ON_SURFACE
-Categorical snow on surface
+559
+GSD_CSNOW_ON_SURFACE
+GSD_Categorical snow on surface
 1
 tmpl4_0
 CSNOW
@@ -13206,9 +13206,9 @@ surface
 ?
 ?
 ?
-552
-CICEP_ON_SURFACE
-Categorical ice pellets on surface
+560
+GSD_CICEP_ON_SURFACE
+GSD_Categorical ice pellets on surface
 1
 tmpl4_0
 CICEP
@@ -13243,9 +13243,9 @@ surface
 ?
 ?
 ?
-553
-CFRZR_ON_SURFACE
-Categorical freezing rain on surface
+561
+GSD_CFRZR_ON_SURFACE
+GSD_Categorical freezing rain on surface
 1
 tmpl4_0
 CFRZR

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -42,6 +42,7 @@
 !> 2023-03-22 | S Trahan   | Fixed out-of-bounds access calling BOUND with wrong array dimensions
 !> 2023-04-21 | E James    | Enabling GSL precip type for RRFS
 !> 2023-05-19 | E James    | Cleaning up GRIB2 encoding for 1-h max precip rate
+!> 2023-06-15 | E James    | Correcting bug fix in GSL precip type for RRFS (use 1h pcp, not run total pcp)
 !>     
 !> @note
 !> USAGE:    CALL SURFCE

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -5137,7 +5137,9 @@
            DO J=JSTA,JEND
              DO I=ISTA,IEND
 !-- TOTPRCP is total 1-hour accumulated precipitation in  [m]
-               totprcp = (AVGPREC_CONT(I,J)*FLOAT(IFHR)*3600./DTQ2)
+!-- RAP/HRRR and RRFS use 1-h bucket. GFS uses 3-h bucket
+!-- so this section will need to be revised for GFS
+               totprcp = (AVGPREC(I,J)*3600.*1000./DTQ2)
                snowratio = 0.0
                if(graup_bucket(i,j)*1.e-3 > totprcp.and.graup_bucket(i,j)/=spval)then
                  print *,'WARNING - Graupel is higher that total precip at point',i,j


### PR DESCRIPTION
Correcting GSL precip type diagnosis to use 1-h precip instead of run total precip for RRFS.  

The code was tested for RRFS_3km_CONUS system on Jet.  