### PR TITLE
Update Jet to spack stack 1.8.0

### DIFF
--- a/modulefiles/jet.lua
+++ b/modulefiles/jet.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build UPP on Jet
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.8.0/envs/ue-intel-2021.5.0/install/modulefiles/Core/")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 load(pathJoin("stack-intel", stack_intel_ver))
@@ -10,7 +10,7 @@ load(pathJoin("stack-intel", stack_intel_ver))
 stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 
-cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 load(pathJoin("cmake", cmake_ver))
 
 load("upp_common")


### PR DESCRIPTION
This small PR updates the Jet modulefile to utilize the spack stack 1.8.0 ue-intel 2021.5.0 env and cmake to 3.27.9.