### PR TITLE
Verifying complete initialization of all allocated variables.

### DIFF
--- a/sorc/ncep_post.fd/ALLOCATE_ALL.f
+++ b/sorc/ncep_post.fd/ALLOCATE_ALL.f
@@ -194,6 +194,7 @@
             QQNW(i,j,l)=spval
             QQNI(i,j,l)=spval
             QQNR(i,j,l)=spval
+            QQNG(i,j,l)=spval
             QQNWFA(i,j,l)=spval
             QQNIFA(i,j,l)=spval
             TAOD5503D(i,j,l)=spval
@@ -652,6 +653,9 @@
           snow_bucket1(i,j)=spval
           graup_bucket(i,j)=spval
           graup_bucket1(i,j)=spval
+          frzrn_bucket(i,j)=spval
+          snow_acm(i,j)=spval
+          snow_bkt(i,j)=spval
           qrmax(i,j)=spval
           tmax(i,j)=spval
           snownc(i,j)=spval
@@ -761,6 +765,7 @@
           sfclhx(i,j)=spval
           fis(i,j)=spval
           t500(i,j)=spval
+          z500(i,j)=spval
           t700(i,j)=spval
           z700(i,j)=spval
           teql(i,j)=spval


### PR DESCRIPTION
This PR addresses Issue #1169.

The initialization of all variables in `ALLOCATE_ALL.f` was reviewed.  A total of five variables (QQNG, frzrn_bucket, snow_acm, snow_bkt, z500) were found to have been allocated but not initialized.  It is noted that #1171 initializes variable QQNG.  All variables allocated in `ALLOCATE_ALL.f` are verified to be deallocated in `DEALLOCATE.f`.