### PR TITLE
fix missing reflectivity bug by adding nssl mp to MP options for refl

### DIFF
--- a/sorc/ncep_post.fd/MDLFLD.f
+++ b/sorc/ncep_post.fd/MDLFLD.f
@@ -587,7 +587,7 @@ refl_adj:           IF(REF_10CM(I,J,L)<=DBZmin) THEN
 
       ELSE IF(((MODELNAME == 'NMM' .and. GRIDTYPE=='B') .OR. MODELNAME == 'FV3R' &
         .OR. MODELNAME == 'GFS') &
-        .and. imp_physics==8)THEN !NMMB or FV3R or GFS +THOMPSON
+        .and. (imp_physics==8 .or. imp_physics==17 .or. imp_physics==18))THEN !NMMB or FV3R or GFS +THOMPSON
        DO L=1,LM
         DO J=JSTA,JEND
          DO I=ista,iend


### PR DESCRIPTION
This PR will fix the missing reflectivity bug when using NSSL MP by adding nssl mp to microphysics options when assigning model reflectivity. 