### PR TITLE
Bug fix for time labeling in GRIB2 template 4.46

### DIFF
--- a/parm/post_avblflds.xml
+++ b/parm/post_avblflds.xml
@@ -7001,6 +7001,7 @@
        <pname>MASSDEN</pname>
        <stats_proc>AVE</stats_proc>
        <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <aerosol_type>total_aerosol</aerosol_type>
        <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
        <scale_fact_1st_size>7</scale_fact_1st_size>
        <scale_val_1st_size>25</scale_val_1st_size>
@@ -7107,6 +7108,7 @@
        <pname>MASSDEN</pname>
        <stats_proc>AVE</stats_proc>
        <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <aerosol_type>total_aerosol</aerosol_type>
        <level>8.</level>
        <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
        <scale_fact_1st_size>7</scale_fact_1st_size>

--- a/parm/postxconfig-NT-rrfs.txt
+++ b/parm/postxconfig-NT-rrfs.txt
@@ -11377,7 +11377,7 @@ spec_hgt_lvl_above_grnd
 ?
 0
 ?
-?
+total_aerosol
 ?
 smaller_than_first_limit
 7
@@ -11419,7 +11419,7 @@ spec_hgt_lvl_above_grnd
 ?
 0
 ?
-?
+total_aerosol
 ?
 smaller_than_first_limit
 7

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -936,7 +936,7 @@
               pset%param(nprm)%scale_val_2nd_size,             &
               pset%gen_proc_type,                              &
               pset%gen_proc,hrs_obs_cutoff,min_obs_cutoff,     &
-              pset%time_range_unit,ifhr,                       &
+              pset%time_range_unit,ihr_start,                  &
               pset%param(nprm)%fixed_sfc1_type,                &
               scale_fct_fixed_sfc1,                            &
               scaled_val_fixed_sfc1,                           &


### PR DESCRIPTION
This PR fixes the bug in time labeling for the RRFS 1-h average PM2.5 and PM10 variables.  The code was tested for the RRFS_NA_3km system on Jet.