### PR TITLE
[release/rrfs_v1] Removes lines that generate warnings during compilation

### DIFF
--- a/sorc/ncep_post.fd/io_int_stubs.f
+++ b/sorc/ncep_post.fd/io_int_stubs.f
@@ -2,12 +2,6 @@
 !
 !--- get_dom_ti_real
 SUBROUTINE ext_int_get_dom_ti_real ( DataHandle,Element,   Data, Count, Outcount, Status )
-  INTEGER ,       INTENT(IN)  :: DataHandle
-  CHARACTER*(*) :: Element
-  REAL ,          INTENT(OUT) :: Data(*)
-  INTEGER ,       INTENT(IN)  :: Count
-  INTEGER ,       INTENT(OUT) :: Outcount
-  INTEGER ,       INTENT(OUT) :: Status
 
 RETURN
 END SUBROUTINE ext_int_get_dom_ti_real 


### PR DESCRIPTION
Updates io_int_stubs.f to allow for a warning-free compilation.  Haven't made runs with this change, but was hoping that regression tests could validate that it doesn't create a problem.