### PR TITLE
HAILCAST fix

### DIFF
--- a/sorc/ncep_post.fd/MDL2AGL.f
+++ b/sorc/ncep_post.fd/MDL2AGL.f
@@ -674,7 +674,9 @@
           IF((IGET(728)>0) )THEN
              DO J=JSTA,JEND
              DO I=ISTA,IEND
+             IF(HAIL_MAX2D(I,J)<SPVAL)THEN
                GRID1(I,J)=HAIL_MAXHAILCAST(I,J)/1000.0 ! convert mm to m
+             ENDIF
              ENDDO
              ENDDO
              if(grib=='grib2') then

--- a/sorc/ncep_post.fd/MDL2AGL.f
+++ b/sorc/ncep_post.fd/MDL2AGL.f
@@ -674,7 +674,7 @@
           IF((IGET(728)>0) )THEN
              DO J=JSTA,JEND
              DO I=ISTA,IEND
-             IF(HAIL_MAX2D(I,J)<SPVAL)THEN
+             IF(HAIL_MAXHAILCAST(I,J)<SPVAL)THEN
                GRID1(I,J)=HAIL_MAXHAILCAST(I,J)/1000.0 ! convert mm to m
              ENDIF
              ENDDO


### PR DESCRIPTION
Adding a check for undefined values before assigning hailcast in RRFS output.  

The code was tested for a RRFS_CONUS_3km case on Jet.