### PR TITLE
Bugfix on `-prefix` and build flexibility for UPP.

### DIFF
--- a/tests/compile_upp.sh
+++ b/tests/compile_upp.sh
@@ -63,13 +63,13 @@ while getopts ":p:gwc:vhiId" opt; do
 done
 cmake_opts=" -DCMAKE_INSTALL_PREFIX=$prefix"${wrfio_opt}${gtg_opt}${ifi_opt}${debug_opt}
 
-source ./detect_machine.sh
 if [[ $(uname -s) == Darwin ]]; then
   readonly MYDIR=$(cd "$(dirname "$(greadlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 else
   readonly MYDIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 fi
 PATHTR=${PATHTR:-$( cd ${MYDIR}/.. && pwd )}
+source ${PATHTR}/tests/detect_machine.sh
 
 #Load required modulefiles
 if [[ $MACHINE_ID != "unknown" ]]; then
@@ -94,11 +94,12 @@ if [[ $MACHINE_ID != "unknown" ]]; then
    module list
 fi
 
-rm -rf build install
-mkdir build && cd build
-cmake $cmake_opts ../..
-make -j6 $verbose_opt 
+BUILD_DIR=${BUILD_DIR:-"build"}
+rm -rf ${BUILD_DIR} install
+mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
+cmake $cmake_opts ${PATHTR}
+make -j${BUILD_JOBS:-6} $verbose_opt
 make install
 
-rm -rf $PATHTR/exec && mkdir $PATHTR/exec
-cp $PATHTR/tests/install/bin/upp.x $PATHTR/exec/.
+rm -rf $PATHTR/exec && mkdir -p $PATHTR/exec
+cp $prefix/bin/upp.x $PATHTR/exec/.


### PR DESCRIPTION
This PR:
- corrects a bug when `-prefix` is provided with `compile.sh`, the executable is not placed in the right directory
- allows user to specify a `build` directory rather than hard-wiring it in the repo source.
- allows user to call `compile.sh` from anywhere.  This is used in the GFS and GEFS applications
- does not alter the default behavior of `compile.sh`.  

Fixes #747 #748 