### PR TITLE
Update Jet modulefile spack-stack path

### DIFF
--- a/modulefiles/jet.lua
+++ b/modulefiles/jet.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build UPP on Jet
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 load(pathJoin("stack-intel", stack_intel_ver))


### PR DESCRIPTION
This PR switches over to the new Jet spack-stack path following the transition to lfs5.