### PR TITLE
Correct spack-stack path for Gaea-C6

### DIFF
--- a/modulefiles/gaeac6.lua
+++ b/modulefiles/gaeac6.lua
@@ -5,12 +5,12 @@ help([[
 
 whatis([===[Loads libraries needed for building the UPP on Gaea C6 ]===])
 
-prepend_path("MODULEPATH", "/autofs/ncrc-svm1_proj/epic/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/autofs/ncrc-svm1_proj/epic/spack-stack/c6/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
 load(pathJoin("stack-intel", stack_intel_ver))
 
-stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
+stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.29"
 load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
 
 cmake_ver=os.getenv("cmake_ver") or "3.23.1"


### PR DESCRIPTION
Updates the spack-stack path for Gaea-C6 to follow ufs-wx-model.
Resolves #1082 
Refs https://github.com/NOAA-EMC/global-workflow/issues/3011