### PR TITLE
Change gen_proc_type from ens_fcst to fcst for REFS

### DIFF
--- a/parm/rrfs/postxconfig-NT-refs.txt
+++ b/parm/rrfs/postxconfig-NT-refs.txt
@@ -9,7 +9,7 @@ local_tab_yes1
 fcst
 oper
 fcst
-ens_fcst
+fcst
 hour
 nws_ncep
 refs
@@ -17,7 +17,6 @@ complex_packing_spatial_diff
 2nd_ord_sptdiff
 fltng_pnt
 lossless
-?
 1
 PRES_ON_HYBRID_LVL
 ?
@@ -11240,7 +11239,7 @@ local_tab_yes1
 fcst
 oper
 fcst
-ens_fcst
+fcst
 hour
 nws_ncep
 refs
@@ -11248,7 +11247,6 @@ complex_packing_spatial_diff
 2nd_ord_sptdiff
 fltng_pnt
 lossless
-?
 12
 HGT_ON_ISOBARIC_SFC
 ?

--- a/parm/rrfs/postxconfig-NT-refs_f00.txt
+++ b/parm/rrfs/postxconfig-NT-refs_f00.txt
@@ -9,7 +9,7 @@ local_tab_yes1
 fcst
 oper
 fcst
-ens_fcst
+fcst
 hour
 nws_ncep
 refs
@@ -17,7 +17,6 @@ complex_packing_spatial_diff
 2nd_ord_sptdiff
 fltng_pnt
 lossless
-?
 1
 PRES_ON_HYBRID_LVL
 ?
@@ -8972,7 +8971,7 @@ local_tab_yes1
 fcst
 oper
 fcst
-ens_fcst
+fcst
 hour
 nws_ncep
 refs
@@ -8980,7 +8979,6 @@ complex_packing_spatial_diff
 2nd_ord_sptdiff
 fltng_pnt
 lossless
-?
 12
 HGT_ON_ISOBARIC_SFC
 ?

--- a/parm/rrfs/postxconfig-NT-refs_f01.txt
+++ b/parm/rrfs/postxconfig-NT-refs_f01.txt
@@ -9,7 +9,7 @@ local_tab_yes1
 fcst
 oper
 fcst
-ens_fcst
+fcst
 hour
 nws_ncep
 refs
@@ -17,7 +17,6 @@ complex_packing_spatial_diff
 2nd_ord_sptdiff
 fltng_pnt
 lossless
-?
 1
 PRES_ON_HYBRID_LVL
 ?
@@ -11072,7 +11071,7 @@ local_tab_yes1
 fcst
 oper
 fcst
-ens_fcst
+fcst
 hour
 nws_ncep
 refs
@@ -11080,7 +11079,6 @@ complex_packing_spatial_diff
 2nd_ord_sptdiff
 fltng_pnt
 lossless
-?
 12
 HGT_ON_ISOBARIC_SFC
 ?

--- a/parm/rrfs/refs_postcntrl.xml
+++ b/parm/rrfs/refs_postcntrl.xml
@@ -10,7 +10,7 @@
     <sigreftime>fcst</sigreftime>
     <prod_status>oper</prod_status>
     <data_type>fcst</data_type>
-    <gen_proc_type>ens_fcst</gen_proc_type>
+    <gen_proc_type>fcst</gen_proc_type>
     <time_range_unit>hour</time_range_unit>
     <orig_center>nws_ncep</orig_center>
     <gen_proc>refs</gen_proc>
@@ -1756,7 +1756,7 @@
     <sigreftime>fcst</sigreftime>
     <prod_status>oper</prod_status>
     <data_type>fcst</data_type>
-    <gen_proc_type>ens_fcst</gen_proc_type>
+    <gen_proc_type>fcst</gen_proc_type>
     <time_range_unit>hour</time_range_unit>
     <orig_center>nws_ncep</orig_center>
     <gen_proc>refs</gen_proc>

--- a/parm/rrfs/refs_postcntrl_f00.xml
+++ b/parm/rrfs/refs_postcntrl_f00.xml
@@ -10,7 +10,7 @@
     <sigreftime>fcst</sigreftime>
     <prod_status>oper</prod_status>
     <data_type>fcst</data_type>
-    <gen_proc_type>ens_fcst</gen_proc_type>
+    <gen_proc_type>fcst</gen_proc_type>
     <time_range_unit>hour</time_range_unit>
     <orig_center>nws_ncep</orig_center>
     <gen_proc>refs</gen_proc>
@@ -1435,7 +1435,7 @@
     <sigreftime>fcst</sigreftime>
     <prod_status>oper</prod_status>
     <data_type>fcst</data_type>
-    <gen_proc_type>ens_fcst</gen_proc_type>
+    <gen_proc_type>fcst</gen_proc_type>
     <time_range_unit>hour</time_range_unit>
     <orig_center>nws_ncep</orig_center>
     <gen_proc>refs</gen_proc>

--- a/parm/rrfs/refs_postcntrl_f01.xml
+++ b/parm/rrfs/refs_postcntrl_f01.xml
@@ -10,7 +10,7 @@
     <sigreftime>fcst</sigreftime>
     <prod_status>oper</prod_status>
     <data_type>fcst</data_type>
-    <gen_proc_type>ens_fcst</gen_proc_type>
+    <gen_proc_type>fcst</gen_proc_type>
     <time_range_unit>hour</time_range_unit>
     <orig_center>nws_ncep</orig_center>
     <gen_proc>refs</gen_proc>
@@ -1736,7 +1736,7 @@
     <sigreftime>fcst</sigreftime>
     <prod_status>oper</prod_status>
     <data_type>fcst</data_type>
-    <gen_proc_type>ens_fcst</gen_proc_type>
+    <gen_proc_type>fcst</gen_proc_type>
     <time_range_unit>hour</time_range_unit>
     <orig_center>nws_ncep</orig_center>
     <gen_proc>refs</gen_proc>


### PR DESCRIPTION
When implementing the REFS grib2 output encoding changes from PR #1184 in the RRFS real-time parallel, an unexpected issue was discovered related to the bucket accumulated precipitation.  The time intervals and values were not correct in the REFS output.  @EricJames-NOAA found that the issue is fixed by reverting the <gen_proc_type> from ens_fcst back to fcst, so that is what we suggest doing for RRFSv1.  The UPP control xml and text files are updated here.  @WenMeng-NOAA you had suggested we change <gen_proc_type> to ens_fcst in PR #1184 so let us know if this change is acceptable to you.

I completed a standalone UPP test for REFS on WCOSS2, and my run directory is here on Cactus:
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_refs_2025040112
The time interval for bucket APCP is now correct as f17-f18, and the ensemble member number is still included in the output information.

Resolves issue #1214 