### PR TITLE
Update modulefile for wcoss2, hera and orion with crtm/2.4.0.1

### DIFF
--- a/modulefiles/post/post_hera.lua
+++ b/modulefiles/post/post_hera.lua
@@ -38,7 +38,7 @@ ip_ver=os.getenv("ip_ver") or "3.3.3"
 load(pathJoin("ip", ip_ver))
 sp_ver=os.getenv("sp_ver") or "2.3.3"
 load(pathJoin("sp", sp_ver))
-crtm_ver=os.getenv("crtm_ver") or "2.4.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 load(pathJoin("crtm", crtm_ver))
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("w3emc", w3emc_ver))

--- a/modulefiles/post/post_orion.lua
+++ b/modulefiles/post/post_orion.lua
@@ -38,7 +38,7 @@ ip_ver=os.getenv("ip_ver") or "3.3.3"
 load(pathJoin("ip", ip_ver))
 sp_ver=os.getenv("sp_ver") or "2.3.3"
 load(pathJoin("sp", sp_ver))
-crtm_ver=os.getenv("crtm_ver") or "2.4.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 load(pathJoin("crtm", crtm_ver))
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("w3emc", w3emc_ver))

--- a/modulefiles/post/post_wcoss2.lua
+++ b/modulefiles/post/post_wcoss2.lua
@@ -30,7 +30,7 @@ bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 gfsio_ver=os.getenv("gfsio_ver") or "1.4.1"
 ip_ver=os.getenv("ip_ver") or "3.3.3"
 sp_ver=os.getenv("sp_ver") or "2.3.3"
-crtm_ver=os.getenv("crtm_ver") or "2.4.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("g2", g2_ver))
 load(pathJoin("g2tmpl", g2tmpl_ver))

--- a/modulefiles/upp/upp_hera.lua
+++ b/modulefiles/upp/upp_hera.lua
@@ -33,7 +33,7 @@ gfsio_ver=os.getenv("gfsio_ver") or "1.4.1"
 load(pathJoin("gfsio", gfsio_ver))
 sp_ver=os.getenv("sp_ver") or "2.3.3"
 load(pathJoin("sp", sp_ver))
-crtm_ver=os.getenv("crtm_ver") or "2.4.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 load(pathJoin("crtm", crtm_ver))
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("w3emc", w3emc_ver))

--- a/modulefiles/upp/upp_orion.lua
+++ b/modulefiles/upp/upp_orion.lua
@@ -38,7 +38,7 @@ gfsio_ver=os.getenv("gfsio_ver") or "1.4.1"
 load(pathJoin("gfsio", gfsio_ver))
 sp_ver=os.getenv("sp_ver") or "2.3.3"
 load(pathJoin("sp", sp_ver))
-crtm_ver=os.getenv("crtm_ver") or "2.4.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 load(pathJoin("crtm", crtm_ver))
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("w3emc", w3emc_ver))

--- a/modulefiles/upp/upp_wcoss2.lua
+++ b/modulefiles/upp/upp_wcoss2.lua
@@ -30,7 +30,7 @@ bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 gfsio_ver=os.getenv("gfsio_ver") or "1.4.1"
 ip_ver=os.getenv("ip_ver") or "3.3.3"
 sp_ver=os.getenv("sp_ver") or "2.3.3"
-crtm_ver=os.getenv("crtm_ver") or "2.4.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 load(pathJoin("g2", g2_ver))
 load(pathJoin("g2tmpl", g2tmpl_ver))


### PR DESCRIPTION
Update the modulefile files for wcoss2, hera and orion with crtm/2.4.0.1.