### PR TITLE
Update grib2 tables with g2tmpl v1.10.2 and change soil moisture grib2 name

### DIFF
--- a/parm/nam_cntrl_cmaq.xml
+++ b/parm/nam_cntrl_cmaq.xml
@@ -451,7 +451,7 @@
 
        <param>
        <shortname>SOILM_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <pname>SOILM</pname>
+       <pname>SOILMOI</pname>
        <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
        <level>0.</level>
        <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
@@ -2282,7 +2282,7 @@
 
        <param>
        <shortname>SOILM_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <pname>SOILM</pname>
+       <pname>SOILMOI</pname>
        <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
        <level>0.</level>
        <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
@@ -3793,7 +3793,7 @@
 
        <param>
        <shortname>SOILM_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <pname>SOILM</pname>
+       <pname>SOILMOI</pname>
        <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
        <level>0.</level>
        <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>

--- a/parm/nam_post_avblflds.xml
+++ b/parm/nam_post_avblflds.xml
@@ -297,7 +297,7 @@
     <param>
       <post_avblfldidx>36</post_avblfldidx>
       <shortname>SOILM_ON_DEPTH_BEL_LAND_SFC</shortname>
-      <pname>SOILM</pname>
+      <pname>SOILMOI</pname>
       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
       <fixed_sfc2_type>depth_bel_land_sfc</fixed_sfc2_type>

--- a/parm/ngac_post_avblflds.xml
+++ b/parm/ngac_post_avblflds.xml
@@ -299,7 +299,7 @@
     <param>
        <post_avblfldidx>36</post_avblfldidx>
        <shortname>SOILM_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <pname>SOILM</pname>
+       <pname>SOILMOI</pname>
        <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
     </param>

--- a/parm/params_grib2_tbl_new
+++ b/parm/params_grib2_tbl_new
@@ -936,7 +936,6 @@
    2   3     5   0 SOILL
    2   3   192   1 SOILL
    2   3    19   0 SOILMOI
-   2   0    22   0 SOILM
    2   3    15   0 SOILP
    2   0   239   1 SOILSE
    2   3    18   0 SOILTMP

--- a/parm/params_grib2_tbl_new.text
+++ b/parm/params_grib2_tbl_new.text
@@ -97,7 +97,7 @@
    0   1    19   0 PTYPE
    0   1    20   0 ILIQW
    0   1    21   0 TCOND
-!  Changed from CLWMR to CLWR 
+!  Changed from CLWMR to CLWR
 ! (WGRIB2 v2.0.8 updated) in 4/6/2021
    0   1    22   0 CLMR
    0   1    23   0 ICMR
@@ -953,6 +953,7 @@
    2   0     0   0 LAND
    2   0     1   0 SFCR
    2   0     2   0 TSOIL
+!  Parameter SOILM deprecated 12/03/2021
 !   2   0     3   0 SOILM
    2   0     4   0 VEG
    2   0     5   0 WATR
@@ -973,7 +974,8 @@
    2   0    19   0 RCT
    2   0    20   0 RCSOL
    2   0    21   0 RCQ
-   2   0    22   0 SOILM
+!  Parameter SOILD deprecated 12/03/2021
+!   2   0    22   0 SOILM
    2   0    23   0 CISOILW
    2   0    24   0 HFLUX
    2   0    25   0 VSOILM

--- a/parm/post_avblflds.xml
+++ b/parm/post_avblflds.xml
@@ -297,7 +297,7 @@
     <param>
        <post_avblfldidx>36</post_avblfldidx>
        <shortname>SOILM_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <pname>SOILM</pname>
+       <pname>SOILMOI</pname>
        <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
        <fixed_sfc2_type>depth_bel_land_sfc</fixed_sfc2_type>
        <scale>3.0</scale>

--- a/parm/post_avblflds_raphrrr.xml
+++ b/parm/post_avblflds_raphrrr.xml
@@ -311,7 +311,7 @@
     <param>
        <post_avblfldidx>36</post_avblfldidx>
        <shortname>SOILM_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <pname>SOILM</pname>
+       <pname>SOILMOI</pname>
        <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
        <scale>3.0</scale>
     </param>

--- a/parm/postxconfig-NT-GFS-F00-TWO.txt
+++ b/parm/postxconfig-NT-GFS-F00-TWO.txt
@@ -7475,7 +7475,7 @@ SOILM_ON_DEPTH_BEL_LAND_SFC
 ?
 1
 tmpl4_0
-SOILM
+SOILMOI
 ?
 ?
 depth_bel_land_sfc

--- a/parm/postxconfig-NT-GFS-FLUX-F00.txt
+++ b/parm/postxconfig-NT-GFS-FLUX-F00.txt
@@ -1686,7 +1686,7 @@ SOILM_ON_DEPTH_BEL_LAND_SFC
 ?
 1
 tmpl4_0
-SOILM
+SOILMOI
 ?
 ?
 depth_bel_land_sfc

--- a/parm/postxconfig-NT-GFS-FLUX.txt
+++ b/parm/postxconfig-NT-GFS-FLUX.txt
@@ -3832,7 +3832,7 @@ SOILM_ON_DEPTH_BEL_LAND_SFC
 ?
 1
 tmpl4_0
-SOILM
+SOILMOI
 ?
 ?
 depth_bel_land_sfc

--- a/parm/postxconfig-NT-GFS-TWO.txt
+++ b/parm/postxconfig-NT-GFS-TWO.txt
@@ -11619,7 +11619,7 @@ SOILM_ON_DEPTH_BEL_LAND_SFC
 ?
 1
 tmpl4_0
-SOILM
+SOILMOI
 ?
 ?
 depth_bel_land_sfc

--- a/parm/postxconfig-NT-NMM.txt
+++ b/parm/postxconfig-NT-NMM.txt
@@ -2169,7 +2169,7 @@ SOILM_ON_DEPTH_BEL_LAND_SFC
 ?
 1
 tmpl4_0
-SOILM
+SOILMOI
 ?
 ?
 depth_bel_land_sfc
@@ -11916,7 +11916,7 @@ SOILM_ON_DEPTH_BEL_LAND_SFC
 ?
 1
 tmpl4_0
-SOILM
+SOILMOI
 ?
 ?
 depth_bel_land_sfc
@@ -19850,7 +19850,7 @@ SOILM_ON_DEPTH_BEL_LAND_SFC
 ?
 1
 tmpl4_0
-SOILM
+SOILMOI
 ?
 ?
 depth_bel_land_sfc

--- a/parm/postxconfig-NT-rap.txt
+++ b/parm/postxconfig-NT-rap.txt
@@ -577,7 +577,7 @@ SOILM_ON_DEPTH_BEL_LAND_SFC
 ?
 1
 tmpl4_0
-SOILM
+SOILMOI
 ?
 ?
 depth_bel_land_sfc


### PR DESCRIPTION
The main changes are:

- Update grib2 tables in UPP with g2tmpl v1.10.2
- Change soil moisture grib2 name from 'SOILM' into 'SOILMOI'