### PR TITLE
Remove hardcoded value of bucket time interval for REFS

### DIFF
--- a/sorc/ncep_post.fd/xml_perl_data.f
+++ b/sorc/ncep_post.fd/xml_perl_data.f
@@ -7,6 +7,7 @@
 ! program log:
 !   March, 2015    Lin Gan    Initial Code
 !   July,  2016    J. Carley  Clean up prints 
+!   May,   2025    B. Blake   Remove hardcoded value for tprec
 !   
 !------------------------------------------------------------------------
 !> @defgroup xml_perl_data_mod Sets parameters that are used to read in 
@@ -200,7 +201,6 @@
           if(paramset(i)%gen_proc_type=='ens_fcst')then
             read(22,*)paramset(i)%type_ens_fcst
             call filter_char_inp(paramset(i)%type_ens_fcst)
-            tprec   = 6  ! always 6 hr bucket for gefs
             tclod   = tprec
             trdlw   = tprec
             trdsw   = tprec


### PR DESCRIPTION
When implementing the REFS grib2 output encoding changes from PR #1184 in the RRFS real-time parallel, an unexpected issue was discovered related to the bucket accumulated precipitation. The time intervals and values were not correct in the REFS output.  @WenMeng-NOAA discovered that tprec was hardcoded to 6 for ensemble applications in sorc/ncep_post.fd/xml_perl_data.f, and removing this hardcoded value fixes the issue.  A separate PR will also be forthcoming to the UPP develop branch with this change for GEFS/REFS.

I completed a standalone UPP test for REFS on WCOSS2, and my run directory is here on Cactus:
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_refs_2025040112
The time interval for bucket APCP is now correct as f17-f18.

This PR resolves issue #1214 

Tagging @MatthewPyle-NOAA for awareness