### PR TITLE
[develop]: Turn on WARN_AS_ERROR for Doxygen Documentation Builds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@
 
 
 # Support for public releases and documentation 
-docs/*  @hertneky @fossell @camshe
-scripts/run_upp @hertneky @fossell @camshe
+docs/*  @gspetro-NOAA
+scripts/run_upp @FernandoAndrade-NOAA @gspetro-NOAA
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -110,6 +110,6 @@ jobs:
           export FC=mpiifort
           cd UPP
           mkdir -p build && cd build
-          cmake -DCMAKE_INSTALL_PREFIX=../install ..
+          cmake -DENABLE_DOCS=ON -DCMAKE_INSTALL_PREFIX=../install ..
           make -j2 VERBOSE=1
           make install

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -891,7 +891,7 @@ WARN_IF_UNDOC_ENUM_VAL = NO
 # Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which


### PR DESCRIPTION
This PR turns on the `WARN_AS_ERROR` flag in `Doxyfile.in`, which will cause a build of the documentation to fail when there are warnings (e.g., due to missing/undocumented variables). 
It also enables the doc build in the CI to check that docs are building without warnings.
Resolves Issue #392 .

Documentation builds without warnings or errors on Hercules. 