### PR TITLE
Bump up w3emc and ip versions on WCOSS2.

### DIFF
--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -26,10 +26,10 @@ load(pathJoin("zlib", zlib_ver))
 g2_ver=os.getenv("g2_ver") or "3.5.1"
 g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-ip_ver=os.getenv("ip_ver") or "3.3.3"
+ip_ver=os.getenv("ip_ver") or "4.0.0"
 sp_ver=os.getenv("sp_ver") or "2.3.3"
 crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
-w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
+w3emc_ver=os.getenv("w3emc_ver") or "2.12.0"
 load(pathJoin("g2", g2_ver))
 load(pathJoin("g2tmpl", g2tmpl_ver))
 load(pathJoin("bacio", bacio_ver))


### PR DESCRIPTION
Update UPP with w3emc/2.12.0 and ip/4.0.0 on WCOSS2.