### PR TITLE
EE2 compliance for AQMv7 for ufs-weather-model, adding -ftrapuv and -check all for DEBUG builds

### DIFF
--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -169,7 +169,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS
       "-g -traceback -fp-model source -free -convert big_endian")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -ftrapuv")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_Fortran_FLAGS
       "-g -fbacktrace -ffree-form -ffree-line-length-none -fconvert=big-endian")


### PR DESCRIPTION
This PR brings in build flags of `-ftrapuv` and `-check all` for DEBUG builds of UPP.

This helps AQM.v7 meet NCO EE2 compliance with the ufs-weather-model/fv3atm/upp code.

This new branch does differ from release/aqm_v7 as it pertains only to needs for ufs-weather-model/FV3/upp

- Closes #825 