### PR TITLE
Minor fix to avoid zmid=NaN in very thin layers.

### DIFF
--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -114,7 +114,7 @@
       use masks, only: lmv, lmh, htm, vtm, gdlat, gdlon, dx, dy, hbm2, sm, sice
       use physcons_post, only: grav => con_g, fv => con_fvirt, rgas => con_rd,                     &
                             eps => con_eps, epsm1 => con_epsm1
-      use params_mod, only: erad, dtr, tfrz, h1, d608, rd, p1000, capa,pi
+      use params_mod, only: erad, dtr, tfrz, h1, d608, rd, p1000, capa,pi, small
       use lookup_mod, only: thl, plq, ptbl, ttbl, rdq, rdth, rdp, rdthe, pl, qs0, sqs, sthe,    &
                             ttblq, rdpq, rdtheq, stheq, the0q, the0
       use ctlblk_mod, only: me, mpi_comm_comp, icnt, idsp, jsta, jend, ihrst, idat, sdat, ifhr, &
@@ -1220,9 +1220,13 @@
           do i=ista,iend
             if(zint(i,j,l+1)/=spval .and. zint(i,j,l)/=spval &
             .and. pmid(i,j,l)/=spval)then
-             zmid(i,j,l)=zint(i,j,l+1)+(zint(i,j,l)-zint(i,j,l+1))* &
+             if (abs(zint(i,j,l+1)-zint(i,j,l)) < small) then
+              zmid(i,j,l)=zint(i,j,l)
+             else
+              zmid(i,j,l)=zint(i,j,l+1)+(zint(i,j,l)-zint(i,j,l+1))* &
                     (log(pmid(i,j,l))-alpint(i,j,l+1))/ &
                     (alpint(i,j,l)-alpint(i,j,l+1))
+             endif
              if(zmid(i,j,l)>1.0E6)print*,'bad Hmid ',i,j,l,zmid(i,j,l)
             else
              zmid(i,j,l)=spval

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -60,6 +60,7 @@
 !> 2024-10-11 | Sam Trahan    | Fixed an incorrect array length in read_netcdf_3d_para
 !> 2025-02-25 | Wen Meng      | Remove duplicated declaraion for tshltr 
 !> 2024-03-25 | Biju Thomas   | Bug fix float overlow in hafs_upp debug build run
+!> 2025-04-23 ! Jesse Meng    | Bug fix zmid calculation in very thin layers
 !>
 !> @author Hui-Ya Chuang @date 2016-03-04
 !----------------------------------------------------------------------

--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -5010,7 +5010,8 @@
       real,dimension(ista:iend,jsta:jend,nfl) :: tfd,ufd,vfd,pfd,qfd,rhfd
       real,dimension(ista:iend,jsta:jend)     :: zsfc
 
-      real lhl(nfl),dzabh(nfl),swnd(nfl)
+      integer lhl(nfl)
+      real dzabh(nfl),swnd(nfl)
       real htsfc,htabh,dz,rdz,delt,delu,delv,delp,delq
 
       real, parameter :: s03 = 0.2113589753880838
@@ -5076,13 +5077,16 @@
          htsfc = zint(i,j,lm+1)
          llmh  = nint(lmh(i,j))
       ifd = 1
+      lhl=llmh
       do l = llmh,1,-1
+        if(zmid(i,j,l)<spval) then
          htabh = zmid(i,j,l)-htsfc
-         if(htabh>htfl(ifd)) then
+         if(htabh>=htfl(ifd)) then
             lhl(ifd) = l
             dzabh(ifd) = htabh-htfl(ifd)
             ifd = ifd + 1
          endif
+        endif
          if(ifd > nfl) exit
       enddo
 
@@ -5090,7 +5094,7 @@
 
       do ifd = 1,nfl 
          l = lhl(ifd)
-         if (l<lm .and. t(i,j,l)<spval .and. uh(i,j,l)<spval .and. vh(i,j,l)<spval) then
+         if (l<lm .and. t(i,j,l)<spval .and. uh(i,j,l)<spval .and. vh(i,j,l)<spval .and. zmid(i,j,l)<spval) then
            dz   = zmid(i,j,l)-zmid(i,j,l+1)
            rdz  = 1./dz
            delt = t(i,j,l)-t(i,j,l+1)

--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -4990,6 +4990,7 @@
 !> Date | Programmer | Comments
 !> -----|------------|---------
 !> 2024-11-15 | Jesse Meng | Initial
+!> 2025-04-23 | Jesse Meng | Bug fix zmid calculation in very thin layers
 !>
 !> @author Jesse Meng @date 2024-11-15
 

--- a/tests/logs/rt.log.HERA
+++ b/tests/logs/rt.log.HERA
@@ -1,75 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-34860e5237089bfe8e6f36aefb9a71555325387a
+226a19b8c11ac9b8bd520e05e2a1cecbee8fe17d
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1186/UPP/ci/rundir/upp-HERA
+Run directory: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1193/UPP/ci/rundir/upp-HERA
 Baseline directory: /scratch2/NAGAPE/epic/UPP/test_suite
 
-Total runtime: 00h:12m:44s
-Test Date: 20250417 20:06:34
+Total runtime: 00h:21m:29s
+Test Date: 20250423 16:40:50
 Summary Results:
 
-04/17 19:57:00Z -fv3r_ifi_missing test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
-04/17 19:57:03Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-04/17 19:57:26Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-04/17 19:58:03Z -fv3hafs test: your new post executable did not generate bit-identical HURPRS09.tm00 as the trunk
-04/17 19:58:05Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-04/17 19:58:08Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-04/17 19:58:11Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-04/17 19:58:12Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-04/17 19:58:14Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-04/17 19:58:17Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-04/17 19:58:22Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-04/17 19:58:24Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-04/17 19:58:25Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-04/17 19:58:27Z -fv3hafs pe test: your new post executable did not generate bit-identical HURPRS09.tm00 as the trunk
-04/17 19:58:28Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-04/17 19:58:29Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-04/17 19:58:29Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-04/17 19:58:30Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-04/17 19:58:30Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-04/17 19:58:41Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-04/17 19:58:42Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-04/17 19:58:45Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-04/17 19:59:07Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-04/17 19:59:08Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-04/17 19:59:10Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-04/17 19:59:54Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-04/17 19:59:54Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-04/17 19:59:59Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-04/17 19:59:59Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-04/17 20:05:39Z -fv3gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the trunk
-04/17 20:05:41Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-04/17 20:05:42Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-04/17 20:06:15Z -fv3gfs pe test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the trunk
-04/17 20:06:18Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-04/17 20:06:18Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-04/17 19:58:43Z -Runtime: nmmb_test 00:01:15 -- baseline 00:01:00
-04/17 19:58:43Z -Runtime: nmmb_pe_test 00:01:16 -- baseline 00:01:00
-04/17 19:58:43Z -Runtime: fv3gefs_test 00:00:25 -- baseline 00:40:00
-04/17 19:58:43Z -Runtime: fv3gefs_pe_test 00:00:26 -- baseline 00:40:00
-04/17 19:58:43Z -Runtime: rap_test 00:01:05 -- baseline 00:02:00
-04/17 19:58:43Z -Runtime: rap_pe_test 00:01:22 -- baseline 00:02:00
-04/17 19:59:14Z -Runtime: hrrr_test 00:02:21 -- baseline 00:02:00
-04/17 19:59:14Z -Runtime: hrrr_pe_test 00:02:15 -- baseline 00:02:00
-04/17 20:05:46Z -Runtime: fv3gfs_test 00:09:12 -- baseline 00:15:00
-04/17 20:06:32Z -Runtime: fv3gfs_pe_test 00:09:41 -- baseline 00:15:00
-04/17 20:06:32Z -Runtime: fv3r_test 00:03:22 -- baseline 00:03:00
-04/17 20:06:32Z -Runtime: fv3r_pe_test 00:03:17 -- baseline 00:03:00
-04/17 20:06:32Z -Runtime: fv3r_ifi_missing 00:00:23 -- baseline 00:03:00
-04/17 20:06:33Z -Runtime: fv3hafs_test 00:01:10 -- baseline 00:03:00
-04/17 20:06:33Z -Runtime: fv3hafs_pe_test 00:01:19 -- baseline 00:03:00
-04/17 20:06:33Z -Runtime: rtma_test 00:01:40 -- baseline 00:03:00
-04/17 20:06:33Z -Runtime: rtma_pe_test 00:01:38 -- baseline 00:03:00
-There are changes in results for case fv3r_pe_test in /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1186/UPP/ci/rundir/upp-HERA/fv3r_2023062800_pe_test/PRSLEV10.tm00
-There are changes in results for case fv3r in /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1186/UPP/ci/rundir/upp-HERA/fv3r_2023062800/PRSLEV10.tm00
-There are changes in results for case gfs_pe_test in /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1186/UPP/ci/rundir/upp-HERA/fv3gfs_2019083000_pe_test/gfs.t00z.master.grb2f006
-There are changes in results for case gfs in /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1186/UPP/ci/rundir/upp-HERA/fv3gfs_2019083000/gfs.t00z.master.grb2f006
-There are changes in results for case fv3hafs in /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1186/UPP/ci/rundir/upp-HERA/fv3hafs_2022092800/HURPRS09.tm00
-There are changes in results for case fv3hafs_pe_test in /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1186/UPP/ci/rundir/upp-HERA/fv3hafs_2022092800_pe_test/HURPRS09.tm00
-Refer to .diff files in rundir: /scratch2/NAGAPE/epic/Fernando.Andrade-maldonado/regression-tests/upp/1186/UPP/ci/rundir/upp-HERA for details on differences in results for each case.
+04/23 16:22:48Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+04/23 16:23:04Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+04/23 16:23:17Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+04/23 16:23:46Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+04/23 16:23:48Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+04/23 16:24:04Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+04/23 16:24:06Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+04/23 16:24:07Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+04/23 16:24:28Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+04/23 16:24:29Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+04/23 16:24:30Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+04/23 16:24:30Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+04/23 16:24:31Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+04/23 16:30:44Z -fv3r_ifi_missing test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
+04/23 16:31:55Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+04/23 16:32:01Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+04/23 16:37:00Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+04/23 16:37:06Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+04/23 16:37:06Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+04/23 16:37:38Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+04/23 16:37:41Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+04/23 16:37:41Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+04/23 16:39:24Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+04/23 16:39:27Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+04/23 16:39:28Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+04/23 16:39:46Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+04/23 16:39:52Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+04/23 16:39:52Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+04/23 16:39:56Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+04/23 16:40:26Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+04/23 16:40:28Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+04/23 16:40:29Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+04/23 16:40:31Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+04/23 16:40:33Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+04/23 16:40:33Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+04/23 16:40:47Z -Runtime: nmmb_test 00:01:42 -- baseline 00:01:00
+04/23 16:40:47Z -Runtime: nmmb_pe_test 00:01:42 -- baseline 00:01:00
+04/23 16:40:47Z -Runtime: fv3gefs_test 00:00:36 -- baseline 00:40:00
+04/23 16:40:47Z -Runtime: fv3gefs_pe_test 00:00:59 -- baseline 00:40:00
+04/23 16:40:48Z -Runtime: rap_test 00:01:11 -- baseline 00:02:00
+04/23 16:40:48Z -Runtime: rap_pe_test 00:01:26 -- baseline 00:02:00
+04/23 16:40:48Z -Runtime: hrrr_test 00:02:25 -- baseline 00:02:00
+04/23 16:40:48Z -Runtime: hrrr_pe_test 00:02:11 -- baseline 00:02:00
+04/23 16:40:48Z -Runtime: fv3gfs_test 00:07:05 -- baseline 00:15:00
+04/23 16:40:49Z -Runtime: fv3gfs_pe_test 00:07:16 -- baseline 00:15:00
+04/23 16:40:49Z -Runtime: fv3r_test 00:01:48 -- baseline 00:03:00
+04/23 16:40:49Z -Runtime: fv3r_pe_test 00:01:51 -- baseline 00:03:00
+04/23 16:40:49Z -Runtime: fv3r_ifi_missing 00:00:25 -- baseline 00:03:00
+04/23 16:40:49Z -Runtime: fv3hafs_test 00:00:38 -- baseline 00:03:00
+04/23 16:40:49Z -Runtime: fv3hafs_pe_test 00:00:37 -- baseline 00:03:00
+04/23 16:40:50Z -Runtime: rtma_test 00:01:55 -- baseline 00:03:00
+04/23 16:40:50Z -Runtime: rtma_pe_test 00:01:43 -- baseline 00:03:00
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.HERCULES
+++ b/tests/logs/rt.log.HERCULES
@@ -1,75 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-34860e5237089bfe8e6f36aefb9a71555325387a
+226a19b8c11ac9b8bd520e05e2a1cecbee8fe17d
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work/noaa/epic/nandoam/regression-testing/upp/hercules/1186/UPP/ci/rundir/upp-HERCULES
+Run directory: /work/noaa/epic/nandoam/regression-testing/upp/hercules/1193/UPP/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:12m:35s
-Test Date: 20250417 15:12:23
+Total runtime: 00h:11m:10s
+Test Date: 20250424 10:18:58
 Summary Results:
 
-04/17 20:02:05Z -fv3r test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
-04/17 20:02:08Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-04/17 20:02:12Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-04/17 20:02:45Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-04/17 20:02:46Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-04/17 20:02:48Z -fv3hafs test: your new post executable did not generate bit-identical HURPRS09.tm00 as the trunk
-04/17 20:02:48Z -fv3hafs pe test: your new post executable did not generate bit-identical HURPRS09.tm00 as the trunk
-04/17 20:02:53Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-04/17 20:02:54Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-04/17 20:03:03Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-04/17 20:03:05Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-04/17 20:03:05Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-04/17 20:03:12Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-04/17 20:03:13Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-04/17 20:03:13Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-04/17 20:03:32Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-04/17 20:03:33Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-04/17 20:03:35Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-04/17 20:03:59Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-04/17 20:03:59Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-04/17 20:04:01Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-04/17 20:04:01Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-04/17 20:05:14Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-04/17 20:05:14Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-04/17 20:05:16Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-04/17 20:05:17Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-04/17 20:06:16Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-04/17 20:06:17Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-04/17 20:06:19Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-04/17 20:09:42Z -fv3gfs pe test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the trunk
-04/17 20:09:44Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-04/17 20:09:44Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-04/17 20:12:19Z -fv3gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the trunk
-04/17 20:12:19Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-04/17 20:12:19Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-04/17 20:03:22Z -Runtime: nmmb_test 00:01:20 -- baseline 00:03:00
-04/17 20:03:22Z -Runtime: nmmb_pe_test 00:01:13 -- baseline 00:03:00
-04/17 20:03:22Z -Runtime: fv3gefs_test 00:00:15 -- baseline 01:20:00
-04/17 20:03:22Z -Runtime: fv3gefs_pe_test 00:00:19 -- baseline 01:20:00
-04/17 20:03:22Z -Runtime: rap_test 00:00:53 -- baseline 00:02:00
-04/17 20:03:22Z -Runtime: rap_pe_test 00:01:01 -- baseline 00:02:00
-04/17 20:06:22Z -Runtime: hrrr_test 00:04:26 -- baseline 00:02:00
-04/17 20:06:22Z -Runtime: hrrr_pe_test 00:01:42 -- baseline 00:02:00
-04/17 20:12:23Z -Runtime: fv3gfs_test 00:10:26 -- baseline 00:18:00
-04/17 20:12:23Z -Runtime: fv3gfs_pe_test 00:07:51 -- baseline 00:18:00
-04/17 20:12:23Z -Runtime: fv3r_test 00:03:24 -- baseline 00:03:00
-04/17 20:12:23Z -Runtime: fv3r_pe_test 00:03:23 -- baseline 00:03:00
-04/17 20:12:23Z -Runtime: fv3r_ifi_missing 00:00:12 -- baseline 00:03:00
-04/17 20:12:23Z -Runtime: fv3hafs_test 00:00:55 -- baseline 00:00:40
-04/17 20:12:23Z -Runtime: fv3hafs_pe_test 00:00:55 -- baseline 00:00:40
-04/17 20:12:23Z -Runtime: rtma_test 00:02:08 -- baseline 00:04:00
-04/17 20:12:23Z -Runtime: rtma_pe_test 00:02:08 -- baseline 00:04:00
-There are changes in results for case fv3r_pe_test in /work/noaa/epic/nandoam/regression-testing/upp/hercules/1186/UPP/ci/rundir/upp-HERCULES/fv3r_2023062800_pe_test/PRSLEV10.tm00
-There are changes in results for case fv3hafs_pe_test in /work/noaa/epic/nandoam/regression-testing/upp/hercules/1186/UPP/ci/rundir/upp-HERCULES/fv3hafs_2022092800_pe_test/HURPRS09.tm00
-There are changes in results for case fv3r in /work/noaa/epic/nandoam/regression-testing/upp/hercules/1186/UPP/ci/rundir/upp-HERCULES/fv3r_2023062800/PRSLEV10.tm00
-There are changes in results for case gfs in /work/noaa/epic/nandoam/regression-testing/upp/hercules/1186/UPP/ci/rundir/upp-HERCULES/fv3gfs_2019083000/gfs.t00z.master.grb2f006
-There are changes in results for case gfs_pe_test in /work/noaa/epic/nandoam/regression-testing/upp/hercules/1186/UPP/ci/rundir/upp-HERCULES/fv3gfs_2019083000_pe_test/gfs.t00z.master.grb2f006
-There are changes in results for case fv3hafs in /work/noaa/epic/nandoam/regression-testing/upp/hercules/1186/UPP/ci/rundir/upp-HERCULES/fv3hafs_2022092800/HURPRS09.tm00
-Refer to .diff files in rundir: /work/noaa/epic/nandoam/regression-testing/upp/hercules/1186/UPP/ci/rundir/upp-HERCULES for details on differences in results for each case.
+04/24 15:10:26Z -fv3r test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
+04/24 15:10:27Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+04/24 15:10:30Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+04/24 15:10:36Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+04/24 15:10:36Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+04/24 15:11:04Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+04/24 15:11:05Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+04/24 15:11:06Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+04/24 15:11:07Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+04/24 15:11:11Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+04/24 15:11:14Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+04/24 15:11:14Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+04/24 15:11:19Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+04/24 15:11:20Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+04/24 15:11:20Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+04/24 15:11:57Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+04/24 15:11:59Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+04/24 15:11:59Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+04/24 15:12:01Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+04/24 15:12:01Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+04/24 15:12:04Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+04/24 15:12:07Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+04/24 15:12:19Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+04/24 15:12:21Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+04/24 15:12:24Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+04/24 15:12:26Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+04/24 15:14:40Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+04/24 15:14:41Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+04/24 15:14:42Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+04/24 15:16:05Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+04/24 15:16:06Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+04/24 15:16:06Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+04/24 15:18:46Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+04/24 15:18:46Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+04/24 15:18:46Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+04/24 15:11:24Z -Runtime: nmmb_test 00:01:12 -- baseline 00:03:00
+04/24 15:11:24Z -Runtime: nmmb_pe_test 00:01:05 -- baseline 00:03:00
+04/24 15:11:24Z -Runtime: fv3gefs_test 00:00:18 -- baseline 01:20:00
+04/24 15:11:24Z -Runtime: fv3gefs_pe_test 00:00:21 -- baseline 01:20:00
+04/24 15:11:24Z -Runtime: rap_test 00:00:56 -- baseline 00:02:00
+04/24 15:11:24Z -Runtime: rap_pe_test 00:00:58 -- baseline 00:02:00
+04/24 15:14:55Z -Runtime: hrrr_test 00:04:33 -- baseline 00:02:00
+04/24 15:14:55Z -Runtime: hrrr_pe_test 00:01:52 -- baseline 00:02:00
+04/24 15:18:56Z -Runtime: fv3gfs_test 00:08:37 -- baseline 00:18:00
+04/24 15:18:56Z -Runtime: fv3gfs_pe_test 00:05:57 -- baseline 00:18:00
+04/24 15:18:56Z -Runtime: fv3r_test 00:01:52 -- baseline 00:03:00
+04/24 15:18:56Z -Runtime: fv3r_pe_test 00:01:58 -- baseline 00:03:00
+04/24 15:18:56Z -Runtime: fv3r_ifi_missing 00:00:14 -- baseline 00:03:00
+04/24 15:18:57Z -Runtime: fv3hafs_test 00:00:24 -- baseline 00:00:40
+04/24 15:18:57Z -Runtime: fv3hafs_pe_test 00:00:24 -- baseline 00:00:40
+04/24 15:18:57Z -Runtime: rtma_test 00:02:09 -- baseline 00:04:00
+04/24 15:18:57Z -Runtime: rtma_pe_test 00:02:14 -- baseline 00:04:00
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION
+++ b/tests/logs/rt.log.ORION
@@ -1,75 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-34860e5237089bfe8e6f36aefb9a71555325387a
+226a19b8c11ac9b8bd520e05e2a1cecbee8fe17d
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work/noaa/epic/nandoam/regression-testing/upp/orion/1186/UPP/ci/rundir/upp-ORION
+Run directory: /work/noaa/epic/nandoam/regression-testing/upp/orion/1193/UPP/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:21m:36s
-Test Date: 20250417 15:49:05
+Total runtime: 01h:03m:49s
+Test Date: 20250424 13:23:18
 Summary Results:
 
-04/17 20:32:04Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-04/17 20:32:05Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-04/17 20:32:05Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-04/17 20:32:14Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-04/17 20:32:15Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-04/17 20:32:15Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-04/17 20:32:45Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-04/17 20:32:46Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-04/17 20:32:47Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-04/17 20:36:40Z -fv3r test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
-04/17 20:36:46Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-04/17 20:38:59Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-04/17 20:39:00Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-04/17 20:39:02Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-04/17 20:39:03Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
-04/17 20:39:22Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-04/17 20:39:23Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-04/17 20:39:25Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-04/17 20:42:00Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-04/17 20:42:04Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-04/17 20:42:08Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-04/17 20:42:12Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
-04/17 20:42:38Z -fv3hafs test: your new post executable did not generate bit-identical HURPRS09.tm00 as the trunk
-04/17 20:42:39Z -fv3hafs pe test: your new post executable did not generate bit-identical HURPRS09.tm00 as the trunk
-04/17 20:42:47Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-04/17 20:42:48Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-04/17 20:46:42Z -fv3gfs pe test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the trunk
-04/17 20:46:44Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-04/17 20:46:44Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-04/17 20:48:27Z -fv3gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the trunk
-04/17 20:48:29Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-04/17 20:48:29Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-04/17 20:48:50Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-04/17 20:48:51Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-04/17 20:48:53Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-04/17 20:32:17Z -Runtime: nmmb_test 00:01:26 -- baseline 00:03:00
-04/17 20:32:17Z -Runtime: nmmb_pe_test 00:01:16 -- baseline 00:03:00
-04/17 20:36:47Z -Runtime: fv3gefs_test 00:00:24 -- baseline 01:20:00
-04/17 20:36:47Z -Runtime: fv3gefs_pe_test 00:01:26 -- baseline 01:20:00
-04/17 20:42:48Z -Runtime: rap_test 00:01:24 -- baseline 00:02:00
-04/17 20:42:48Z -Runtime: rap_pe_test 00:01:28 -- baseline 00:02:00
-04/17 20:49:04Z -Runtime: hrrr_test 00:07:29 -- baseline 00:02:00
-04/17 20:49:04Z -Runtime: hrrr_pe_test 00:03:03 -- baseline 00:02:00
-04/17 20:49:04Z -Runtime: fv3gfs_test 00:12:07 -- baseline 00:18:00
-04/17 20:49:04Z -Runtime: fv3gfs_pe_test 00:10:22 -- baseline 00:18:00
-04/17 20:49:04Z -Runtime: fv3r_test 00:05:42 -- baseline 00:03:00
-04/17 20:49:04Z -Runtime: fv3r_pe_test 00:05:50 -- baseline 00:03:00
-04/17 20:49:05Z -Runtime: fv3r_ifi_missing 00:00:18 -- baseline 00:03:00
-04/17 20:49:05Z -Runtime: fv3hafs_test 00:01:14 -- baseline 00:00:40
-04/17 20:49:05Z -Runtime: fv3hafs_pe_test 00:01:15 -- baseline 00:00:40
-04/17 20:49:05Z -Runtime: rtma_test 00:02:40 -- baseline 00:04:00
-04/17 20:49:05Z -Runtime: rtma_pe_test 00:02:41 -- baseline 00:04:00
-There are changes in results for case fv3r_pe_test in /work/noaa/epic/nandoam/regression-testing/upp/orion/1186/UPP/ci/rundir/upp-ORION/fv3r_2023062800_pe_test/PRSLEV10.tm00
-There are changes in results for case fv3hafs_pe_test in /work/noaa/epic/nandoam/regression-testing/upp/orion/1186/UPP/ci/rundir/upp-ORION/fv3hafs_2022092800_pe_test/HURPRS09.tm00
-There are changes in results for case fv3r in /work/noaa/epic/nandoam/regression-testing/upp/orion/1186/UPP/ci/rundir/upp-ORION/fv3r_2023062800/PRSLEV10.tm00
-There are changes in results for case gfs in /work/noaa/epic/nandoam/regression-testing/upp/orion/1186/UPP/ci/rundir/upp-ORION/fv3gfs_2019083000/gfs.t00z.master.grb2f006
-There are changes in results for case gfs_pe_test in /work/noaa/epic/nandoam/regression-testing/upp/orion/1186/UPP/ci/rundir/upp-ORION/fv3gfs_2019083000_pe_test/gfs.t00z.master.grb2f006
-There are changes in results for case fv3hafs in /work/noaa/epic/nandoam/regression-testing/upp/orion/1186/UPP/ci/rundir/upp-ORION/fv3hafs_2022092800/HURPRS09.tm00
-Refer to .diff files in rundir: /work/noaa/epic/nandoam/regression-testing/upp/orion/1186/UPP/ci/rundir/upp-ORION for details on differences in results for each case.
+04/24 17:24:04Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+04/24 17:24:06Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+04/24 17:24:06Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+04/24 17:24:14Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+04/24 17:24:15Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+04/24 17:24:15Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+04/24 17:26:04Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+04/24 17:26:05Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+04/24 17:26:09Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+04/24 17:26:10Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+04/24 17:30:17Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+04/24 17:35:26Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+04/24 17:37:57Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+04/24 17:37:58Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+04/24 17:37:58Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+04/24 17:43:10Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+04/24 17:43:11Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+04/24 17:43:13Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+04/24 17:47:38Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+04/24 17:47:39Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+04/24 17:47:41Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+04/24 17:51:23Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+04/24 18:13:25Z -fv3r test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
+04/24 18:15:12Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+04/24 18:15:16Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+04/24 18:15:18Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+04/24 18:15:22Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+04/24 18:15:40Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+04/24 18:15:40Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+04/24 18:15:43Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+04/24 18:15:45Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+04/24 18:16:21Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+04/24 18:23:02Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+04/24 18:23:03Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+04/24 18:23:03Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+04/24 17:24:16Z -Runtime: nmmb_test 00:01:29 -- baseline 00:03:00
+04/24 17:24:16Z -Runtime: nmmb_pe_test 00:01:20 -- baseline 00:03:00
+04/24 17:35:33Z -Runtime: fv3gefs_test 00:00:17 -- baseline 01:20:00
+04/24 17:35:33Z -Runtime: fv3gefs_pe_test 00:00:24 -- baseline 01:20:00
+04/24 17:35:33Z -Runtime: rap_test 00:01:32 -- baseline 00:02:00
+04/24 17:35:33Z -Runtime: rap_pe_test 00:01:27 -- baseline 00:02:00
+04/24 17:47:50Z -Runtime: hrrr_test 00:07:17 -- baseline 00:02:00
+04/24 17:47:50Z -Runtime: hrrr_pe_test 00:02:49 -- baseline 00:02:00
+04/24 18:23:10Z -Runtime: fv3gfs_test 00:09:58 -- baseline 00:18:00
+04/24 18:23:10Z -Runtime: fv3gfs_pe_test 00:08:05 -- baseline 00:18:00
+04/24 18:23:10Z -Runtime: fv3r_test 00:02:11 -- baseline 00:03:00
+04/24 18:23:10Z -Runtime: fv3r_pe_test 00:02:17 -- baseline 00:03:00
+04/24 18:23:10Z -Runtime: fv3r_ifi_missing 00:00:20 -- baseline 00:03:00
+04/24 18:23:10Z -Runtime: fv3hafs_test 00:00:33 -- baseline 00:00:40
+04/24 18:23:10Z -Runtime: fv3hafs_pe_test 00:00:36 -- baseline 00:00:40
+04/24 18:23:10Z -Runtime: rtma_test 00:02:38 -- baseline 00:04:00
+04/24 18:23:10Z -Runtime: rtma_pe_test 00:02:40 -- baseline 00:04:00
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
To fix UPP issue 1174 https://github.com/NOAA-EMC/UPP/issues/1174
ufs-weather-model inline post crashed due to zmid=NaN in very thin layers where dpres-->0.
