### PR TITLE
Bug fix for QPFARI and QPFFFG encoding in RRFS

### DIFF
--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -45,9 +45,6 @@ load(pathJoin("nemsio", nemsio_ver))
 load(pathJoin("sigio", sigio_ver))
 load(pathJoin("wrf_io", wrf_io_ver))
 
-prepend_path("MODULEPATH"," /u/wen.meng/noscrub/ncep_post/g2tmpl/libs/modulefiles/compiler/intel/19.1.3.304")
-load(pathJoin("g2tmpl", g2tmpl_ver))
-
 setenv("CC","cc")
 setenv("CXX","CC")
 setenv("FC","ftn")

--- a/parm/post_avblflds.xml
+++ b/parm/post_avblflds.xml
@@ -6996,11 +6996,10 @@
 
     <param>
        <post_avblfldidx>759</post_avblfldidx>
-       <shortname>AVE_SMOKE_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
+       <shortname>AVE_PM25_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
        <pdstmpl>tmpl4_46</pdstmpl>
        <pname>MASSDEN</pname>
        <stats_proc>AVE</stats_proc>
-       <aerosol_type>particulate_org_matter_dry</aerosol_type>
        <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
        <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
        <scale_fact_1st_size>7</scale_fact_1st_size>
@@ -7103,11 +7102,10 @@
 
     <param>
        <post_avblfldidx>771</post_avblfldidx>
-       <shortname>AVE_DUST_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
+       <shortname>AVE_PM10_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
        <pdstmpl>tmpl4_46</pdstmpl>
        <pname>MASSDEN</pname>
        <stats_proc>AVE</stats_proc>
-       <aerosol_type>dust_dry</aerosol_type>
        <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
        <level>8.</level>
        <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>

--- a/parm/postxconfig-NT-rrfs.txt
+++ b/parm/postxconfig-NT-rrfs.txt
@@ -11360,7 +11360,7 @@ surface
 ?
 ?
 759
-AVE_SMOKE_ON_SPEC_HGT_LVL_ABOVE_GRND_8m
+AVE_PM25_ON_SPEC_HGT_LVL_ABOVE_GRND_8m
 ?
 1
 tmpl4_46
@@ -11377,7 +11377,7 @@ spec_hgt_lvl_above_grnd
 ?
 0
 ?
-particulate_org_matter_dry
+?
 ?
 smaller_than_first_limit
 7
@@ -11402,7 +11402,7 @@ smaller_than_first_limit
 ?
 ?
 771
-AVE_DUST_ON_SPEC_HGT_LVL_ABOVE_GRND_8m
+AVE_PM10_ON_SPEC_HGT_LVL_ABOVE_GRND_8m
 ?
 1
 tmpl4_46
@@ -11419,7 +11419,7 @@ spec_hgt_lvl_above_grnd
 ?
 0
 ?
-dust_dry
+?
 ?
 smaller_than_first_limit
 7

--- a/parm/postxconfig-NT-rrfs_subh.txt
+++ b/parm/postxconfig-NT-rrfs_subh.txt
@@ -352,9 +352,9 @@ surface
 ?
 ?
 ?
-525
-BUCKET1_ASNOW_ON_SURFACE
-bucket Var density snowfall on surface
+725
+GSD_ACM_SNOD_ON_SURFACE
+?
 1
 tmpl4_8
 ASNOW
@@ -394,9 +394,9 @@ surface
 ?
 ?
 ?
-526
-BUCKET1_APCP_ON_SURFACE
-bucket Total precipitation on surface
+417
+CACM_APCP_ON_SURFACE
+?
 1
 tmpl4_8
 APCP
@@ -436,9 +436,9 @@ surface
 ?
 ?
 ?
-528
-BUCKET1_TSNOWP_ON_SURFACE
-bucket snow on surface
+1004
+ACM_SNOWFALL_ON_SURFACE
+?
 1
 tmpl4_8
 TSNOWP
@@ -478,9 +478,9 @@ surface
 ?
 ?
 ?
-527
-BUCKET1_FRZR_ON_SURFACE
-bucket Freezing rain on surface
+782
+ACM_FRAIN_ON_SURFACE
+?
 1
 tmpl4_8
 FRZR
@@ -520,9 +520,9 @@ surface
 ?
 ?
 ?
-530
-BUCKET1_GRAUPEL_ON_SURFACE
-bucket graupel precipitation on surface
+746
+ACM_GRAUPEL_ON_SURFACE
+?
 1
 tmpl4_8
 FROZR

--- a/parm/rrfs_postcntrl.xml
+++ b/parm/rrfs_postcntrl.xml
@@ -1755,12 +1755,12 @@
        </param>
 
        <param>
-	   <shortname>AVE_SMOKE_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
+	   <shortname>AVE_PM25_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
 	   <scale>6.0</scale>
        </param>
 
        <param>
-	   <shortname>AVE_DUST_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
+	   <shortname>AVE_PM10_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
 	   <scale>6.0</scale>
        </param>
 

--- a/parm/rrfs_postcntrl_subh.xml
+++ b/parm/rrfs_postcntrl_subh.xml
@@ -71,27 +71,27 @@
        </param>
 
        <param>
-       <shortname>BUCKET1_ASNOW_ON_SURFACE</shortname>
+       <shortname>GSD_ACM_SNOD_ON_SURFACE</shortname>
        <scale>9.0</scale>
        </param>
 
        <param>
-       <shortname>BUCKET1_APCP_ON_SURFACE</shortname>
+       <shortname>CACM_APCP_ON_SURFACE</shortname>
        <scale>-4.0</scale>
        </param>
 
        <param>
-       <shortname>BUCKET1_TSNOWP_ON_SURFACE</shortname>
+       <shortname>ACM_SNOWFALL_ON_SURFACE</shortname>
        <scale>6.0</scale>
        </param>
 
        <param>
-       <shortname>BUCKET1_FRZR_ON_SURFACE</shortname>
+       <shortname>ACM_FRAIN_ON_SURFACE</shortname>
        <scale>6.0</scale>
        </param>
 
        <param>
-       <shortname>BUCKET1_GRAUPEL_ON_SURFACE</shortname>
+       <shortname>ACM_GRAUPEL_ON_SURFACE</shortname>
        <scale>6.0</scale>
        </param>
 

--- a/sorc/ncep_post.fd/CALPW.f
+++ b/sorc/ncep_post.fd/CALPW.f
@@ -38,7 +38,6 @@
 !> 2021-09-02 | Bo Cui         | Decompose UPP in X direction          
 !> 2022-11-16 | Eric James     | Adding calculation of vertically integrated dust from RRFS
 !> 2023-02-23 | Eric James     | Adding vertically integrated coarse PM from RRFS
-!> 2024-04-23 | Eric James     | Adding vertically integrated smoke emissions (ebb)
 !>     
 !> @author Russ Treadon W/NP2 @date 1992-12-24
 !-----------------------------------------------------------------------
@@ -55,7 +54,7 @@
       use vrbls3d,    only: q, qqw, qqi, qqr, qqs, cwm, qqg, t, rswtt,    &
                             train, tcucn, mcvg, pmid, o3, ext, pint, rlwtt, &
                             taod5503d,sca, asy
-      use vrbls4d,    only: smoke, fv3dust, coarsepm, ebb
+      use vrbls4d,    only: smoke, fv3dust, coarsepm
       use masks,      only: htm
       use params_mod, only: tfrz, gi
       use ctlblk_mod, only: lm, jsta, jend, im, spval, ista, iend
@@ -296,15 +295,6 @@
           DO J=JSTA,JEND
             DO I=ISTA,IEND
               Qdum(I,J) = COARSEPM(I,J,L,1)/(1E9)
-            ENDDO
-          END DO
-
-! EBB (from RRFS)
-        ELSE IF (IDECID == 24) THEN
-!$omp  parallel do private(i,j)
-          DO J=JSTA,JEND
-            DO I=ISTA,IEND
-              Qdum(I,J) = EBB(I,J,L,1)/(1E9)
             ENDDO
           END DO
         ENDIF

--- a/sorc/ncep_post.fd/CLDRAD.f
+++ b/sorc/ncep_post.fd/CLDRAD.f
@@ -86,7 +86,7 @@
       SUBROUTINE CLDRAD
 
 !
-      use vrbls4d, only: DUST,SUSO, SALT, SOOT, WASO,NO3,NH4
+      use vrbls4d, only: DUST,SUSO, SALT, SOOT, WASO,NO3,NH4,EBB
       use vrbls3d, only: QQW, QQR, T, ZINT, CFR, QQI, QQS, Q, EXT, ZMID,PMID,&
                          PINT, DUEM, DUSD, DUDP, DUWT, DUSV, SSEM, SSSD,SSDP,&
                          SSWT, SSSV, BCEM, BCSD, BCDP, BCWT, BCSV, OCEM,OCSD,&
@@ -533,8 +533,18 @@
 !     TOTAL COLUMN EBB (BIOMASS BURNING EMISSIONS)
 !
       IF (IGET(745) > 0) THEN
-         CALL CALPW(GRID1(ista:iend,jsta:iend),24)
-         CALL BOUND(GRID1,D00,H99999)
+!$omp parallel do private(i,j,ii,jj)
+          do j=1,jend-jsta+1
+            jj = jsta+j-1
+            do i=1,iend-ista+1
+              ii=ista+i-1
+              GRID1(ii,jj) = 0.0
+              do k=1,lm
+                LL=LM-k+1
+                GRID1(ii,jj) = GRID1(ii,jj) + EBB(ii,jj,k,1)
+              enddo
+            enddo
+          enddo
         if(grib == "grib2" )then
           cfld = cfld + 1
           fld_info(cfld)%ifld = IAVBLFLD(IGET(745))

--- a/sorc/ncep_post.fd/CLDRAD.f
+++ b/sorc/ncep_post.fd/CLDRAD.f
@@ -77,6 +77,7 @@
 !> 2023-09-26 | Jaymes Kenyon     | For RRFS, use cloud fraction to diagnose cloud base/top (height and pressure)
 !> 2024-04-23 | Eric James        | Adding smoke emissions (ebb) from RRFS
 !> 2024-05-01 | Jaymes Kenyon     | Updates to the GSL exp-1 ceiling diagnostic
+!> 2024-05-24 | Eric James        | Correcting the vertical summing of biomass burning emissions (EBB)
 !>
 !> @author Russ Treadon W/NP2 @date 1993-08-30
 !---------------------------------------------------------------------------------
@@ -541,7 +542,9 @@
               GRID1(ii,jj) = 0.0
               do k=1,lm
                 LL=LM-k+1
-                GRID1(ii,jj) = GRID1(ii,jj) + EBB(ii,jj,k,1)
+                if(EBB(ii,jj,k,1)/=spval)then
+                  GRID1(ii,jj) = GRID1(ii,jj) + EBB(ii,jj,k,1)/(1E9)
+                endif
               enddo
             enddo
           enddo

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -829,7 +829,7 @@
       !print *,' ifhr=',ifhr
       ifmin = nint(rinc(3))
 !      if(ifhr /= nint(fhour))print*,'find wrong Grib file';stop
-      print*,' in INITPOST ifhr ifmin fileName=',ifhr,ifmin,fileName
+!      print*,' in INITPOST ifhr ifmin fileName=',ifhr,ifmin,fileName
       
 ! Getting tstart
       tstart = 0.

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -829,7 +829,7 @@
       !print *,' ifhr=',ifhr
       ifmin = nint(rinc(3))
 !      if(ifhr /= nint(fhour))print*,'find wrong Grib file';stop
-!      print*,' in INITPOST ifhr ifmin fileName=',ifhr,ifmin,fileName
+      print*,' in INITPOST ifhr ifmin fileName=',ifhr,ifmin,fileName
       
 ! Getting tstart
       tstart = 0.

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -53,6 +53,7 @@
 !> 2024-04-23 | E James    | Adding smoke emissions (ebb) from RRFS
 !> 2024-05-01 | E James    | Adapt the BUCKET1 type fields (15-min acc) for use in RRFS
 !> 2024-05-24 | E James    | Modify the run total acc precip fields for 15-min output
+!> 2024-06-11 | E James    | Modifying RRFS hourly average smoke/dust fields to be PM2.5 and PM20
 !>     
 !> @note
 !> USAGE:    CALL SURFCE

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -52,6 +52,7 @@
 !> 2024-04-03 | E James    | Enabling output of hourly average smoke PM2.5 and dust PM10
 !> 2024-04-23 | E James    | Adding smoke emissions (ebb) from RRFS
 !> 2024-05-01 | E James    | Adapt the BUCKET1 type fields (15-min acc) for use in RRFS
+!> 2024-05-24 | E James    | Modify the run total acc precip fields for 15-min output
 !>     
 !> @note
 !> USAGE:    CALL SURFCE
@@ -482,7 +483,11 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(725))
             fld_info(cfld)%ntrange=1
-            fld_info(cfld)%tinvstat=IFHR
+            if(ifmin>1)then
+              fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+            else
+              fld_info(cfld)%tinvstat=IFHR
+            endif
 !$omp parallel do private(i,j,ii,jj)
             do j=1,jend-jsta+1
               jj = jsta+j-1
@@ -3576,7 +3581,11 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(746))
             fld_info(cfld)%ntrange=1
-            fld_info(cfld)%tinvstat=IFHR-ID(18)
+            if(ifmin>1)then
+              fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+            else
+              fld_info(cfld)%tinvstat=IFHR
+            endif
             if(MODELNAME=='FV3R' .OR. MODELNAME=='GFS')fld_info(cfld)%tinvstat=IFHR
 !$omp parallel do private(i,j,ii,jj)
             do j=1,jend-jsta+1
@@ -3622,7 +3631,11 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(782))
             fld_info(cfld)%ntrange=1
-            fld_info(cfld)%tinvstat=IFHR-ID(18)
+            if(ifmin>1)then
+              fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+            else
+              fld_info(cfld)%tinvstat=IFHR
+            endif
             if(MODELNAME=='FV3R' .OR. MODELNAME=='GFS')fld_info(cfld)%tinvstat=IFHR
 !$omp parallel do private(i,j,ii,jj)
             do j=1,jend-jsta+1
@@ -3668,7 +3681,11 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(1004))
             fld_info(cfld)%ntrange=1
-            fld_info(cfld)%tinvstat=IFHR-ID(18)
+            if(ifmin>1)then
+              fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+            else
+              fld_info(cfld)%tinvstat=IFHR
+            endif
             if(MODELNAME=='FV3R' .or. MODELNAME=='GFS')fld_info(cfld)%tinvstat=IFHR
 !            print*,'id(18),tinvstat in acgraup= ',ID(18),fld_info(cfld)%tinvstat
 !$omp parallel do private(i,j,ii,jj)

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -3581,12 +3581,15 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(746))
             fld_info(cfld)%ntrange=1
-            if(ifmin>1)then
-              fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+            if(MODELNAME=='FV3R' .OR. MODELNAME=='GFS')then
+              if(ifmin>1)then
+                fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+              else
+                fld_info(cfld)%tinvstat=IFHR
+              endif
             else
-              fld_info(cfld)%tinvstat=IFHR
+              fld_info(cfld)%tinvstat=IFHR-ID(18)
             endif
-            if(MODELNAME=='FV3R' .OR. MODELNAME=='GFS')fld_info(cfld)%tinvstat=IFHR
 !$omp parallel do private(i,j,ii,jj)
             do j=1,jend-jsta+1
               jj = jsta+j-1
@@ -3631,12 +3634,15 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(782))
             fld_info(cfld)%ntrange=1
-            if(ifmin>1)then
-              fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+            if(MODELNAME=='FV3R' .OR. MODELNAME=='GFS')then
+              if(ifmin>1)then
+                fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+              else
+                fld_info(cfld)%tinvstat=IFHR
+              endif
             else
-              fld_info(cfld)%tinvstat=IFHR
+              fld_info(cfld)%tinvstat=IFHR-ID(18)
             endif
-            if(MODELNAME=='FV3R' .OR. MODELNAME=='GFS')fld_info(cfld)%tinvstat=IFHR
 !$omp parallel do private(i,j,ii,jj)
             do j=1,jend-jsta+1
               jj = jsta+j-1
@@ -3681,12 +3687,15 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(1004))
             fld_info(cfld)%ntrange=1
-            if(ifmin>1)then
-              fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+            if(MODELNAME=='FV3R' .OR. MODELNAME=='GFS')then
+              if(ifmin>1)then
+                fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+              else
+                fld_info(cfld)%tinvstat=IFHR
+              endif
             else
-              fld_info(cfld)%tinvstat=IFHR
+              fld_info(cfld)%tinvstat=IFHR-ID(18)
             endif
-            if(MODELNAME=='FV3R' .or. MODELNAME=='GFS')fld_info(cfld)%tinvstat=IFHR
 !            print*,'id(18),tinvstat in acgraup= ',ID(18),fld_info(cfld)%tinvstat
 !$omp parallel do private(i,j,ii,jj)
             do j=1,jend-jsta+1

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -2216,14 +2216,14 @@
            endif
          ENDIF
 !
-! Hourly averaged surface smoke
+! Hourly averaged surface PM2.5
 !
         IF (IGET(759)>0) THEN
           GRID1=SPVAL
           DO J=JSTA,JEND
             DO I=ISTA,IEND
             if(T(I,J,LM)/=spval.and.PMID(I,J,LM)/=spval.and.SMOKE_AVE(I,J)/=spval)&
-              GRID1(I,J) = (1./RD)*(PMID(I,J,LM)/T(I,J,LM))*SMOKE_AVE(I,J)/(1E9)
+              GRID1(I,J) = (1./RD)*(PMID(I,J,LM)/T(I,J,LM))*(SMOKE_AVE(I,J)+DUST_AVE(I,J))/(1E9)
             ENDDO
           ENDDO
           ID(1:25) = 0
@@ -2264,7 +2264,7 @@
           DO J=JSTA,JEND
             DO I=ISTA,IEND
             if(T(I,J,LM)/=spval.and.PMID(I,J,LM)/=spval.and.DUST_AVE(I,J)/=spval)&
-              GRID1(I,J) = (1./RD)*(PMID(I,J,LM)/T(I,J,LM))*(DUST_AVE(I,J)+COARSEPM_AVE(I,J))/(1E9)
+              GRID1(I,J) = (1./RD)*(PMID(I,J,LM)/T(I,J,LM))*(SMOKE_AVE(I,J)+DUST_AVE(I,J)+COARSEPM_AVE(I,J))/(1E9)
             ENDDO
           ENDDO
           ID(1:25) = 0

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -4533,7 +4533,7 @@
            DO J=JSTA,JEND
              DO I=ISTA,IEND
                IF(AVGPREC_CONT(I,J) < SPVAL)THEN
-                 GRID1(I,J) = AVGPREC_CONT(I,J)*((IFHR*3600.)+(IFMIN*60.))*1000./DTQ2
+                 GRID1(I,J) = AVGPREC_CONT(I,J)*900.*1000./DTQ2
                ENDIF
              ENDDO
            ENDDO

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -3128,7 +3128,7 @@
            DO J=JSTA,JEND
              DO I=ISTA,IEND
                IF(AVGPREC_CONT(I,J) < SPVAL)THEN
-                 GRID2(I,J) = AVGPREC_CONT(I,J)*FLOAT(IFHR)*3600.*1000./DTQ2
+                 GRID2(I,J) = AVGPREC_CONT(I,J)*((3600.*FLOAT(IFHR))+(60.*FLOAT(IFMIN)))*1000./DTQ2
                ELSE
                  GRID2(I,J) = SPVAL
                END IF
@@ -3142,7 +3142,11 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(417))
             fld_info(cfld)%ntrange=1
-            fld_info(cfld)%tinvstat=IFHR
+            if(ifmin>1)then
+              fld_info(cfld)%tinvstat=IFHR*60+IFMIN
+            else
+              fld_info(cfld)%tinvstat=IFHR
+            endif
 !            print*,'tinvstat in cont bucket= ',fld_info(cfld)%tinvstat
 !$omp parallel do private(i,j,ii,jj)
               do j=1,jend-jsta+1
@@ -4529,7 +4533,7 @@
            DO J=JSTA,JEND
              DO I=ISTA,IEND
                IF(AVGPREC_CONT(I,J) < SPVAL)THEN
-                 GRID1(I,J) = AVGPREC_CONT(I,J)*900.*1000./DTQ2
+                 GRID1(I,J) = AVGPREC_CONT(I,J)*((IFHR*3600.)+(IFMIN*60.))*1000./DTQ2
                ENDIF
              ENDDO
            ENDDO

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -85,7 +85,7 @@
   integer num_pset
   integer isec,hrs_obs_cutoff,min_obs_cutoff
   integer sec_intvl,stat_miss_val,time_inc_betwn_succ_fld
-  integer perturb_num,num_ens_fcst
+  integer perturb_num,num_ens_fcst,prob_num,tot_num_prob
   character*80 type_of_time_inc,stat_unit_time_key_succ
   logical*1,allocatable :: bmap(:)
   integer ibm
@@ -165,7 +165,9 @@
     type_of_time_inc='same_start_time_fcst_fcst_time_inc'
     stat_unit_time_key_succ='missing'
     time_inc_betwn_succ_fld=0
-!
+    prob_num = 0
+    tot_num_prob = 1
+    !
 !-- open fld name tble 
 !
     if(first_grbtbl) then
@@ -548,7 +550,6 @@
     integer scaled_val_fixed_sfc1,scale_fct_fixed_sfc2
     character(80) fixed_sfc2_type
     integer idec_scl,ibin_scl,ibmap,inumbits
-    integer prob_num,tot_num_prob
     character(80) prob_type
     real    fldscl
     integer igdstmpl(igdsmaxlen)
@@ -560,6 +561,7 @@
     integer gefs1,gefs2,gefs3,gefs_status
     character(len=4) cdum
     integer perturb_num,num_ens_fcst,e1_type
+
 !
 !----------------------------------------------------------------------------------------
 ! Find out if the Post is being run for the GEFS model

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -561,7 +561,6 @@
     integer gefs1,gefs2,gefs3,gefs_status
     character(len=4) cdum
     integer perturb_num,num_ens_fcst,e1_type
-
 !
 !----------------------------------------------------------------------------------------
 ! Find out if the Post is being run for the GEFS model
@@ -763,11 +762,9 @@
 
        ihr_start = ifhr-tinvstat 
        if((modelname=='RAPR'.and.vtimeunits=='FMIN').or.(modelname=='FV3R'.and.pset%time_range_unit=="minute")) then
-         print *,'EJ grib2_module.f: time_range_unit is minute'
          ifhrorig = ifhr
          ifhr = ifhr*60 + ifmin
          if(ifmin<1)then
-           print *,'EJ: ifmin<1'
            tinvstat = tinvstat*60 + ifmin
          endif
          ihr_start = max(0,ifhr-tinvstat)

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -507,8 +507,8 @@
     !use gdtsec3, only: getgdtnum
     implicit none
 !
-    integer,intent(in) :: idisc,icatg, iparm,nprm,fldlvl1,fldlvl2,ntrange,tinvstat
-    integer,intent(inout) :: nlvl
+    integer,intent(in) :: idisc,icatg, iparm,nprm,fldlvl1,fldlvl2,ntrange
+    integer,intent(inout) :: nlvl,tinvstat
     real,dimension(:),intent(in) :: datafld1
     character(1),intent(inout) :: cgrib(max_bytes)
     integer, intent(inout) :: lengrib
@@ -763,8 +763,13 @@
 
        ihr_start = ifhr-tinvstat 
        if((modelname=='RAPR'.and.vtimeunits=='FMIN').or.(modelname=='FV3R'.and.pset%time_range_unit=="minute")) then
+         print *,'EJ grib2_module.f: time_range_unit is minute'
          ifhrorig = ifhr
          ifhr = ifhr*60 + ifmin
+         if(ifmin<1)then
+           print *,'EJ: ifmin<1'
+           tinvstat = tinvstat*60 + ifmin
+         endif
          ihr_start = max(0,ifhr-tinvstat)
        else
          if(ifmin > 0.)then  ! change time range unit to minute


### PR DESCRIPTION
The main changes are:

- Bug fix in prob values denoted in QPFARI and QPFFG
- Bug fix in labeling of run total accumulated fields in sub-hourly 
- Bug fix in calculation of vertically summed smoke emissions
- Change the path of g2tmpl/1.12.0 on WCOSS2 to the prod side
- Change 1-h averaged MASSDEN to PM2.5 and PM10

prob_num and tot_num_prob were not set in grib2_module.f, resulting in seemingly random values showing up for the new GRIB2 records QPFARI and QPFFFG, as noted by Hui-Ya Chuang:

< 772:4824832913:vt=2024022023:surface:11-12 hour acc fcst:var discipline=1 center=7 local_table=1 parmcat
=1 parm=197:prob >1:prob fcst 72/110
772:4824832913:vt=2024022023:surface:11-12 hour acc fcst:var discipline=1 center=7 local_table=1 parmcat
=1 parm=197:prob >1:prob fcst 96/110
6177c6177
< 773:4824833141:vt=2024022023:surface:0-12 hour acc fcst:var discipline=1 center=7 local_table=1 parmcat=
1 parm=197:prob >1:prob fcst 72/110

773:4824833141:vt=2024022023:surface:0-12 hour acc fcst:var discipline=1 center=7 local_table=1 parmcat=
1 parm=197:prob >1:prob fcst 96/110

This small change fixes the issue, and should lead to bitwise identical results.

The change was tested for the RRFS_NA_3km system on Hera.