### PR TITLE
Fix for hydrostatic runs - write out Omega and HGT from model output

### DIFF
--- a/tests/logs/rt.log.HERA
+++ b/tests/logs/rt.log.HERA
@@ -64,3 +64,26 @@ Summary Results:
 06/13 19:13:53Z -Runtime: rtma_test_pe_test 00:01:43 -- baseline 
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====
+===== Start of UPP Regression Testing Log =====
+UPP Hash Tested:
+2d086ec0580a345c5b4067fdaa0ce6efc135f25d
+
+Submodule hashes:
+-1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
+-567edcc94bc418d0dcd6cdaafed448eeb5aab570 sorc/ncep_post.fd/post_gtg.fd
+
+Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/959/UPP/ci/rundir/upp-HERA
+Baseline directory: /scratch2/NAGAPE/epic/UPP/test_suite
+
+Total runtime: 00h:02m:20s
+Test Date: 20240613 20:59:44
+Summary Results:
+
+06/13 20:59:23Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/13 20:59:28Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/13 20:59:35Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/13 20:59:39Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/13 20:59:43Z -Runtime: fv3r_test 00:01:32 -- baseline 00:03:00
+06/13 20:59:44Z -Runtime: fv3r_pe_test 00:01:46 -- baseline 00:03:00
+No changes in test results detected.
+===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.HERA
+++ b/tests/logs/rt.log.HERA
@@ -1,69 +1,66 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-51057edacce7a6696319e9780544a56b0ce5d829
+675a5402d26a7c81e19d96c7a04489cdf7710ab1
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -567edcc94bc418d0dcd6cdaafed448eeb5aab570 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/963/UPP/ci/rundir/upp-HERA
+Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/959/UPP/ci/rundir/upp-HERA
 Baseline directory: /scratch2/NAGAPE/epic/UPP/test_suite
 
-Total runtime: 00h:16m:00s
-Test Date: 20240529 15:01:26
+Total runtime: 01h:44m:54s
+Test Date: 20240613 19:13:53
 Summary Results:
 
-05/29 14:48:51Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/29 14:48:52Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/29 14:49:31Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/29 14:49:32Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/29 14:49:40Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/29 14:50:04Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/29 14:50:35Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/29 14:50:37Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/29 14:50:37Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/29 14:50:45Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/29 14:50:46Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/29 14:50:55Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/29 14:50:57Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/29 14:51:00Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/29 14:51:01Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/29 14:51:03Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/29 14:51:03Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/29 14:51:04Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/29 14:51:05Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/29 14:51:06Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/29 14:51:08Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/29 14:51:08Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/29 14:51:08Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/29 14:51:09Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/29 14:51:09Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/29 14:51:09Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/29 14:51:14Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/29 14:51:15Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/29 14:51:16Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/29 14:51:18Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/29 15:00:40Z gfs_post_00.1392909-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/29 15:00:41Z gfs_post_00.1392909-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/29 15:00:41Z gfs_post_00.1392909-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/29 15:01:15Z gfs_post_00.30719-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/29 15:01:15Z gfs_post_00.30719-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/29 15:01:15Z gfs_post_00.30719-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/29 14:51:17Z -Runtime: nmmb_test 00:01:24 -- baseline 00:01:00
-05/29 14:51:18Z -Runtime: nmmb_pe_test 00:01:22 -- baseline 00:01:00
-05/29 14:51:18Z -Runtime: fv3gefs_test 00:00:20 -- baseline 00:40:00
-05/29 14:51:18Z -Runtime: fv3gefs_pe_test 00:00:21 -- baseline 00:40:00
-05/29 14:51:18Z -Runtime: rap_test 00:01:01 -- baseline 00:02:00
-05/29 14:51:19Z -Runtime: rap_pe_test 00:01:12 -- baseline 00:02:00
-05/29 14:51:19Z -Runtime: hrrr_test 00:02:26 -- baseline 00:02:00
-05/29 14:51:19Z -Runtime: hrrr_pe_test 00:02:13 -- baseline 00:02:00
-05/29 15:00:54Z -Runtime: fv3gfs_test 00:11:24 -- baseline 00:15:00
-05/29 15:01:24Z -Runtime: fv3gfs_pe_test 00:11:47 -- baseline 00:15:00
-05/29 15:01:25Z -Runtime: fv3r_test 00:01:40 -- baseline 00:03:00
-05/29 15:01:25Z -Runtime: fv3r_pe_test 00:01:36 -- baseline 00:03:00
-05/29 15:01:25Z -Runtime: fv3hafs_test 00:00:37 -- baseline 00:03:00
-05/29 15:01:25Z -Runtime: fv3hafs_pe_test 00:00:36 -- baseline 00:03:00
-05/29 15:01:26Z -Runtime: rtma_test 00:01:41 -- baseline 00:03:00
-05/29 15:01:26Z -Runtime: rtma_test_pe_test 00:01:41 -- baseline 
+06/13 17:35:28Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/13 17:35:31Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/13 17:35:31Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+06/13 17:43:35Z gfs_post_00.2347069-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/13 17:43:36Z gfs_post_00.2347069-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/13 17:43:36Z gfs_post_00.2347069-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/13 17:43:52Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/13 17:43:53Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/13 17:43:55Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/13 17:44:03Z gfs_post_00.3285752-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/13 17:44:04Z gfs_post_00.3285752-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/13 17:44:04Z gfs_post_00.3285752-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/13 17:56:04Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/13 17:56:04Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/13 17:56:16Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/13 17:56:18Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/13 17:56:43Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+06/13 17:56:44Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/13 17:56:53Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/13 17:56:55Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/13 17:56:56Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/13 17:56:59Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/13 17:57:01Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/13 17:57:01Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/13 17:57:17Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/13 17:57:22Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/13 17:57:31Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/13 17:57:35Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/13 17:57:35Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+06/13 17:57:44Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/13 17:57:45Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/13 17:57:47Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/13 17:57:59Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+06/13 17:57:59Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/13 17:57:12Z -Runtime: nmmb_test 00:01:20 -- baseline 00:01:00
+06/13 17:57:12Z -Runtime: nmmb_pe_test 00:01:15 -- baseline 00:01:00
+06/13 17:57:12Z -Runtime: fv3gefs_test 00:00:23 -- baseline 00:40:00
+06/13 17:57:13Z -Runtime: fv3gefs_pe_test 00:00:23 -- baseline 00:40:00
+06/13 17:57:13Z -Runtime: rap_test 00:01:03 -- baseline 00:02:00
+06/13 17:58:14Z -Runtime: rap_pe_test 00:01:14 -- baseline 00:02:00
+06/13 17:58:14Z -Runtime: hrrr_test 00:02:31 -- baseline 00:02:00
+06/13 17:58:14Z -Runtime: hrrr_pe_test 00:02:06 -- baseline 00:02:00
+06/13 17:58:15Z -Runtime: fv3gfs_test 00:11:25 -- baseline 00:15:00
+06/13 17:58:15Z -Runtime: fv3gfs_pe_test 00:11:45 -- baseline 00:15:00
+06/13 17:58:15Z -Runtime: fv3r_test 00:01:41 -- baseline 00:03:00
+06/13 19:13:52Z -Runtime: fv3hafs_test 00:00:35 -- baseline 00:03:00
+06/13 19:13:52Z -Runtime: fv3hafs_pe_test 00:00:37 -- baseline 00:03:00
+06/13 19:13:53Z -Runtime: rtma_test 00:01:54 -- baseline 00:03:00
+06/13 19:13:53Z -Runtime: rtma_test_pe_test 00:01:43 -- baseline 
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.HERCULES
+++ b/tests/logs/rt.log.HERCULES
@@ -1,69 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b4968a09b5c27eadd239219750c0cf20692b68c1
+675a5402d26a7c81e19d96c7a04489cdf7710ab1
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -567edcc94bc418d0dcd6cdaafed448eeb5aab570 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/hercules/957/UPP/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/hercules/959/UPP/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:21m:22s
-Test Date: 20240514 17:04:55
+Total runtime: 00h:21m:53s
+Test Date: 20240613 16:12:14
 Summary Results:
 
-05/14 21:45:57Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/14 21:46:03Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/14 21:46:11Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/14 21:46:11Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/14 21:46:31Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/14 21:46:32Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/14 21:46:37Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/14 21:46:38Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/14 21:46:59Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/14 21:47:00Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/14 21:47:01Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/14 21:47:05Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/14 21:47:06Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/14 21:47:06Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/14 21:47:17Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/14 21:47:18Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/14 21:47:19Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/14 21:47:28Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/14 21:47:31Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/14 21:47:41Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-05/14 21:47:42Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-05/14 21:47:58Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/14 21:47:59Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/14 21:48:00Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/14 21:48:01Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/14 21:48:02Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-05/14 21:48:03Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-05/14 21:51:47Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/14 21:51:48Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/14 21:51:50Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/14 22:01:34Z gfs_post_00.747957-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/14 22:01:34Z gfs_post_00.747957-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/14 22:01:35Z gfs_post_00.747957-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/14 22:04:45Z gfs_post_00.747955-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/14 22:04:45Z gfs_post_00.747955-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/14 22:04:45Z gfs_post_00.747955-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/14 21:47:08Z -Runtime: nmmb_test 00:01:27 -- baseline 00:03:00
-05/14 21:47:08Z -Runtime: nmmb_pe_test 00:01:22 -- baseline 00:03:00
-05/14 21:47:08Z -Runtime: fv3gefs_test 00:00:18 -- baseline 01:20:00
-05/14 21:47:08Z -Runtime: fv3gefs_pe_test 00:00:24 -- baseline 01:20:00
-05/14 21:47:09Z -Runtime: rap_test 00:00:53 -- baseline 00:02:00
-05/14 21:47:09Z -Runtime: rap_pe_test 00:00:59 -- baseline 00:02:00
-05/14 21:51:54Z -Runtime: hrrr_test 00:06:11 -- baseline 00:02:00
-05/14 21:51:54Z -Runtime: hrrr_pe_test 00:01:40 -- baseline 00:02:00
-05/14 22:04:55Z -Runtime: fv3gfs_test 00:19:06 -- baseline 00:18:00
-05/14 22:04:55Z -Runtime: fv3gfs_pe_test 00:15:56 -- baseline 00:18:00
-05/14 22:04:55Z -Runtime: fv3r_test 00:01:52 -- baseline 00:03:00
-05/14 22:04:55Z -Runtime: fv3r_pe_test 00:02:03 -- baseline 00:03:00
-05/14 22:04:55Z -Runtime: fv3hafs_test 00:00:32 -- baseline 00:00:40
-05/14 22:04:55Z -Runtime: fv3hafs_pe_test 00:00:32 -- baseline 00:00:40
-05/14 22:04:55Z -Runtime: rtma_test 00:02:24 -- baseline 00:04:00
-05/14 22:04:55Z -Runtime: rtma_pe_test 00:02:22 -- baseline 00:04:00
+06/13 20:53:33Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+06/13 20:53:33Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/13 20:53:41Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/13 20:53:42Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/13 20:53:42Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/13 20:53:49Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/13 20:53:50Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/13 20:53:50Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/13 20:54:13Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/13 20:54:14Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/13 20:54:15Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/13 20:54:23Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/13 20:54:25Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/13 20:54:31Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/13 20:54:33Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/13 20:54:44Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/13 20:55:02Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/13 20:55:07Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/13 20:55:10Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/13 20:55:36Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+06/13 20:55:37Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/13 20:56:59Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/13 20:57:00Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/13 20:57:01Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+06/13 20:57:01Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/13 20:57:02Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/13 20:57:03Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+06/13 21:00:41Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/13 21:00:42Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/13 21:00:42Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/13 21:08:33Z gfs_post_00.2777856-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/13 21:08:33Z gfs_post_00.2777856-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/13 21:08:34Z gfs_post_00.2777856-fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/13 21:12:04Z gfs_post_00.3405424-fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/13 21:12:05Z gfs_post_00.3405424-fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/13 21:12:05Z gfs_post_00.3405424-fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/13 20:54:05Z -Runtime: nmmb_test 00:01:15 -- baseline 00:03:00
+06/13 20:54:05Z -Runtime: nmmb_pe_test 00:01:07 -- baseline 00:03:00
+06/13 20:55:06Z -Runtime: fv3gefs_test 00:00:18 -- baseline 01:20:00
+06/13 20:55:21Z -Runtime: fv3gefs_pe_test 00:00:23 -- baseline 01:20:00
+06/13 20:55:51Z -Runtime: rap_test 00:00:53 -- baseline 00:02:00
+06/13 20:55:51Z -Runtime: rap_pe_test 00:00:58 -- baseline 00:02:00
+06/13 21:01:08Z -Runtime: hrrr_test 00:05:58 -- baseline 00:02:00
+06/13 21:01:34Z -Runtime: hrrr_pe_test 00:01:40 -- baseline 00:02:00
+06/13 21:12:13Z -Runtime: fv3gfs_test 00:19:30 -- baseline 00:18:00
+06/13 21:12:14Z -Runtime: fv3gfs_pe_test 00:15:59 -- baseline 00:18:00
+06/13 21:12:14Z -Runtime: fv3r_test 00:01:50 -- baseline 00:03:00
+06/13 21:12:14Z -Runtime: fv3r_pe_test 00:01:58 -- baseline 00:03:00
+06/13 21:12:14Z -Runtime: fv3hafs_test 00:00:29 -- baseline 00:00:40
+06/13 21:12:14Z -Runtime: fv3hafs_pe_test 00:00:26 -- baseline 00:00:40
+06/13 21:12:14Z -Runtime: rtma_test 00:02:17 -- baseline 00:04:00
+06/13 21:12:14Z -Runtime: rtma_pe_test 00:02:19 -- baseline 00:04:00
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
This PR should fix UPP offline post hydrostatic runs by writing out Omega and HGT from model output. The fix is synced with inline post as described in [Issue #946 ](https://github.com/NOAA-EMC/UPP/issues/946). See issue for test results with GFSv17, GEFSv13, SFSv1.