### PR TITLE
RRFS-MPAS: Provide TSOIL and SOILW (9 levels) in native-level GRIB2 files

### DIFF
--- a/parm/postxconfig-NT-rrfs_mpas.txt
+++ b/parm/postxconfig-NT-rrfs_mpas.txt
@@ -1,5 +1,5 @@
 3
-18
+19
 14
 144
 WRFTWO
@@ -7400,6 +7400,48 @@ smaller_than_first_limit
 ?
 ?
 ?
+116
+TSOIL_ON_DEPTH_BEL_LAND_SFC
+?
+1
+tmpl4_0
+TSOIL
+?
+?
+depth_bel_land_sfc
+1
+2
+9
+0. 1. 4. 10. 30. 60. 100. 160. 300.
+depth_bel_land_sfc
+1
+2
+9
+0. 1. 4. 10. 30. 60. 100. 160. 300.
+?
+?
+?
+0
+0.0
+0
+0.0
+?
+0
+0.0
+0
+0.0
+0
+0.0
+0
+0.0
+1
+4.0
+0
+0
+0
+?
+?
+?
 117
 SOILW_ON_DEPTH_BEL_LAND_SFC
 ?
@@ -7411,13 +7453,13 @@ NCEP
 depth_bel_land_sfc
 1
 2
-2
-0. 1.
+9
+0. 1. 4. 10. 30. 60. 100. 160. 300.
 depth_bel_land_sfc
 1
 2
-2
-0. 1.
+9
+0. 1. 4. 10. 30. 60. 100. 160. 300.
 ?
 ?
 ?

--- a/parm/rrfs_mpas_postcntrl.xml
+++ b/parm/rrfs_mpas_postcntrl.xml
@@ -1168,11 +1168,21 @@
        </param>
 
        <param>
+          <shortname>TSOIL_ON_DEPTH_BEL_LAND_SFC</shortname>
+          <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+          <level>0. 1. 4. 10. 30. 60. 100. 160. 300.</level>
+          <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+          <level2>0. 1. 4. 10. 30. 60. 100. 160. 300.</level2> 
+          <scale>4.0</scale> 
+       </param>
+
+
+       <param>
           <shortname>SOILW_ON_DEPTH_BEL_LAND_SFC</shortname>
           <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
-          <level>0. 1.</level>
+          <level>0. 1. 4. 10. 30. 60. 100. 160. 300.</level>
           <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
-          <level2>0. 1.</level2>
+          <level2>0. 1. 4. 10. 30. 60. 100. 160. 300.</level2> 
           <scale>3.0</scale>
        </param>
 

--- a/tests/logs/rt.log.HERA
+++ b/tests/logs/rt.log.HERA
@@ -1,69 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-851a62886aed14a0a3c0af36077dc20dd87ca8d1
+c02d8cdb266911ce7ce0a6a21b58401b5fb33915
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -529f870d33b65c3b6c1aa3c3236b94efc3bd336d sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1025/UPP/ci/rundir/upp-HERA
+Run directory: /scratch2/NAGAPE/epic/Gillian.Petro/upp-1054/ci/rundir/upp-HERA
 Baseline directory: /scratch2/NAGAPE/epic/UPP/test_suite
 
-Total runtime: 00h:12m:53s
-Test Date: 20240918 19:45:16
+Total runtime: 00h:10m:46s
+Test Date: 20241003 14:50:37
 Summary Results:
 
-09/18 19:37:12Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-09/18 19:37:15Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-09/18 19:37:15Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-09/18 19:37:32Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-09/18 19:37:53Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-09/18 19:37:54Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-09/18 19:38:27Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-09/18 19:38:30Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-09/18 19:38:31Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-09/18 19:38:33Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-09/18 19:38:34Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-09/18 19:38:34Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-09/18 19:38:37Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-09/18 19:38:38Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-09/18 19:38:38Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-09/18 19:38:50Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-09/18 19:38:50Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-09/18 19:38:51Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-09/18 19:38:53Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-09/18 19:39:14Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-09/18 19:39:15Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-09/18 19:39:16Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-09/18 19:39:17Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-09/18 19:39:19Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-09/18 19:39:19Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-09/18 19:39:21Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-09/18 19:39:23Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-09/18 19:39:23Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-09/18 19:39:25Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-09/18 19:39:26Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-09/18 19:44:36Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-09/18 19:44:38Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-09/18 19:44:38Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-09/18 19:45:10Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-09/18 19:45:12Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-09/18 19:45:12Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-09/18 19:39:39Z -Runtime: nmmb_test 00:01:09 -- baseline 00:01:00
-09/18 19:39:39Z -Runtime: nmmb_pe_test 00:01:05 -- baseline 00:01:00
-09/18 19:39:39Z -Runtime: fv3gefs_test 00:00:20 -- baseline 00:40:00
-09/18 19:39:40Z -Runtime: fv3gefs_pe_test 00:00:20 -- baseline 00:40:00
-09/18 19:39:40Z -Runtime: rap_test 00:01:01 -- baseline 00:02:00
-09/18 19:39:40Z -Runtime: rap_pe_test 00:01:12 -- baseline 00:02:00
-09/18 19:39:40Z -Runtime: hrrr_test 00:02:23 -- baseline 00:02:00
-09/18 19:39:41Z -Runtime: hrrr_pe_test 00:02:00 -- baseline 00:02:00
-09/18 19:44:43Z -Runtime: fv3gfs_test 00:07:46 -- baseline 00:15:00
-09/18 19:45:14Z -Runtime: fv3gfs_pe_test 00:08:19 -- baseline 00:15:00
-09/18 19:45:14Z -Runtime: fv3r_test 00:01:37 -- baseline 00:03:00
-09/18 19:45:15Z -Runtime: fv3r_pe_test 00:01:44 -- baseline 00:03:00
-09/18 19:45:15Z -Runtime: fv3hafs_test 00:00:39 -- baseline 00:03:00
-09/18 19:45:15Z -Runtime: fv3hafs_pe_test 00:00:36 -- baseline 00:03:00
-09/18 19:45:16Z -Runtime: rtma_test 00:01:45 -- baseline 00:03:00
-09/18 19:45:16Z -Runtime: rtma_test_pe_test 00:01:44 -- baseline 
+10/03 14:42:38Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+10/03 14:43:23Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+10/03 14:43:32Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+10/03 14:43:53Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+10/03 14:43:56Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+10/03 14:43:57Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+10/03 14:44:03Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+10/03 14:44:08Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+10/03 14:44:09Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+10/03 14:44:09Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+10/03 14:44:10Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+10/03 14:44:12Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+10/03 14:44:13Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+10/03 14:44:14Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+10/03 14:44:16Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+10/03 14:44:16Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+10/03 14:44:16Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+10/03 14:44:17Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+10/03 14:44:31Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+10/03 14:44:33Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+10/03 14:44:34Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+10/03 14:44:34Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+10/03 14:44:35Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+10/03 14:44:35Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+10/03 14:44:36Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+10/03 14:44:36Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+10/03 14:44:37Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+10/03 14:44:39Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+10/03 14:44:40Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+10/03 14:44:41Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+10/03 14:49:43Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+10/03 14:49:45Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+10/03 14:49:45Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+10/03 14:50:18Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+10/03 14:50:21Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+10/03 14:50:21Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+10/03 14:44:44Z -Runtime: nmmb_test 00:01:07 -- baseline 00:01:00
+10/03 14:44:44Z -Runtime: nmmb_pe_test 00:01:11 -- baseline 00:01:00
+10/03 14:44:45Z -Runtime: fv3gefs_test 00:00:22 -- baseline 00:40:00
+10/03 14:44:45Z -Runtime: fv3gefs_pe_test 00:00:15 -- baseline 00:40:00
+10/03 14:44:46Z -Runtime: rap_test 00:01:00 -- baseline 00:02:00
+10/03 14:44:46Z -Runtime: rap_pe_test 00:01:13 -- baseline 00:02:00
+10/03 14:44:46Z -Runtime: hrrr_test 00:02:24 -- baseline 00:02:00
+10/03 14:44:47Z -Runtime: hrrr_pe_test 00:02:00 -- baseline 00:02:00
+10/03 14:49:49Z -Runtime: fv3gfs_test 00:07:21 -- baseline 00:15:00
+10/03 14:50:35Z -Runtime: fv3gfs_pe_test 00:07:45 -- baseline 00:15:00
+10/03 14:50:35Z -Runtime: fv3r_test 00:01:32 -- baseline 00:03:00
+10/03 14:50:35Z -Runtime: fv3r_pe_test 00:01:35 -- baseline 00:03:00
+10/03 14:50:36Z -Runtime: fv3hafs_test 00:00:34 -- baseline 00:03:00
+10/03 14:50:36Z -Runtime: fv3hafs_pe_test 00:00:33 -- baseline 00:03:00
+10/03 14:50:36Z -Runtime: rtma_test 00:01:36 -- baseline 00:03:00
+10/03 14:50:36Z -Runtime: rtma_test_pe_test 00:01:37 -- baseline 
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.HERCULES
+++ b/tests/logs/rt.log.HERCULES
@@ -1,69 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-851a62886aed14a0a3c0af36077dc20dd87ca8d1
+c02d8cdb266911ce7ce0a6a21b58401b5fb33915
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -529f870d33b65c3b6c1aa3c3236b94efc3bd336d sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/hercules/1025/UPP/ci/rundir/upp-HERCULES
+Run directory: /work/noaa/epic/gpetro/upp-1054-h/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:12m:05s
-Test Date: 20240918 14:47:28
+Total runtime: 00h:18m:09s
+Test Date: 20241003 09:57:43
 Summary Results:
 
-09/18 19:37:48Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-09/18 19:37:51Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-09/18 19:38:06Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-09/18 19:38:06Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-09/18 19:38:34Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-09/18 19:38:34Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-09/18 19:38:35Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-09/18 19:38:36Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-09/18 19:38:47Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-09/18 19:38:47Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-09/18 19:38:48Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-09/18 19:38:55Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-09/18 19:38:55Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-09/18 19:38:56Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-09/18 19:39:22Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-09/18 19:39:24Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-09/18 19:39:28Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-09/18 19:39:29Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-09/18 19:39:30Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-09/18 19:39:37Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-09/18 19:39:39Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-09/18 19:39:56Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-09/18 19:39:57Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-09/18 19:39:58Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-09/18 19:39:58Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-09/18 19:39:59Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-09/18 19:39:59Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-09/18 19:42:27Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-09/18 19:42:28Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-09/18 19:42:28Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-09/18 19:44:36Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-09/18 19:44:38Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-09/18 19:44:38Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-09/18 19:47:16Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-09/18 19:47:17Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-09/18 19:47:17Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-09/18 19:38:57Z -Runtime: nmmb_test 00:01:29 -- baseline 00:03:00
-09/18 19:38:57Z -Runtime: nmmb_pe_test 00:01:22 -- baseline 00:03:00
-09/18 19:38:57Z -Runtime: fv3gefs_test 00:00:22 -- baseline 01:20:00
-09/18 19:38:57Z -Runtime: fv3gefs_pe_test 00:00:24 -- baseline 01:20:00
-09/18 19:38:57Z -Runtime: rap_test 00:01:09 -- baseline 00:02:00
-09/18 19:38:57Z -Runtime: rap_pe_test 00:01:07 -- baseline 00:02:00
-09/18 19:42:42Z -Runtime: hrrr_test 00:05:01 -- baseline 00:02:00
-09/18 19:42:42Z -Runtime: hrrr_pe_test 00:02:03 -- baseline 00:02:00
-09/18 19:47:28Z -Runtime: fv3gfs_test 00:09:50 -- baseline 00:18:00
-09/18 19:47:28Z -Runtime: fv3gfs_pe_test 00:07:11 -- baseline 00:18:00
-09/18 19:47:28Z -Runtime: fv3r_test 00:01:57 -- baseline 00:03:00
-09/18 19:47:28Z -Runtime: fv3r_pe_test 00:02:12 -- baseline 00:03:00
-09/18 19:47:28Z -Runtime: fv3hafs_test 00:00:39 -- baseline 00:00:40
-09/18 19:47:28Z -Runtime: fv3hafs_pe_test 00:00:39 -- baseline 00:00:40
-09/18 19:47:28Z -Runtime: rtma_test 00:02:32 -- baseline 00:04:00
-09/18 19:47:28Z -Runtime: rtma_pe_test 00:02:29 -- baseline 00:04:00
+10/03 14:44:06Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+10/03 14:44:08Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+10/03 14:44:53Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+10/03 14:44:54Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+10/03 14:44:56Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+10/03 14:45:13Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+10/03 14:45:21Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+10/03 14:46:25Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+10/03 14:46:27Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+10/03 14:46:27Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+10/03 14:46:50Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+10/03 14:46:51Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+10/03 14:46:51Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+10/03 14:47:51Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+10/03 14:48:19Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+10/03 14:48:19Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+10/03 14:49:36Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+10/03 14:49:42Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+10/03 14:49:43Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+10/03 14:50:29Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+10/03 14:50:29Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+10/03 14:50:30Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+10/03 14:51:02Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+10/03 14:51:04Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+10/03 14:51:31Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+10/03 14:51:31Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+10/03 14:51:33Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+10/03 14:51:33Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+10/03 14:51:33Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+10/03 14:51:33Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+10/03 14:51:57Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+10/03 14:51:58Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+10/03 14:51:59Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+10/03 14:57:33Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+10/03 14:57:33Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+10/03 14:57:33Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+10/03 14:46:57Z -Runtime: nmmb_test 00:04:25 -- baseline 00:03:00
+10/03 14:46:57Z -Runtime: nmmb_pe_test 00:04:01 -- baseline 00:03:00
+10/03 14:49:42Z -Runtime: fv3gefs_test 00:00:16 -- baseline 01:20:00
+10/03 14:49:42Z -Runtime: fv3gefs_pe_test 00:00:21 -- baseline 01:20:00
+10/03 14:49:42Z -Runtime: rap_test 00:00:49 -- baseline 00:02:00
+10/03 14:49:42Z -Runtime: rap_pe_test 00:01:38 -- baseline 00:02:00
+10/03 14:52:12Z -Runtime: hrrr_test 00:04:29 -- baseline 00:02:00
+10/03 14:52:12Z -Runtime: hrrr_pe_test 00:02:26 -- baseline 00:02:00
+10/03 14:57:43Z -Runtime: fv3gfs_test 00:10:03 -- baseline 00:18:00
+10/03 14:57:43Z -Runtime: fv3gfs_pe_test 00:08:00 -- baseline 00:18:00
+10/03 14:57:43Z -Runtime: fv3r_test 00:02:51 -- baseline 00:03:00
+10/03 14:57:43Z -Runtime: fv3r_pe_test 00:01:54 -- baseline 00:03:00
+10/03 14:57:43Z -Runtime: fv3hafs_test 00:00:30 -- baseline 00:00:40
+10/03 14:57:43Z -Runtime: fv3hafs_pe_test 00:00:29 -- baseline 00:00:40
+10/03 14:57:43Z -Runtime: rtma_test 00:02:16 -- baseline 00:04:00
+10/03 14:57:43Z -Runtime: rtma_pe_test 00:02:13 -- baseline 00:04:00
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION
+++ b/tests/logs/rt.log.ORION
@@ -1,69 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-851a62886aed14a0a3c0af36077dc20dd87ca8d1
+c02d8cdb266911ce7ce0a6a21b58401b5fb33915
 
 Submodule hashes:
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e sorc/libIFI.fd
 -529f870d33b65c3b6c1aa3c3236b94efc3bd336d sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/nandoam/regression-testing/upp/orion/1025/UPP/ci/rundir/upp-ORION
+Run directory: /work/noaa/epic/gpetro/upp-1054-o/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:14m:20s
-Test Date: 20240918 14:48:28
+Total runtime: 00h:16m:02s
+Test Date: 20241003 09:55:50
 Summary Results:
 
-09/18 19:38:05Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-09/18 19:38:07Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-09/18 19:38:23Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-09/18 19:38:24Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-09/18 19:38:52Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-09/18 19:38:53Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-09/18 19:38:53Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-09/18 19:38:53Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-09/18 19:38:54Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-09/18 19:39:06Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-09/18 19:39:07Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-09/18 19:39:07Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-09/18 19:39:09Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-09/18 19:39:10Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-09/18 19:39:42Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-09/18 19:39:45Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-09/18 19:39:51Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-09/18 19:39:54Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-09/18 19:40:12Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-09/18 19:40:15Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-09/18 19:40:15Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-09/18 19:40:15Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-09/18 19:40:17Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-09/18 19:40:18Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-09/18 19:40:24Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-09/18 19:40:25Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-09/18 19:40:26Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-09/18 19:45:28Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-09/18 19:45:29Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-09/18 19:45:30Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-09/18 19:46:16Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-09/18 19:46:17Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-09/18 19:46:17Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-09/18 19:48:19Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-09/18 19:48:20Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-09/18 19:48:20Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-09/18 19:39:10Z -Runtime: nmmb_test 00:01:42 -- baseline 00:03:00
-09/18 19:39:10Z -Runtime: nmmb_pe_test 00:01:28 -- baseline 00:03:00
-09/18 19:39:10Z -Runtime: fv3gefs_test 00:00:24 -- baseline 01:20:00
-09/18 19:39:10Z -Runtime: fv3gefs_pe_test 00:00:26 -- baseline 01:20:00
-09/18 19:39:11Z -Runtime: rap_test 00:01:29 -- baseline 00:02:00
-09/18 19:39:11Z -Runtime: rap_pe_test 00:01:29 -- baseline 00:02:00
-09/18 19:45:42Z -Runtime: hrrr_test 00:07:49 -- baseline 00:02:00
-09/18 19:45:42Z -Runtime: hrrr_pe_test 00:03:02 -- baseline 00:02:00
-09/18 19:48:27Z -Runtime: fv3gfs_test 00:10:55 -- baseline 00:18:00
-09/18 19:48:27Z -Runtime: fv3gfs_pe_test 00:08:52 -- baseline 00:18:00
-09/18 19:48:27Z -Runtime: fv3r_test 00:02:20 -- baseline 00:03:00
-09/18 19:48:27Z -Runtime: fv3r_pe_test 00:02:29 -- baseline 00:03:00
-09/18 19:48:28Z -Runtime: fv3hafs_test 00:00:43 -- baseline 00:00:40
-09/18 19:48:28Z -Runtime: fv3hafs_pe_test 00:00:42 -- baseline 00:00:40
-09/18 19:48:28Z -Runtime: rtma_test 00:02:50 -- baseline 00:04:00
-09/18 19:48:28Z -Runtime: rtma_pe_test 00:02:51 -- baseline 00:04:00
+10/03 14:44:43Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+10/03 14:44:48Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+10/03 14:45:28Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+10/03 14:46:01Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+10/03 14:46:05Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+10/03 14:46:07Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+10/03 14:46:19Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+10/03 14:46:24Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+10/03 14:47:07Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+10/03 14:47:10Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+10/03 14:47:10Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+10/03 14:47:11Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+10/03 14:47:12Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+10/03 14:47:13Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+10/03 14:47:13Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+10/03 14:47:21Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+10/03 14:47:21Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+10/03 14:47:22Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+10/03 14:47:22Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+10/03 14:47:22Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+10/03 14:47:24Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+10/03 14:47:38Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+10/03 14:47:40Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+10/03 14:47:40Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+10/03 14:47:41Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+10/03 14:47:43Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+10/03 14:47:43Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+10/03 14:51:59Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+10/03 14:52:00Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+10/03 14:52:02Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+10/03 14:53:55Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+10/03 14:53:56Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+10/03 14:53:56Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+10/03 14:55:34Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+10/03 14:55:35Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+10/03 14:55:35Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+10/03 14:47:32Z -Runtime: nmmb_test 00:03:06 -- baseline 00:03:00
+10/03 14:47:32Z -Runtime: nmmb_pe_test 00:02:58 -- baseline 00:03:00
+10/03 14:47:33Z -Runtime: fv3gefs_test 00:00:28 -- baseline 01:20:00
+10/03 14:47:33Z -Runtime: fv3gefs_pe_test 00:00:32 -- baseline 01:20:00
+10/03 14:47:33Z -Runtime: rap_test 00:01:49 -- baseline 00:02:00
+10/03 14:47:33Z -Runtime: rap_pe_test 00:02:06 -- baseline 00:02:00
+10/03 14:52:03Z -Runtime: hrrr_test 00:07:44 -- baseline 00:02:00
+10/03 14:52:03Z -Runtime: hrrr_pe_test 00:03:06 -- baseline 00:02:00
+10/03 14:55:49Z -Runtime: fv3gfs_test 00:11:17 -- baseline 00:18:00
+10/03 14:55:49Z -Runtime: fv3gfs_pe_test 00:09:38 -- baseline 00:18:00
+10/03 14:55:49Z -Runtime: fv3r_test 00:02:55 -- baseline 00:03:00
+10/03 14:55:49Z -Runtime: fv3r_pe_test 00:02:52 -- baseline 00:03:00
+10/03 14:55:49Z -Runtime: fv3hafs_test 00:01:10 -- baseline 00:00:40
+10/03 14:55:49Z -Runtime: fv3hafs_pe_test 00:01:43 -- baseline 00:00:40
+10/03 14:55:49Z -Runtime: rtma_test 00:03:25 -- baseline 00:04:00
+10/03 14:55:49Z -Runtime: rtma_pe_test 00:03:23 -- baseline 00:04:00
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
For RRFS-MPAS applications, this update provides TSOIL and SOILW within the native-level GRIB2 files for all nine soil levels.  It has been successfully tested in a real-time RRFS-MPAS configuration.

This PR addresses issue #1053.