### PR TITLE
Update S4 module file to use Rocky8 install of Spack-Stack

### DIFF
--- a/modulefiles/s4.lua
+++ b/modulefiles/s4.lua
@@ -5,10 +5,10 @@
 -- ---------------------------------------------------------------------------
 
 
-prepend_path("MODULEPATH", "/data/prod/jedi/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/data/prod/jedi/spack-stack/spack-stack-1.6.0/envs/upp-addon-ue-intel-2021.10.0/install/modulefiles/Core")
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.0"
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/tests/logs/rt.log.HERA
+++ b/tests/logs/rt.log.HERA
@@ -1,67 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-43f7fc0f66bb41bdb35af7be717141bebdee6bda
+81ca61225fa2e7ce61884c22e06508359a79db52
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -529f870d33b65c3b6c1aa3c3236b94efc3bd336d sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch1/NCEPDEV/nems/Gillian.Petro/RTs/upp-rts/1085/ci/rundir/upp-HERA
+Run directory: /scratch1/NESDIS/nesdis-rdo2/Innocent.Souopgui/devel/s4-rocky8/UPP/ci/rundir/upp-HERA
 Baseline directory: /scratch2/NAGAPE/epic/UPP/test_suite
 
-Total runtime: 03h:34m:41s
-Test Date: 20241108 01:22:51
+Total runtime: 00h:11m:43s
+Test Date: 20241119 16:49:16
 Summary Results:
 
-11/08 01:14:39Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-11/08 01:14:44Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-11/08 01:14:54Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-11/08 01:15:20Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-11/08 01:15:22Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-11/08 01:15:38Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-11/08 01:15:39Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-11/08 01:15:39Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-11/08 01:15:44Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-11/08 01:15:45Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-11/08 01:15:46Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
-11/08 01:15:49Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-11/08 01:15:50Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-11/08 01:15:53Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-11/08 01:15:53Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-11/08 01:15:54Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-11/08 01:15:57Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-11/08 01:15:57Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
-11/08 01:16:06Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-11/08 01:16:08Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-11/08 01:16:10Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-11/08 01:16:29Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-11/08 01:16:30Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-11/08 01:16:32Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-11/08 01:16:51Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-11/08 01:16:54Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-11/08 01:16:54Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-11/08 01:16:56Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-11/08 01:16:57Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-11/08 01:16:58Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-11/08 01:22:07Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-11/08 01:22:11Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-11/08 01:22:12Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-11/08 01:22:44Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-11/08 01:22:47Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-11/08 01:22:48Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-11/08 01:15:56Z -Runtime: fv3gefs_test 00:00:27 -- baseline 00:40:00
-11/08 01:15:57Z -Runtime: fv3gefs_pe_test 00:00:35 -- baseline 00:40:00
-11/08 01:15:57Z -Runtime: rap_test 00:01:18 -- baseline 00:02:00
-11/08 01:15:57Z -Runtime: rap_pe_test 00:01:35 -- baseline 00:02:00
-11/08 01:16:43Z -Runtime: hrrr_test 00:02:48 -- baseline 00:02:00
-11/08 01:16:43Z -Runtime: hrrr_pe_test 00:02:26 -- baseline 00:02:00
-11/08 01:22:18Z -Runtime: fv3gfs_test 00:08:28 -- baseline 00:15:00
-11/08 01:22:49Z -Runtime: fv3gfs_pe_test 00:09:04 -- baseline 00:15:00
-11/08 01:22:49Z -Runtime: fv3r_test 00:02:02 -- baseline 00:03:00
-11/08 01:22:49Z -Runtime: fv3r_pe_test 00:02:06 -- baseline 00:03:00
-11/08 01:22:50Z -Runtime: fv3hafs_test 00:01:00 -- baseline 00:03:00
-11/08 01:22:50Z -Runtime: fv3hafs_pe_test 00:00:50 -- baseline 00:03:00
-11/08 01:22:50Z -Runtime: rtma_test 00:02:13 -- baseline 00:03:00
-11/08 01:22:51Z -Runtime: rtma_test_pe_test 00:02:09 -- baseline 
+11/19 16:40:44Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+11/19 16:40:44Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+11/19 16:40:59Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+11/19 16:41:00Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+11/19 16:41:26Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+11/19 16:41:27Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+11/19 16:41:34Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+11/19 16:41:38Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+11/19 16:41:39Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+11/19 16:41:39Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+11/19 16:41:40Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+11/19 16:41:41Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+11/19 16:41:43Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+11/19 16:41:44Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+11/19 16:41:56Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+11/19 16:42:01Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+11/19 16:42:04Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+11/19 16:42:06Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+11/19 16:42:08Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+11/19 16:42:10Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+11/19 16:42:10Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+11/19 16:42:10Z -rtma pe test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+11/19 16:42:12Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+11/19 16:42:12Z -rtma test: your new post executable generates bit-identical IFIFIP00.tm00 as the trunk
+11/19 16:42:24Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+11/19 16:42:27Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+11/19 16:42:29Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+11/19 16:42:52Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+11/19 16:42:53Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+11/19 16:42:54Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+11/19 16:48:22Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+11/19 16:48:24Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+11/19 16:48:24Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+11/19 16:48:59Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+11/19 16:49:02Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+11/19 16:49:02Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+11/19 16:41:52Z -Runtime: nmmb_test 00:01:33 -- baseline 00:01:00
+11/19 16:41:53Z -Runtime: nmmb_pe_test 00:01:31 -- baseline 00:01:00
+11/19 16:41:53Z -Runtime: fv3gefs_test 00:00:36 -- baseline 00:40:00
+11/19 16:41:53Z -Runtime: fv3gefs_pe_test 00:00:36 -- baseline 00:40:00
+11/19 16:41:53Z -Runtime: rap_test 00:01:19 -- baseline 00:02:00
+11/19 16:41:54Z -Runtime: rap_pe_test 00:01:36 -- baseline 00:02:00
+11/19 16:43:10Z -Runtime: hrrr_test 00:02:46 -- baseline 00:02:00
+11/19 16:43:11Z -Runtime: hrrr_pe_test 00:02:22 -- baseline 00:02:00
+11/19 16:48:29Z -Runtime: fv3gfs_test 00:08:16 -- baseline 00:15:00
+11/19 16:49:14Z -Runtime: fv3gfs_pe_test 00:08:54 -- baseline 00:15:00
+11/19 16:49:14Z -Runtime: fv3r_test 00:01:53 -- baseline 00:03:00
+11/19 16:49:15Z -Runtime: fv3r_pe_test 00:02:00 -- baseline 00:03:00
+11/19 16:49:15Z -Runtime: fv3hafs_test 00:00:51 -- baseline 00:03:00
+11/19 16:49:15Z -Runtime: fv3hafs_pe_test 00:00:52 -- baseline 00:03:00
+11/19 16:49:16Z -Runtime: rtma_test 00:02:04 -- baseline 00:03:00
+11/19 16:49:16Z -Runtime: rtma_test_pe_test 00:02:02 -- baseline 
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
**Description**

Following OS upgrade to Rocky8 on S4, spack stack was re-installed and s4 module files needs updates.
This PR updates S4 module files to point to the new install of spack stack.

Resolve #1094 

**Type of change**
This is non-breaking change which fixes an issue on a single platform, without affecting other platforms.

**How Has This Been Tested?**
- [X] Successful Regression Tests on Hera
- [X] Clone and build on Hera, Jet and S4
- [X] Cycle test within Global Workflow at the following resolutions on S4:
  - [x] 96/48
  - [x] 192/96