### PR TITLE
Load cmake on wcoss2 at build time

### DIFF
--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -11,6 +11,9 @@ load(pathJoin("intel", intel_ver))
 load(pathJoin("craype", craype_ver))
 load(pathJoin("cray-mpich", cray_mpich_ver))
 
+cmake_ver=os.getenv("cmake_ver") or "3.20.2"
+load(pathJoin("cmake", cmake_ver))
+
 hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
 netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 load(pathJoin("hdf5", hdf5_ver))


### PR DESCRIPTION
This PR enables loading of cmake on wcoss2 at build time.
Resolves #1106 

For additional information, please look at the conversations in https://github.com/NOAA-EMC/global-workflow/pull/3186