### PR TITLE
RRFS IFI crash fix + debug mode change

### DIFF
--- a/tests/compile_upp.sh
+++ b/tests/compile_upp.sh
@@ -61,6 +61,14 @@ while getopts ":p:gwc:vhiId" opt; do
       ;;
   esac
 done
+
+if [[ ! -z $debug_opt && $ifi_opt =~ INTERNAL.*=ON ]] ; then
+    echo ENABLING IFI DEBUG
+    # When building debug mode with internal IFI, also enable debugging in IFI.
+    # This includes bounds checking in much of the libIFI C++ library.
+    debug_opt="$debug_opt -DIFI_DEBUG=ON"
+fi
+
 cmake_opts=" -DCMAKE_INSTALL_PREFIX=$prefix"${wrfio_opt}${gtg_opt}${ifi_opt}${debug_opt}
 
 if [[ $(uname -s) == Darwin ]]; then
@@ -112,6 +120,7 @@ if [[ $MACHINE_ID != "unknown" ]]; then
    module list
 fi
 
+set -x
 BUILD_DIR=${BUILD_DIR:-"build"}
 rm -rf ${BUILD_DIR} install
 mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}


### PR DESCRIPTION
This fixes the RRFS IFI crash, which was caused by incorrect error handling for extreme values of potential temperature. 

Also, it enables libIFI's own debug mode (-DIFI_DEBUG=ON) when UPP is built with inline IFI (-I) and debug (-d). That debug mode enables bounds checking and other safeguards. It also causes uncaught C++ exceptions to pass through to Fortran. That usually results in a stack trace or core dump to the point in the C++ library that raised the exception. (Without debug mode, C++ returns an integer error code to Fortran.)

- waiting on https://github.com/NCAR/UPP_IFI/pull/5
- fixes #850 