### PR TITLE
use @v4 of cache & checkout actions

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -35,14 +35,14 @@ jobs:
 
     steps:
       - name: checkout-upp  # This is for getting spack.yaml
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: UPP
 
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             spack
@@ -71,13 +71,13 @@ jobs:
 
     steps:
       - name: checkout-upp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: UPP
 
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             spack

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -38,14 +38,14 @@ jobs:
     steps:
       - name: checkout-upp  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: UPP
 
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             spack
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: checkout-upp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: UPP
 
@@ -94,7 +94,7 @@ jobs:
 
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             spack


### PR DESCRIPTION
This PR updates the CI workflows to use cache@v4 and checkout@v4, which are the latest versions.

Fixes #649