### PR TITLE
Add PRs #1159, 1171, and 1179 into release/rrfs_v1

### DIFF
--- a/sorc/ncep_post.fd/ALLOCATE_ALL.f
+++ b/sorc/ncep_post.fd/ALLOCATE_ALL.f
@@ -155,6 +155,7 @@
       allocate(QQNW(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QQNI(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QQNR(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
+      allocate(QQNG(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QQNWFA(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QQNIFA(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(TAOD5503D(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
@@ -191,6 +192,7 @@
             QQNW(i,j,l)=spval
             QQNI(i,j,l)=spval
             QQNR(i,j,l)=spval
+            QQNG(i,j,l)=spval
             QQNWFA(i,j,l)=spval
             QQNIFA(i,j,l)=spval
             TAOD5503D(i,j,l)=spval
@@ -649,6 +651,9 @@
           snow_bucket1(i,j)=spval
           graup_bucket(i,j)=spval
           graup_bucket1(i,j)=spval
+          frzrn_bucket(i,j)=spval
+          snow_acm(i,j)=spval
+          snow_bkt(i,j)=spval
           qrmax(i,j)=spval
           tmax(i,j)=spval
           snownc(i,j)=spval
@@ -758,6 +763,7 @@
           sfclhx(i,j)=spval
           fis(i,j)=spval
           t500(i,j)=spval
+          z500(i,j)=spval
           t700(i,j)=spval
           z700(i,j)=spval
           teql(i,j)=spval

--- a/sorc/ncep_post.fd/ALLOCATE_ALL.f
+++ b/sorc/ncep_post.fd/ALLOCATE_ALL.f
@@ -155,7 +155,6 @@
       allocate(QQNW(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QQNI(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QQNR(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
-      allocate(QQNG(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QQNWFA(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(QQNIFA(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
       allocate(TAOD5503D(ista_2l:iend_2u,jsta_2l:jend_2u,lm))
@@ -192,7 +191,6 @@
             QQNW(i,j,l)=spval
             QQNI(i,j,l)=spval
             QQNR(i,j,l)=spval
-            QQNG(i,j,l)=spval
             QQNWFA(i,j,l)=spval
             QQNIFA(i,j,l)=spval
             TAOD5503D(i,j,l)=spval

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -2093,8 +2093,10 @@
 !$omp parallel do private(i,j,tlmh)
       Do j=jsta,jend
         Do i=ista,iend
-          TLMH = T(I,J,LM) * T(I,J,LM)
-          Sigt4(i,j) = 5.67E-8 * TLMH * TLMH
+          if ( T(I,J,LM) < spval ) then
+            TLMH = T(I,J,LM) * T(I,J,LM)
+            Sigt4(i,j) = 5.67E-8 * TLMH * TLMH
+          endif
         End do
       End do
 
@@ -2643,7 +2645,9 @@
           if(ext550(i,j,l)<spval)then
             taod5503d ( i, j, l) = ext550 ( i, j, l )
             dz = ZINT( i, j, l ) - ZINT( i, j, l+1 )
-            aextc55 ( i, j, l ) = taod5503d ( i, j, l ) / dz
+            if ( dz /= 0.0) then
+              aextc55 ( i, j, l ) = taod5503d ( i, j, l ) / dz
+            endif
           endif
           if(debugprint.and.i==im/2.and.j==(jsta+jend)/2)print*,'sample taod5503d= ',   &
            i,j,l,taod5503d ( i, j, l )

--- a/sorc/ncep_post.fd/MDL2AGL.f
+++ b/sorc/ncep_post.fd/MDL2AGL.f
@@ -19,6 +19,7 @@
 !!   21-10-14  J MENG - 2D DECOMPOSITION
 !! 2023-03-02  S TRAHAN - copy lightning threat index 3 element-by-element
 !! 2023-10-23  J Kenyon - HAILCAST output enabled in RRFS
+!! 2025-04-01  W Meng - Bug fix in HAILCAST
 !!     
 !! USAGE:    CALL MDL2P
 !!   INPUT ARGUMENT LIST:
@@ -676,6 +677,8 @@
              DO I=ISTA,IEND
              IF(HAIL_MAXHAILCAST(I,J)<SPVAL)THEN
                GRID1(I,J)=HAIL_MAXHAILCAST(I,J)/1000.0 ! convert mm to m
+             ELSE
+               GRID1(I,J)=SPVAL
              ENDIF
              ENDDO
              ENDDO


### PR DESCRIPTION
This PR includes three sets of updates:

1. INITPOST_NETCDF.f is updated to include a post floating overflow bug fix from HAFS.  These changes were merged into the UPP develop branch as part of PR #1159 and are related to issue #1121 .

2. ALLOCATE_ALL.f is updated to include some memory checks that were merged into the UPP develop branch as part of PR #1171 .  The QQNG change is not included here since QQNG is not available in RRFSv1 (intended for MPAS/RRFSv2).

3. MDL2AGL.f is updated to include a bug fix in the hailcast diagnostic calculation.  This change is waiting to be committed to the UPP develop branch as part of PR #1179 and it fixes issue #1178 .

A standalone UPP test was completed on Dogwood and the results are as expected:
/lfs/h2/emc/ptmp/Benjamin.Blake/post_rrfs_2025040112

