### PR TITLE
Correct rt.sh paths

### DIFF
--- a/ci/rt.sh
+++ b/ci/rt.sh
@@ -67,7 +67,7 @@ if [ $mac2 = hf ]; then # for HERA
  export machine=HERA
  export homedir=${homedir:-"/scratch2/NAGAPE/epic/UPP/test_suite"}
  export rundir=${rundir:-"/scratch1/NCEPDEV/stmp2/${USER}"}
- module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core
+ module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core
  module load stack-intel/2021.5.0
  module load stack-intel-oneapi-mpi/2021.5.1
  module load prod_util/2.1.1
@@ -75,7 +75,7 @@ elif [ $mac = O ] ; then
  export machine=ORION
  export homedir=${homedir:-"/work/noaa/epic/UPP"}
  export rundir=${rundir:-"/work2/noaa/stmp/$USER"}
- module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
+ module use /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core
  module load stack-intel/2022.0.2
  module load stack-intel-oneapi-mpi/2021.5.1
  module load prod_util/2.1.1
@@ -83,11 +83,11 @@ elif [ $mac3 = herc ] ; then
  export machine=HERCULES
  export homedir=${homedir:-"/work/noaa/epic/UPP"}
  export rundir=${rundir:-"/work2/noaa/stmp/$USER"}
- module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
+ module use /work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core
  module load stack-intel/2021.9.0
  module load stack-intel-oneapi-mpi/2021.9.0
  module load prod_util/2.1.1
- module load stack-python/3.10.13
+ module load python/3.10.8
 fi
 
 #set working directory

--- a/modulefiles/hercules.lua
+++ b/modulefiles/hercules.lua
@@ -14,8 +14,8 @@ load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 load(pathJoin("cmake", cmake_ver))
 
-stack_python_ver=os.getenv("stack_python_ver") or "3.10.13"
-load(pathJoin("stack-python", stack_python_ver))
+python_ver=os.getenv("python_ver") or "3.10.8"
+load(pathJoin("python", stack_python_ver))
 
 load("upp_common")
 

--- a/modulefiles/hercules.lua
+++ b/modulefiles/hercules.lua
@@ -15,7 +15,7 @@ cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 load(pathJoin("cmake", cmake_ver))
 
 python_ver=os.getenv("python_ver") or "3.10.8"
-load(pathJoin("python", stack_python_ver))
+load(pathJoin("python", python_ver))
 
 load("upp_common")
 

--- a/tests/logs/rt.log.HERA
+++ b/tests/logs/rt.log.HERA
@@ -1,69 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-f2d72f5e484ad8ba2a3e6bdba471d5a31eb3d64e
+b4968a09b5c27eadd239219750c0cf20692b68c1
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -567edcc94bc418d0dcd6cdaafed448eeb5aab570 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/940/UPP/ci/rundir/upp-HERA
+Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/957/UPP/ci/rundir/upp-HERA
 Baseline directory: /scratch2/NAGAPE/epic/UPP/test_suite
 
-Total runtime: 00h:14m:52s
-Test Date: 20240508 04:54:12
+Total runtime: 00h:30m:58s
+Test Date: 20240514 22:15:11
 Summary Results:
 
-05/08 04:42:43Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/08 04:42:45Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/08 04:42:54Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/08 04:42:54Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/08 04:43:19Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/08 04:43:20Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/08 04:43:47Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/08 04:43:49Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/08 04:43:50Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/08 04:43:53Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/08 04:43:54Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/08 04:43:56Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/08 04:43:59Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/08 04:43:59Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/08 04:44:00Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/08 04:44:00Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/08 04:44:01Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/08 04:44:01Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/08 04:44:01Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/08 04:44:02Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/08 04:44:03Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/08 04:44:03Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/08 04:44:04Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/08 04:44:05Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/08 04:44:05Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/08 04:44:05Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/08 04:44:06Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/08 04:44:32Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/08 04:44:33Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/08 04:44:35Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/08 04:53:35Z gfs_post_00.139644-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/08 04:53:36Z gfs_post_00.139644-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/08 04:53:36Z gfs_post_00.139644-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/08 04:54:02Z gfs_post_00.230422-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/08 04:54:02Z gfs_post_00.230422-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/08 04:54:02Z gfs_post_00.230422-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/08 04:44:19Z -Runtime: nmmb_test 00:01:28 -- baseline 00:01:00
-05/08 04:44:19Z -Runtime: nmmb_pe_test 00:01:24 -- baseline 00:01:00
-05/08 04:44:19Z -Runtime: fv3gefs_test 00:00:17 -- baseline 00:40:00
-05/08 04:44:19Z -Runtime: fv3gefs_pe_test 00:00:30 -- baseline 00:40:00
-05/08 04:44:20Z -Runtime: rap_test 00:01:07 -- baseline 00:02:00
-05/08 04:44:20Z -Runtime: rap_pe_test 00:01:13 -- baseline 00:02:00
-05/08 04:44:35Z -Runtime: hrrr_test 00:02:22 -- baseline 00:02:00
-05/08 04:44:36Z -Runtime: hrrr_pe_test 00:02:17 -- baseline 00:02:00
-05/08 04:53:40Z -Runtime: fv3gfs_test 00:11:47 -- baseline 00:15:00
-05/08 04:54:10Z -Runtime: fv3gfs_pe_test 00:12:13 -- baseline 00:15:00
-05/08 04:54:11Z -Runtime: fv3r_test 00:02:00 -- baseline 00:03:00
-05/08 04:54:11Z -Runtime: fv3r_pe_test 00:01:51 -- baseline 00:03:00
-05/08 04:54:11Z -Runtime: fv3hafs_test 00:00:52 -- baseline 00:03:00
-05/08 04:54:12Z -Runtime: fv3hafs_pe_test 00:00:41 -- baseline 00:03:00
-05/08 04:54:12Z -Runtime: rtma_test 00:01:52 -- baseline 00:03:00
-05/08 04:54:12Z -Runtime: rtma_test_pe_test 00:02:07 -- baseline
+05/14 21:48:11Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/14 21:49:09Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+05/14 21:49:14Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/14 21:49:15Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+05/14 21:49:17Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/14 21:49:20Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/14 21:49:20Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+05/14 21:49:20Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/14 21:49:22Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/14 21:49:26Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+05/14 21:49:26Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/14 21:49:41Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/14 21:49:42Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/14 21:49:44Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/14 21:55:40Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/14 21:56:04Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+05/14 21:56:05Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/14 21:57:24Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/14 21:57:25Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/14 21:57:26Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/14 21:58:00Z gfs_post_00.1645976-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/14 21:58:01Z gfs_post_00.1645976-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/14 21:58:01Z gfs_post_00.1645976-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/14 21:58:31Z gfs_post_00.1154442-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/14 21:58:32Z gfs_post_00.1154442-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/14 21:58:32Z gfs_post_00.1154442-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/14 21:58:48Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+05/14 21:58:49Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/14 22:00:11Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/14 22:00:13Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/14 22:00:14Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/14 22:01:32Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/14 22:13:45Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/14 22:14:57Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/14 22:15:00Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/14 22:15:00Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/14 22:00:15Z -Runtime: nmmb_test 00:01:25 -- baseline 00:01:00
+05/14 22:15:07Z -Runtime: nmmb_pe_test 00:01:34 -- baseline 00:01:00
+05/14 22:15:07Z -Runtime: fv3gefs_test 00:00:19 -- baseline 00:40:00
+05/14 22:15:07Z -Runtime: fv3gefs_pe_test 00:00:19 -- baseline 00:40:00
+05/14 22:15:08Z -Runtime: rap_test 00:01:00 -- baseline 00:02:00
+05/14 22:15:08Z -Runtime: rap_pe_test 00:01:13 -- baseline 00:02:00
+05/14 22:15:08Z -Runtime: hrrr_test 00:02:21 -- baseline 00:02:00
+05/14 22:15:09Z -Runtime: hrrr_pe_test 00:02:11 -- baseline 00:02:00
+05/14 22:15:09Z -Runtime: fv3gfs_test 00:11:20 -- baseline 00:15:00
+05/14 22:15:09Z -Runtime: fv3gfs_pe_test 00:11:51 -- baseline 00:15:00
+05/14 22:15:09Z -Runtime: fv3r_test 00:01:41 -- baseline 00:03:00
+05/14 22:15:10Z -Runtime: fv3r_pe_test 00:01:47 -- baseline 00:03:00
+05/14 22:15:10Z -Runtime: fv3hafs_test 00:00:38 -- baseline 00:03:00
+05/14 22:15:10Z -Runtime: fv3hafs_pe_test 00:00:35 -- baseline 00:03:00
+05/14 22:15:11Z -Runtime: rtma_test 00:01:53 -- baseline 00:03:00
+05/14 22:15:11Z -Runtime: rtma_test_pe_test 00:01:47 -- baseline 
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.HERCULES
+++ b/tests/logs/rt.log.HERCULES
@@ -1,69 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-297445ddce23dcd6cace15f89d777a5522b49d20
+b4968a09b5c27eadd239219750c0cf20692b68c1
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -567edcc94bc418d0dcd6cdaafed448eeb5aab570 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/hercules/954/UPP/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/hercules/957/UPP/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:21m:52s
-Test Date: 20240507 14:50:25
+Total runtime: 00h:21m:22s
+Test Date: 20240514 17:04:55
 Summary Results:
 
-05/07 19:31:22Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/07 19:31:29Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/07 19:31:37Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/07 19:31:37Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/07 19:31:59Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/07 19:32:00Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/07 19:32:03Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/07 19:32:04Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/07 19:32:18Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/07 19:32:19Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/07 19:32:19Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/07 19:32:26Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/07 19:32:27Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/07 19:32:27Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/07 19:32:46Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/07 19:32:47Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/07 19:32:48Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/07 19:32:56Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/07 19:32:59Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/07 19:33:06Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/07 19:33:08Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/07 19:33:25Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/07 19:33:25Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/07 19:33:27Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/07 19:33:27Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/07 19:33:28Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/07 19:33:28Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/07 19:37:04Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/07 19:37:05Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/07 19:37:06Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/07 19:46:50Z gfs_post_00.1842287-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/07 19:46:51Z gfs_post_00.1842287-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/07 19:46:51Z gfs_post_00.1842287-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/07 19:50:10Z gfs_post_00.1842288-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/07 19:50:10Z gfs_post_00.1842288-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/07 19:50:10Z gfs_post_00.1842288-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/07 19:32:33Z -Runtime: nmmb_test 00:01:23 -- baseline 00:03:00
-05/07 19:32:33Z -Runtime: nmmb_pe_test 00:01:16 -- baseline 00:03:00
-05/07 19:32:33Z -Runtime: fv3gefs_test 00:00:18 -- baseline 01:20:00
-05/07 19:32:33Z -Runtime: fv3gefs_pe_test 00:00:25 -- baseline 01:20:00
-05/07 19:32:33Z -Runtime: rap_test 00:00:56 -- baseline 00:02:00
-05/07 19:32:33Z -Runtime: rap_pe_test 00:01:00 -- baseline 00:02:00
-05/07 19:37:19Z -Runtime: hrrr_test 00:06:02 -- baseline 00:02:00
-05/07 19:37:19Z -Runtime: hrrr_pe_test 00:01:44 -- baseline 00:02:00
-05/07 19:50:22Z -Runtime: fv3gfs_test 00:19:06 -- baseline 00:18:00
-05/07 19:50:22Z -Runtime: fv3gfs_pe_test 00:15:47 -- baseline 00:18:00
-05/07 19:50:22Z -Runtime: fv3r_test 00:01:55 -- baseline 00:03:00
-05/07 19:50:23Z -Runtime: fv3r_pe_test 00:02:04 -- baseline 00:03:00
-05/07 19:50:23Z -Runtime: fv3hafs_test 00:00:33 -- baseline 00:00:40
-05/07 19:50:23Z -Runtime: fv3hafs_pe_test 00:00:33 -- baseline 00:00:40
-05/07 19:50:23Z -Runtime: rtma_test 00:02:24 -- baseline 00:04:00
-05/07 19:50:23Z -Runtime: rtma_pe_test 00:02:23 -- baseline 00:04:00
+05/14 21:45:57Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/14 21:46:03Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/14 21:46:11Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/14 21:46:11Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/14 21:46:31Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+05/14 21:46:32Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/14 21:46:37Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+05/14 21:46:38Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/14 21:46:59Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/14 21:47:00Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/14 21:47:01Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/14 21:47:05Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/14 21:47:06Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/14 21:47:06Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/14 21:47:17Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/14 21:47:18Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/14 21:47:19Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/14 21:47:28Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+05/14 21:47:31Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/14 21:47:41Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+05/14 21:47:42Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/14 21:47:58Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/14 21:47:59Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/14 21:48:00Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+05/14 21:48:01Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/14 21:48:02Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+05/14 21:48:03Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/14 21:51:47Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/14 21:51:48Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/14 21:51:50Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/14 22:01:34Z gfs_post_00.747957-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/14 22:01:34Z gfs_post_00.747957-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/14 22:01:35Z gfs_post_00.747957-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/14 22:04:45Z gfs_post_00.747955-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/14 22:04:45Z gfs_post_00.747955-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/14 22:04:45Z gfs_post_00.747955-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/14 21:47:08Z -Runtime: nmmb_test 00:01:27 -- baseline 00:03:00
+05/14 21:47:08Z -Runtime: nmmb_pe_test 00:01:22 -- baseline 00:03:00
+05/14 21:47:08Z -Runtime: fv3gefs_test 00:00:18 -- baseline 01:20:00
+05/14 21:47:08Z -Runtime: fv3gefs_pe_test 00:00:24 -- baseline 01:20:00
+05/14 21:47:09Z -Runtime: rap_test 00:00:53 -- baseline 00:02:00
+05/14 21:47:09Z -Runtime: rap_pe_test 00:00:59 -- baseline 00:02:00
+05/14 21:51:54Z -Runtime: hrrr_test 00:06:11 -- baseline 00:02:00
+05/14 21:51:54Z -Runtime: hrrr_pe_test 00:01:40 -- baseline 00:02:00
+05/14 22:04:55Z -Runtime: fv3gfs_test 00:19:06 -- baseline 00:18:00
+05/14 22:04:55Z -Runtime: fv3gfs_pe_test 00:15:56 -- baseline 00:18:00
+05/14 22:04:55Z -Runtime: fv3r_test 00:01:52 -- baseline 00:03:00
+05/14 22:04:55Z -Runtime: fv3r_pe_test 00:02:03 -- baseline 00:03:00
+05/14 22:04:55Z -Runtime: fv3hafs_test 00:00:32 -- baseline 00:00:40
+05/14 22:04:55Z -Runtime: fv3hafs_pe_test 00:00:32 -- baseline 00:00:40
+05/14 22:04:55Z -Runtime: rtma_test 00:02:24 -- baseline 00:04:00
+05/14 22:04:55Z -Runtime: rtma_pe_test 00:02:22 -- baseline 00:04:00
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION
+++ b/tests/logs/rt.log.ORION
@@ -1,69 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-297445ddce23dcd6cace15f89d777a5522b49d20
+b4968a09b5c27eadd239219750c0cf20692b68c1
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -567edcc94bc418d0dcd6cdaafed448eeb5aab570 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/nandoam/regression-testing/wm/orion/954/UPP/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/orion/957/UPP/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:16m:05s
-Test Date: 20240507 14:36:36
+Total runtime: 00h:15m:27s
+Test Date: 20240517 12:55:34
 Summary Results:
 
-05/07 19:24:03Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/07 19:24:04Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/07 19:24:16Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/07 19:24:17Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/07 19:24:46Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/07 19:24:47Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/07 19:24:52Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/07 19:24:53Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/07 19:24:54Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/07 19:24:56Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/07 19:24:57Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/07 19:25:02Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/07 19:25:03Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/07 19:25:03Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/07 19:25:24Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/07 19:25:26Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/07 19:25:28Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/07 19:25:29Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/07 19:25:38Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/07 19:25:39Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/07 19:25:41Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/07 19:25:41Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/07 19:25:42Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/07 19:25:43Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/07 19:25:54Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/07 19:25:56Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/07 19:25:58Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/07 19:31:02Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/07 19:31:03Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/07 19:31:05Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/07 19:34:57Z gfs_post_00.23335-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/07 19:34:58Z gfs_post_00.23335-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/07 19:34:58Z gfs_post_00.23335-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/07 19:36:19Z gfs_post_00.383561-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/07 19:36:20Z gfs_post_00.383561-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/07 19:36:20Z gfs_post_00.383561-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/07 19:25:11Z -Runtime: nmmb_test 00:01:40 -- baseline 00:03:00
-05/07 19:25:11Z -Runtime: nmmb_pe_test 00:01:30 -- baseline 00:03:00
-05/07 19:25:12Z -Runtime: fv3gefs_test 00:00:26 -- baseline 01:20:00
-05/07 19:25:12Z -Runtime: fv3gefs_pe_test 00:00:27 -- baseline 01:20:00
-05/07 19:25:12Z -Runtime: rap_test 00:01:10 -- baseline 00:02:00
-05/07 19:25:13Z -Runtime: rap_pe_test 00:01:20 -- baseline 00:02:00
-05/07 19:31:16Z -Runtime: hrrr_test 00:07:29 -- baseline 00:02:00
-05/07 19:31:16Z -Runtime: hrrr_pe_test 00:02:21 -- baseline 00:02:00
-05/07 19:36:34Z -Runtime: fv3gfs_test 00:12:44 -- baseline 00:18:00
-05/07 19:36:34Z -Runtime: fv3gfs_pe_test 00:11:22 -- baseline 00:18:00
-05/07 19:36:34Z -Runtime: fv3r_test 00:01:53 -- baseline 00:03:00
-05/07 19:36:35Z -Runtime: fv3r_pe_test 00:01:51 -- baseline 00:03:00
-05/07 19:36:35Z -Runtime: fv3hafs_test 00:00:39 -- baseline 00:00:40
-05/07 19:36:35Z -Runtime: fv3hafs_pe_test 00:00:40 -- baseline 00:00:40
-05/07 19:36:36Z -Runtime: rtma_test 00:02:05 -- baseline 00:04:00
-05/07 19:36:36Z -Runtime: rtma_pe_test 00:02:06 -- baseline 00:04:00
+05/17 17:43:15Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/17 17:43:23Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+05/17 17:43:30Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/17 17:43:31Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+05/17 17:44:10Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/17 17:44:11Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/17 17:44:12Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/17 17:44:13Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+05/17 17:44:14Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/17 17:44:21Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+05/17 17:44:22Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+05/17 17:44:24Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+05/17 17:44:25Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+05/17 17:44:25Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+05/17 17:44:29Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+05/17 17:44:33Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+05/17 17:44:33Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/17 17:44:36Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+05/17 17:45:02Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/17 17:45:02Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+05/17 17:45:04Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+05/17 17:45:04Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+05/17 17:45:04Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/17 17:45:04Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+05/17 17:45:15Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/17 17:45:16Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/17 17:45:18Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/17 17:50:56Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+05/17 17:50:58Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+05/17 17:51:00Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+05/17 17:54:15Z gfs_post_00.278761-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/17 17:54:15Z gfs_post_00.278761-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/17 17:54:15Z gfs_post_00.278761-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/17 17:55:19Z gfs_post_00.434521-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+05/17 17:55:20Z gfs_post_00.434521-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+05/17 17:55:20Z gfs_post_00.434521-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+05/17 17:44:37Z -Runtime: nmmb_test 00:01:35 -- baseline 00:03:00
+05/17 17:44:38Z -Runtime: nmmb_pe_test 00:01:21 -- baseline 00:03:00
+05/17 17:44:38Z -Runtime: fv3gefs_test 00:00:24 -- baseline 01:20:00
+05/17 17:44:39Z -Runtime: fv3gefs_pe_test 00:00:29 -- baseline 01:20:00
+05/17 17:44:39Z -Runtime: rap_test 00:01:22 -- baseline 00:02:00
+05/17 17:44:39Z -Runtime: rap_pe_test 00:01:20 -- baseline 00:02:00
+05/17 17:51:13Z -Runtime: hrrr_test 00:07:59 -- baseline 00:02:00
+05/17 17:51:13Z -Runtime: hrrr_pe_test 00:02:25 -- baseline 00:02:00
+05/17 17:55:31Z -Runtime: fv3gfs_test 00:12:26 -- baseline 00:18:00
+05/17 17:55:31Z -Runtime: fv3gfs_pe_test 00:11:22 -- baseline 00:18:00
+05/17 17:55:31Z -Runtime: fv3r_test 00:01:39 -- baseline 00:03:00
+05/17 17:55:32Z -Runtime: fv3r_pe_test 00:01:43 -- baseline 00:03:00
+05/17 17:55:32Z -Runtime: fv3hafs_test 00:00:36 -- baseline 00:00:40
+05/17 17:55:32Z -Runtime: fv3hafs_pe_test 00:00:37 -- baseline 00:00:40
+05/17 17:55:33Z -Runtime: rtma_test 00:02:11 -- baseline 00:04:00
+05/17 17:55:33Z -Runtime: rtma_pe_test 00:02:11 -- baseline 00:04:00
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
This PR will correct spack-stack paths in rt.sh that should now be in sync with the recent modulefile spack-stack paths update. The new path on hercules does not contain stack-python, so the system's 3.10.8 will be loaded instead.