### PR TITLE
Updates to the GSL exp1 ceiling diagnostic

### DIFF
--- a/tests/logs/rt.log.HERA
+++ b/tests/logs/rt.log.HERA
@@ -1,69 +1,73 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-80626206f72dc6051afa502a10d27691308aea3c
+4d3a0c7f526b12dcfc15f12f8d867960361449f7
 
 Submodule hashes:
--1ba8270870947b583cd51bc72ff8960f4c1fb36e ../sorc/libIFI.fd
--7476b8f2790a47d788f79cebfdbb551567ae7cf8 ../sorc/ncep_post.fd/post_gtg.fd
+-1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
+-7476b8f2790a47d788f79cebfdbb551567ae7cf8 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/941/UPP/ci/rundir/upp-HERA
+Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/947/UPP/ci/rundir/upp-HERA
 Baseline directory: /scratch2/NAGAPE/epic/UPP/test_suite
 
-Total runtime: 00h:15m:36s
-Test Date: 20240501 16:11:45
+Total runtime: 00h:15m:47s
+Test Date: 20240502 15:35:02
 Summary Results:
 
-05/01 16:09:05Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/01 16:09:07Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/01 16:09:21Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/01 16:09:27Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/01 16:09:53Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/01 16:09:54Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/01 16:10:04Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/01 16:10:06Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/01 16:10:07Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/01 16:10:09Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/01 16:10:11Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/01 16:10:11Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/01 16:10:12Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/01 16:10:12Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/01 16:10:17Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/01 16:10:20Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/01 16:10:22Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/01 16:10:24Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/01 16:10:24Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/01 16:10:25Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/01 16:10:25Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/01 16:10:29Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/01 16:10:29Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/01 16:10:29Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/01 16:10:49Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/01 16:10:50Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/01 16:10:53Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/01 16:10:59Z gfs_post_00.1144644-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/01 16:10:59Z gfs_post_00.1144644-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/01 16:11:00Z gfs_post_00.1144644-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/01 16:11:11Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/01 16:11:12Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/01 16:11:14Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/01 16:11:34Z gfs_post_00.3917834-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/01 16:11:34Z gfs_post_00.3917834-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/01 16:11:35Z gfs_post_00.3917834-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/01 16:10:24Z -Runtime: nmmb_test 00:01:17 -- baseline 00:01:00
-05/01 16:10:24Z -Runtime: nmmb_pe_test 00:01:12 -- baseline 00:01:00
-05/01 16:10:25Z -Runtime: fv3gefs_test 00:00:17 -- baseline 00:40:00
-05/01 16:10:25Z -Runtime: fv3gefs_pe_test 00:00:22 -- baseline 00:40:00
-05/01 16:10:25Z -Runtime: rap_test 00:01:07 -- baseline 00:02:00
-05/01 16:10:26Z -Runtime: rap_pe_test 00:01:22 -- baseline 00:02:00
-05/01 16:11:26Z -Runtime: hrrr_test 00:02:27 -- baseline 00:02:00
-05/01 16:11:27Z -Runtime: hrrr_pe_test 00:02:10 -- baseline 00:02:00
-05/01 16:11:27Z -Runtime: fv3gfs_test 00:11:37 -- baseline 00:15:00
-05/01 16:11:43Z -Runtime: fv3gfs_pe_test 00:12:12 -- baseline 00:15:00
-05/01 16:11:43Z -Runtime: fv3r_test 00:01:43 -- baseline 00:03:00
-05/01 16:11:43Z -Runtime: fv3r_pe_test 00:01:46 -- baseline 00:03:00
-05/01 16:11:44Z -Runtime: fv3hafs_test 00:00:38 -- baseline 00:03:00
-05/01 16:11:44Z -Runtime: fv3hafs_pe_test 00:00:37 -- baseline 00:03:00
-05/01 16:11:44Z -Runtime: rtma_test 00:01:50 -- baseline 00:03:00
-05/01 16:11:45Z -Runtime: rtma_test_pe_test 00:01:50 -- baseline 
-No changes in test results detected.
+05/02 15:31:52Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/02 15:32:05Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/02 15:32:06Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/02 15:32:17Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/02 15:32:30Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+05/02 15:32:31Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/02 15:32:48Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+05/02 15:32:49Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/02 15:32:50Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/02 15:32:52Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/02 15:32:52Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/02 15:32:55Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/02 15:32:57Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/02 15:32:57Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/02 15:33:11Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/02 15:33:18Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/02 15:33:36Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/02 15:33:37Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/02 15:33:39Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/02 15:33:41Z gfs_post_00.2929924-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/02 15:33:42Z gfs_post_00.2929924-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/02 15:33:42Z gfs_post_00.2929924-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/02 15:33:59Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/02 15:34:00Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/02 15:34:01Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/02 15:34:07Z gfs_post_00.2880188-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/02 15:34:07Z gfs_post_00.2880188-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/02 15:34:07Z gfs_post_00.2880188-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/02 15:34:43Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
+05/02 15:34:48Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
+05/02 15:34:49Z -rtma pe test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
+05/02 15:34:49Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/02 15:34:49Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/02 15:34:52Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/02 15:34:55Z -rtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
+05/02 15:34:56Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/02 15:33:11Z -Runtime: nmmb_test 00:01:30 -- baseline 00:01:00
+05/02 15:33:11Z -Runtime: nmmb_pe_test 00:01:25 -- baseline 00:01:00
+05/02 15:33:12Z -Runtime: fv3gefs_test 00:00:50 -- baseline 00:40:00
+05/02 15:33:12Z -Runtime: fv3gefs_pe_test 00:00:25 -- baseline 00:40:00
+05/02 15:33:12Z -Runtime: rap_test 00:01:04 -- baseline 00:02:00
+05/02 15:33:13Z -Runtime: rap_pe_test 00:01:22 -- baseline 00:02:00
+05/02 15:34:13Z -Runtime: hrrr_test 00:02:34 -- baseline 00:02:00
+05/02 15:34:14Z -Runtime: hrrr_pe_test 00:02:12 -- baseline 00:02:00
+05/02 15:34:14Z -Runtime: fv3gfs_test 00:11:12 -- baseline 00:15:00
+05/02 15:34:14Z -Runtime: fv3gfs_pe_test 00:11:47 -- baseline 00:15:00
+05/02 15:35:00Z -Runtime: fv3r_test 00:03:22 -- baseline 00:03:00
+05/02 15:35:00Z -Runtime: fv3r_pe_test 00:03:25 -- baseline 00:03:00
+05/02 15:35:01Z -Runtime: fv3hafs_test 00:00:38 -- baseline 00:03:00
+05/02 15:35:01Z -Runtime: fv3hafs_pe_test 00:00:39 -- baseline 00:03:00
+05/02 15:35:01Z -Runtime: rtma_test 00:03:29 -- baseline 00:03:00
+05/02 15:35:02Z -Runtime: rtma_test_pe_test 00:03:22 -- baseline 
+There are changes in results for case fv3r_pe_test in PRSLEV10.tm00
+There are changes in results for case fv3r in PRSLEV10.tm00
+There are changes in results for case rtma_pe_test in PRSLEV00.tm00
+There are changes in results for case rtma in PRSLEV00.tm00
+Refer to .diff files in rundir: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/947/UPP/ci/rundir/upp-HERA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.HERCULES
+++ b/tests/logs/rt.log.HERCULES
@@ -1,69 +1,73 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-83792dd6842a841262e012e230024a7a261d018d
+4d3a0c7f526b12dcfc15f12f8d867960361449f7
 
 Submodule hashes:
--1ba8270870947b583cd51bc72ff8960f4c1fb36e ../sorc/libIFI.fd
--7476b8f2790a47d788f79cebfdbb551567ae7cf8 ../sorc/ncep_post.fd/post_gtg.fd
+-1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
+-7476b8f2790a47d788f79cebfdbb551567ae7cf8 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/hercules/941/UPP/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/hercules/947/UPP/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:26m:55s
-Test Date: 20240501 15:19:33
+Total runtime: 00h:21m:46s
+Test Date: 20240502 10:43:18
 Summary Results:
 
-05/01 19:58:27Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/01 19:58:28Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/01 19:58:28Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/01 19:58:35Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/01 19:58:36Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/01 19:58:36Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/01 19:59:15Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/01 19:59:22Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/01 19:59:50Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/01 19:59:51Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/01 19:59:54Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/01 19:59:54Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/01 20:00:44Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/01 20:00:44Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/01 20:00:45Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/01 20:00:46Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/01 20:00:47Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/01 20:00:57Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/01 20:00:59Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/01 20:01:21Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/01 20:01:22Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/01 20:01:23Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/01 20:01:24Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/01 20:01:24Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/01 20:01:24Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/01 20:02:07Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/01 20:02:08Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/01 20:05:02Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/01 20:05:03Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/01 20:05:04Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/01 20:14:46Z gfs_post_00.896623-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/01 20:14:47Z gfs_post_00.896623-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/01 20:14:47Z gfs_post_00.896623-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/01 20:19:17Z gfs_post_00.896618-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/01 20:19:17Z gfs_post_00.896618-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/01 20:19:17Z gfs_post_00.896618-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/01 19:58:38Z -Runtime: nmmb_test 00:01:30 -- baseline 00:03:00
-05/01 19:58:38Z -Runtime: nmmb_pe_test 00:01:22 -- baseline 00:03:00
-05/01 19:59:24Z -Runtime: fv3gefs_test 00:00:20 -- baseline 01:20:00
-05/01 19:59:24Z -Runtime: fv3gefs_pe_test 00:00:27 -- baseline 01:20:00
-05/01 19:59:54Z -Runtime: rap_test 00:00:56 -- baseline 00:02:00
-05/01 20:00:09Z -Runtime: rap_pe_test 00:00:59 -- baseline 00:02:00
-05/01 20:05:10Z -Runtime: hrrr_test 00:06:09 -- baseline 00:02:00
-05/01 20:05:11Z -Runtime: hrrr_pe_test 00:01:51 -- baseline 00:02:00
-05/01 20:19:29Z -Runtime: fv3gfs_test 00:20:23 -- baseline 00:18:00
-05/01 20:19:29Z -Runtime: fv3gfs_pe_test 00:15:52 -- baseline 00:18:00
-05/01 20:19:29Z -Runtime: fv3r_test 00:01:52 -- baseline 00:03:00
-05/01 20:19:29Z -Runtime: fv3r_pe_test 00:02:04 -- baseline 00:03:00
-05/01 20:19:29Z -Runtime: fv3hafs_test 00:00:36 -- baseline 00:00:40
-05/01 20:19:30Z -Runtime: fv3hafs_pe_test 00:00:36 -- baseline 00:00:40
-05/01 20:19:30Z -Runtime: rtma_test 00:02:29 -- baseline 00:04:00
-05/01 20:19:30Z -Runtime: rtma_pe_test 00:02:29 -- baseline 00:04:00
-No changes in test results detected.
+05/02 15:24:03Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/02 15:24:08Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/02 15:24:19Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/02 15:24:19Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/02 15:24:37Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+05/02 15:24:38Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/02 15:24:41Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+05/02 15:24:42Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/02 15:25:01Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/02 15:25:02Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/02 15:25:02Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/02 15:25:08Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/02 15:25:09Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/02 15:25:09Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/02 15:25:25Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/02 15:25:26Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/02 15:25:27Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/02 15:26:07Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/02 15:26:07Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/02 15:27:06Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
+05/02 15:27:09Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/02 15:27:13Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
+05/02 15:27:15Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/02 15:27:36Z -rtma pe test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
+05/02 15:27:36Z -rtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
+05/02 15:27:36Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/02 15:27:36Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/02 15:29:40Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/02 15:29:42Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/02 15:29:43Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/02 15:39:33Z gfs_post_00.478923-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/02 15:39:33Z gfs_post_00.478923-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/02 15:39:34Z gfs_post_00.478923-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/02 15:43:07Z gfs_post_00.563149-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/02 15:43:08Z gfs_post_00.563149-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/02 15:43:08Z gfs_post_00.563149-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/02 15:25:14Z -Runtime: nmmb_test 00:01:25 -- baseline 00:03:00
+05/02 15:25:14Z -Runtime: nmmb_pe_test 00:01:18 -- baseline 00:03:00
+05/02 15:25:14Z -Runtime: fv3gefs_test 00:00:19 -- baseline 01:20:00
+05/02 15:25:14Z -Runtime: fv3gefs_pe_test 00:00:24 -- baseline 01:20:00
+05/02 15:25:14Z -Runtime: rap_test 00:00:54 -- baseline 00:02:00
+05/02 15:25:14Z -Runtime: rap_pe_test 00:00:58 -- baseline 00:02:00
+05/02 15:29:45Z -Runtime: hrrr_test 00:05:59 -- baseline 00:02:00
+05/02 15:29:45Z -Runtime: hrrr_pe_test 00:01:43 -- baseline 00:02:00
+05/02 15:43:16Z -Runtime: fv3gfs_test 00:19:24 -- baseline 00:18:00
+05/02 15:43:16Z -Runtime: fv3gfs_pe_test 00:15:50 -- baseline 00:18:00
+05/02 15:43:16Z -Runtime: fv3r_test 00:03:25 -- baseline 00:03:00
+05/02 15:43:16Z -Runtime: fv3r_pe_test 00:03:31 -- baseline 00:03:00
+05/02 15:43:16Z -Runtime: fv3hafs_test 00:00:32 -- baseline 00:00:40
+05/02 15:43:16Z -Runtime: fv3hafs_pe_test 00:00:32 -- baseline 00:00:40
+05/02 15:43:16Z -Runtime: rtma_test 00:03:49 -- baseline 00:04:00
+05/02 15:43:16Z -Runtime: rtma_pe_test 00:03:49 -- baseline 00:04:00
+There are changes in results for case rtma in PRSLEV00.tm00
+There are changes in results for case fv3r in PRSLEV10.tm00
+There are changes in results for case fv3r_pe_test in PRSLEV10.tm00
+There are changes in results for case rtma_pe_test in PRSLEV00.tm00
+Refer to .diff files in rundir: /work2/noaa/epic/nandoam/regression-testing/upp/hercules/947/UPP/ci/rundir/upp-HERCULES for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION
+++ b/tests/logs/rt.log.ORION
@@ -1,69 +1,73 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-61edb5a1e1987a1927d6c7864a8b4bc5461c8764
+4d3a0c7f526b12dcfc15f12f8d867960361449f7
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -7476b8f2790a47d788f79cebfdbb551567ae7cf8 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/orion/941/UPP/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/orion/947/UPP/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:15m:52s
-Test Date: 20240501 15:31:47
+Total runtime: 00h:14m:47s
+Test Date: 20240502 10:35:13
 Summary Results:
 
-05/01 20:19:08Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/01 20:19:14Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/01 20:19:26Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/01 20:19:26Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/01 20:19:48Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/01 20:19:50Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/01 20:20:04Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/01 20:20:05Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/01 20:20:10Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/01 20:20:14Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/01 20:20:16Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/01 20:20:18Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/01 20:20:18Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/01 20:20:18Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/01 20:20:23Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/01 20:20:26Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/01 20:20:26Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/01 20:20:27Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/01 20:20:27Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/01 20:20:28Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/01 20:20:29Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/01 20:20:30Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/01 20:20:32Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/01 20:20:33Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/01 20:20:54Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/01 20:20:56Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/01 20:20:58Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/01 20:26:16Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/01 20:26:17Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/01 20:26:19Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/01 20:30:08Z gfs_post_00.5771-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/01 20:30:09Z gfs_post_00.5771-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/01 20:30:09Z gfs_post_00.5771-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/01 20:31:41Z gfs_post_00.205040-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/01 20:31:41Z gfs_post_00.205040-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/01 20:31:41Z gfs_post_00.205040-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/01 20:20:38Z -Runtime: nmmb_test 00:02:06 -- baseline 00:03:00
-05/01 20:20:38Z -Runtime: nmmb_pe_test 00:01:57 -- baseline 00:03:00
-05/01 20:20:38Z -Runtime: fv3gefs_test 00:00:29 -- baseline 01:20:00
-05/01 20:20:39Z -Runtime: fv3gefs_pe_test 00:00:35 -- baseline 01:20:00
-05/01 20:20:39Z -Runtime: rap_test 00:01:27 -- baseline 00:02:00
-05/01 20:20:39Z -Runtime: rap_pe_test 00:01:28 -- baseline 00:02:00
-05/01 20:26:27Z -Runtime: hrrr_test 00:07:40 -- baseline 00:02:00
-05/01 20:26:27Z -Runtime: hrrr_pe_test 00:02:36 -- baseline 00:02:00
-05/01 20:31:45Z -Runtime: fv3gfs_test 00:13:20 -- baseline 00:18:00
-05/01 20:31:45Z -Runtime: fv3gfs_pe_test 00:11:47 -- baseline 00:18:00
-05/01 20:31:46Z -Runtime: fv3r_test 00:01:53 -- baseline 00:03:00
-05/01 20:31:46Z -Runtime: fv3r_pe_test 00:02:01 -- baseline 00:03:00
-05/01 20:31:46Z -Runtime: fv3hafs_test 00:00:48 -- baseline 00:00:40
-05/01 20:31:47Z -Runtime: fv3hafs_pe_test 00:00:48 -- baseline 00:00:40
-05/01 20:31:47Z -Runtime: rtma_test 00:02:08 -- baseline 00:04:00
-05/01 20:31:47Z -Runtime: rtma_pe_test 00:02:05 -- baseline 00:04:00
-No changes in test results detected.
+05/02 15:23:27Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/02 15:23:32Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/02 15:23:42Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/02 15:23:42Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/02 15:24:13Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+05/02 15:24:14Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/02 15:24:21Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+05/02 15:24:22Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/02 15:24:40Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/02 15:24:41Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/02 15:24:42Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/02 15:24:49Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/02 15:24:50Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/02 15:24:50Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/02 15:25:03Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/02 15:25:09Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/02 15:25:21Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/02 15:25:23Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/02 15:25:25Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/02 15:26:17Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
+05/02 15:26:22Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/02 15:26:25Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
+05/02 15:26:30Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/02 15:26:40Z -rtma pe test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
+05/02 15:26:41Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/02 15:26:48Z -rtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
+05/02 15:26:49Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/02 15:30:54Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/02 15:30:54Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/02 15:30:56Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/02 15:34:31Z gfs_post_00.263001-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/02 15:34:32Z gfs_post_00.263001-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/02 15:34:32Z gfs_post_00.263001-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/02 15:35:01Z gfs_post_00.387413-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/02 15:35:01Z gfs_post_00.387413-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/02 15:35:02Z gfs_post_00.387413-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/02 15:25:03Z -Runtime: nmmb_test 00:01:47 -- baseline 00:03:00
+05/02 15:25:04Z -Runtime: nmmb_pe_test 00:01:39 -- baseline 00:03:00
+05/02 15:25:04Z -Runtime: fv3gefs_test 00:00:24 -- baseline 01:20:00
+05/02 15:25:04Z -Runtime: fv3gefs_pe_test 00:00:29 -- baseline 01:20:00
+05/02 15:25:05Z -Runtime: rap_test 00:01:12 -- baseline 00:02:00
+05/02 15:25:05Z -Runtime: rap_pe_test 00:01:20 -- baseline 00:02:00
+05/02 15:31:08Z -Runtime: hrrr_test 00:07:53 -- baseline 00:02:00
+05/02 15:31:08Z -Runtime: hrrr_pe_test 00:02:22 -- baseline 00:02:00
+05/02 15:35:10Z -Runtime: fv3gfs_test 00:11:59 -- baseline 00:18:00
+05/02 15:35:11Z -Runtime: fv3gfs_pe_test 00:11:29 -- baseline 00:18:00
+05/02 15:35:11Z -Runtime: fv3r_test 00:03:27 -- baseline 00:03:00
+05/02 15:35:11Z -Runtime: fv3r_pe_test 00:03:19 -- baseline 00:03:00
+05/02 15:35:12Z -Runtime: fv3hafs_test 00:00:39 -- baseline 00:00:40
+05/02 15:35:12Z -Runtime: fv3hafs_pe_test 00:00:40 -- baseline 00:00:40
+05/02 15:35:12Z -Runtime: rtma_test 00:03:46 -- baseline 00:04:00
+05/02 15:35:12Z -Runtime: rtma_pe_test 00:03:38 -- baseline 00:04:00
+There are changes in results for case rtma in PRSLEV00.tm00
+There are changes in results for case fv3r in PRSLEV10.tm00
+There are changes in results for case fv3r_pe_test in PRSLEV10.tm00
+There are changes in results for case rtma_pe_test in PRSLEV00.tm00
+Refer to .diff files in rundir: /work2/noaa/epic/nandoam/regression-testing/upp/orion/947/UPP/ci/rundir/upp-ORION for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
[Addresses issue #944]

This updates the GSL "exp1" (experimental) ceiling diagnostic for possible use in RRFSv1.  Recent RRFS retrospective tests with this code have produced improved verification statistics relative to the existing "exp1" code.  In particular, this update accomplishes the following:

1) Reduces the threshold cloud fraction used to detect a ceiling, from 0.50 (current) to 0.41 (new).

2) Revises the code to detect shallow fog, and makes this code more readable / understandable.  Any shallow fog that is detected will **_not_** yield a very low ceiling.

Testing of this code has been successful on Hera in a RRFS case (CONUS domain). 