### PR TITLE
Remove hardcoded bucket value for ensemble products

### DIFF
--- a/sorc/ncep_post.fd/xml_perl_data.f
+++ b/sorc/ncep_post.fd/xml_perl_data.f
@@ -239,7 +239,6 @@
           if(paramset(i)%gen_proc_type=='ens_fcst')then
             read(22,*)paramset(i)%type_ens_fcst
             call filter_char_inp(paramset(i)%type_ens_fcst)
-            tprec   = 6  ! always 6 hr bucket for gefs
             tclod   = tprec
             trdlw   = tprec
             trdsw   = tprec

--- a/sorc/ncep_post.fd/xml_perl_data.f
+++ b/sorc/ncep_post.fd/xml_perl_data.f
@@ -10,6 +10,7 @@
 !> March, 2015 | Lin Gan   | Initial Code
 !> July,  2016 | J. Carley | Clean up prints 
 !> July, 2024  | Wen Meng  | Increase datset length
+!> May, 2025   | Ben Blake | Remove hardcoded value for tprec
 !>
 !------------------------------------------------------------------------
 !> @defgroup xml_perl_data_mod xml_perl_data

--- a/tests/logs/rt.log.HERA
+++ b/tests/logs/rt.log.HERA
@@ -1,75 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b3d658c34cc85e519fb9366b287ed628baa76b49
+3e89d51c20108c29943fa7183eb17d99815a1012
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1204/ci/rundir/upp-HERA
+Run directory: /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1220/ci/rundir/upp-HERA
 Baseline directory: /scratch2/NAGAPE/epic/UPP/test_suite
 
-Total runtime: 00h:11m:44s
-Test Date: 20250523 13:51:12
+Total runtime: 00h:10m:36s
+Test Date: 20250602 03:16:29
 Summary Results:
 
-05/23 13:42:35Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/23 13:42:48Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/23 13:43:07Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/23 13:43:15Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/23 13:43:27Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/23 13:43:28Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/23 13:43:48Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/23 13:44:08Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/23 13:44:10Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/23 13:44:11Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/23 13:44:18Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/23 13:44:20Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/23 13:44:20Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/23 13:44:36Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/23 13:44:37Z -fv3r_ifi_missing test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
-05/23 13:44:37Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/23 13:44:38Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/23 13:44:52Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/23 13:44:54Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/23 13:44:54Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/23 13:45:30Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/23 13:45:30Z -rtma pe test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
-05/23 13:45:31Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/23 13:45:52Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/23 13:47:25Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-05/23 13:47:32Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-05/23 13:47:36Z -rtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
-05/23 13:50:08Z -fv3r test: your new post executable did not generate bit-identical NATLEV10.tm00 as the trunk
-05/23 13:50:10Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/23 13:50:14Z -fv3r pe test: your new post executable did not generate bit-identical NATLEV10.tm00 as the trunk
-05/23 13:50:15Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/23 13:50:15Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/23 13:50:53Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/23 13:50:57Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/23 13:50:57Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/23 13:44:22Z -Runtime: nmmb_test 00:01:11 -- baseline 00:01:00
-05/23 13:45:08Z -Runtime: nmmb_pe_test 00:00:37 -- baseline 00:01:00
-05/23 13:45:08Z -Runtime: fv3gefs_test 00:00:25 -- baseline 00:40:00
-05/23 13:45:08Z -Runtime: fv3gefs_pe_test 00:00:21 -- baseline 00:40:00
-05/23 13:45:08Z -Runtime: rap_test 00:01:01 -- baseline 00:02:00
-05/23 13:45:38Z -Runtime: rap_pe_test 00:01:14 -- baseline 00:02:00
-05/23 13:45:39Z -Runtime: hrrr_test 00:02:28 -- baseline 00:02:00
-05/23 13:45:39Z -Runtime: hrrr_pe_test 00:02:00 -- baseline 00:02:00
-05/23 13:50:25Z -Runtime: fv3gfs_test 00:06:50 -- baseline 00:15:00
-05/23 13:51:11Z -Runtime: fv3gfs_pe_test 00:07:36 -- baseline 00:15:00
-05/23 13:51:11Z -Runtime: fv3r_test 00:05:51 -- baseline 00:03:00
-05/23 13:51:11Z -Runtime: fv3r_pe_test 00:05:57 -- baseline 00:03:00
-05/23 13:51:11Z -Runtime: fv3r_ifi_missing 00:00:20 -- baseline 00:03:00
-05/23 13:51:11Z -Runtime: fv3hafs_test 00:00:31 -- baseline 00:03:00
-05/23 13:51:12Z -Runtime: fv3hafs_pe_test 00:00:29 -- baseline 00:03:00
-05/23 13:51:12Z -Runtime: rtma_test 00:03:19 -- baseline 00:03:00
-05/23 13:51:12Z -Runtime: rtma_pe_test 00:03:22 -- baseline 00:03:00
-There are changes in results for case fv3r_pe_test in /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1204/ci/rundir/upp-HERA/fv3r_2023062800_pe_test/NATLEV10.tm00
-There are changes in results for case fv3r_pe_test in /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1204/ci/rundir/upp-HERA/fv3r_2023062800_pe_test/PRSLEV10.tm00
-There are changes in results for case fv3r in /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1204/ci/rundir/upp-HERA/fv3r_2023062800/NATLEV10.tm00
-There are changes in results for case fv3r in /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1204/ci/rundir/upp-HERA/fv3r_2023062800/PRSLEV10.tm00
-There are changes in results for case rtma_pe_test in /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1204/ci/rundir/upp-HERA/rtma_2023040400_pe_test/PRSLEV00.tm00
-There are changes in results for case rtma in /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1204/ci/rundir/upp-HERA/rtma_2023040400/PRSLEV00.tm00
-Refer to .diff files in rundir: /scratch2/NAGAPE/epic/Gillian.Petro/RTs/upp-rts/1204/ci/rundir/upp-HERA for details on differences in results for each case.
+06/02 03:09:06Z -fv3r_ifi_missing test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
+06/02 03:09:16Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/02 03:09:16Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/02 03:09:19Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/02 03:09:20Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/02 03:09:51Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+06/02 03:09:52Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/02 03:10:04Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/02 03:10:06Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/02 03:10:07Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/02 03:10:07Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+06/02 03:10:08Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/02 03:10:09Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/02 03:10:10Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/02 03:10:10Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/02 03:10:16Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/02 03:10:21Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/02 03:10:21Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/02 03:10:23Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/02 03:10:24Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/02 03:10:28Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/02 03:10:29Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/02 03:10:32Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/02 03:10:48Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/02 03:10:49Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/02 03:10:51Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/02 03:11:15Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/02 03:11:16Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/02 03:11:18Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/02 03:15:28Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/02 03:15:31Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/02 03:15:31Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/02 03:16:13Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/02 03:16:16Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/02 03:16:16Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/02 03:10:25Z -Runtime: nmmb_test 00:01:30 -- baseline 00:01:00
+06/02 03:10:25Z -Runtime: nmmb_pe_test 00:01:27 -- baseline 00:01:00
+06/02 03:10:25Z -Runtime: fv3gefs_test 00:00:36 -- baseline 00:40:00
+06/02 03:10:26Z -Runtime: fv3gefs_pe_test 00:00:36 -- baseline 00:40:00
+06/02 03:10:26Z -Runtime: rap_test 00:01:12 -- baseline 00:02:00
+06/02 03:10:26Z -Runtime: rap_pe_test 00:01:28 -- baseline 00:02:00
+06/02 03:11:26Z -Runtime: hrrr_test 00:02:38 -- baseline 00:02:00
+06/02 03:11:26Z -Runtime: hrrr_pe_test 00:02:11 -- baseline 00:02:00
+06/02 03:15:43Z -Runtime: fv3gfs_test 00:06:51 -- baseline 00:15:00
+06/02 03:16:28Z -Runtime: fv3gfs_pe_test 00:07:36 -- baseline 00:15:00
+06/02 03:16:28Z -Runtime: fv3r_test 00:01:41 -- baseline 00:03:00
+06/02 03:16:28Z -Runtime: fv3r_pe_test 00:01:49 -- baseline 00:03:00
+06/02 03:16:29Z -Runtime: fv3r_ifi_missing 00:00:26 -- baseline 00:03:00
+06/02 03:16:29Z -Runtime: fv3hafs_test 00:00:39 -- baseline 00:03:00
+06/02 03:16:29Z -Runtime: fv3hafs_pe_test 00:00:40 -- baseline 00:03:00
+06/02 03:16:29Z -Runtime: rtma_test 00:01:52 -- baseline 00:03:00
+06/02 03:16:29Z -Runtime: rtma_pe_test 00:01:44 -- baseline 00:03:00
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.HERCULES
+++ b/tests/logs/rt.log.HERCULES
@@ -1,75 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b3d658c34cc85e519fb9366b287ed628baa76b49
+3e89d51c20108c29943fa7183eb17d99815a1012
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1204/ci/rundir/upp-HERCULES
+Run directory: /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1220/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:17m:40s
-Test Date: 20250523 08:57:07
+Total runtime: 00h:13m:55s
+Test Date: 20250601 22:31:50
 Summary Results:
 
-05/23 13:42:53Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/23 13:42:55Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/23 13:42:55Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/23 13:43:01Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/23 13:43:02Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/23 13:43:02Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/23 13:45:46Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/23 13:45:46Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/23 13:48:48Z -fv3r test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
-05/23 13:49:00Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/23 13:49:26Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/23 13:49:26Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/23 13:49:29Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/23 13:49:31Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/23 13:49:37Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/23 13:49:51Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/23 13:50:22Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/23 13:50:23Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/23 13:50:42Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-05/23 13:51:23Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/23 13:51:25Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/23 13:51:57Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-05/23 13:52:51Z -rtma pe test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
-05/23 13:52:56Z -rtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
-05/23 13:53:06Z -fv3r test: your new post executable did not generate bit-identical NATLEV10.tm00 as the trunk
-05/23 13:53:45Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/23 13:53:45Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/23 13:53:47Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/23 13:53:57Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/23 13:53:58Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/23 13:53:58Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/23 13:54:17Z -fv3r pe test: your new post executable did not generate bit-identical NATLEV10.tm00 as the trunk
-05/23 13:57:04Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/23 13:57:04Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/23 13:57:04Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/23 13:43:04Z -Runtime: nmmb_test 00:01:27 -- baseline 00:03:00
-05/23 13:43:04Z -Runtime: nmmb_pe_test 00:01:21 -- baseline 00:03:00
-05/23 13:49:50Z -Runtime: fv3gefs_test 00:00:34 -- baseline 01:20:00
-05/23 13:49:50Z -Runtime: fv3gefs_pe_test 00:00:25 -- baseline 01:20:00
-05/23 13:50:36Z -Runtime: rap_test 00:01:22 -- baseline 00:02:00
-05/23 13:50:36Z -Runtime: rap_pe_test 00:01:03 -- baseline 00:02:00
-05/23 13:53:51Z -Runtime: hrrr_test 00:04:46 -- baseline 00:02:00
-05/23 13:53:51Z -Runtime: hrrr_pe_test 00:02:40 -- baseline 00:02:00
-05/23 13:57:06Z -Runtime: fv3gfs_test 00:09:37 -- baseline 00:18:00
-05/23 13:57:06Z -Runtime: fv3gfs_pe_test 00:06:48 -- baseline 00:18:00
-05/23 13:57:06Z -Runtime: fv3r_test 00:05:55 -- baseline 00:03:00
-05/23 13:57:06Z -Runtime: fv3r_pe_test 00:06:10 -- baseline 00:03:00
-05/23 13:57:06Z -Runtime: fv3r_ifi_missing 00:00:34 -- baseline 00:03:00
-05/23 13:57:06Z -Runtime: fv3hafs_test 00:00:45 -- baseline 00:00:40
-05/23 13:57:06Z -Runtime: fv3hafs_pe_test 00:00:40 -- baseline 00:00:40
-05/23 13:57:06Z -Runtime: rtma_test 00:04:08 -- baseline 00:04:00
-05/23 13:57:06Z -Runtime: rtma_pe_test 00:03:51 -- baseline 00:04:00
-There are changes in results for case rtma_pe_test in /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1204/ci/rundir/upp-HERCULES/rtma_2023040400_pe_test/PRSLEV00.tm00
-There are changes in results for case fv3r_pe_test in /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1204/ci/rundir/upp-HERCULES/fv3r_2023062800_pe_test/PRSLEV10.tm00
-There are changes in results for case fv3r_pe_test in /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1204/ci/rundir/upp-HERCULES/fv3r_2023062800_pe_test/NATLEV10.tm00
-There are changes in results for case rtma in /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1204/ci/rundir/upp-HERCULES/rtma_2023040400/PRSLEV00.tm00
-There are changes in results for case fv3r in /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1204/ci/rundir/upp-HERCULES/fv3r_2023062800/NATLEV10.tm00
-There are changes in results for case fv3r in /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1204/ci/rundir/upp-HERCULES/fv3r_2023062800/PRSLEV10.tm00
-Refer to .diff files in rundir: /work/noaa/epic/gpetro/hercules/RTs/upp-rts/1204/ci/rundir/upp-HERCULES for details on differences in results for each case.
+06/02 03:22:52Z -fv3r test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
+06/02 03:23:05Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/02 03:23:18Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/02 03:23:28Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/02 03:23:32Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/02 03:23:53Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/02 03:23:54Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/02 03:23:54Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/02 03:24:18Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/02 03:24:19Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/02 03:24:20Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/02 03:24:49Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/02 03:24:51Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/02 03:24:52Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/02 03:24:53Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/02 03:24:58Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+06/02 03:24:58Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/02 03:25:13Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/02 03:25:15Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/02 03:25:15Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+06/02 03:25:15Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/02 03:26:06Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/02 03:26:08Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/02 03:27:03Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/02 03:27:03Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/02 03:27:03Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/02 03:28:54Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/02 03:28:54Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/02 03:29:19Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/02 03:31:26Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/02 03:31:27Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/02 03:31:27Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/02 03:31:42Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/02 03:31:43Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/02 03:31:43Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/02 03:24:04Z -Runtime: nmmb_test 00:01:34 -- baseline 00:03:00
+06/02 03:27:04Z -Runtime: nmmb_pe_test 00:04:44 -- baseline 00:03:00
+06/02 03:27:04Z -Runtime: fv3gefs_test 00:00:23 -- baseline 01:20:00
+06/02 03:27:05Z -Runtime: fv3gefs_pe_test 00:00:33 -- baseline 01:20:00
+06/02 03:27:05Z -Runtime: rap_test 00:02:03 -- baseline 00:02:00
+06/02 03:27:05Z -Runtime: rap_pe_test 00:02:55 -- baseline 00:02:00
+06/02 03:29:20Z -Runtime: hrrr_test 00:06:24 -- baseline 00:02:00
+06/02 03:29:20Z -Runtime: hrrr_pe_test 00:02:00 -- baseline 00:02:00
+06/02 03:31:50Z -Runtime: fv3gfs_test 00:09:23 -- baseline 00:18:00
+06/02 03:31:50Z -Runtime: fv3gfs_pe_test 00:09:07 -- baseline 00:18:00
+06/02 03:31:50Z -Runtime: fv3r_test 00:02:33 -- baseline 00:03:00
+06/02 03:31:50Z -Runtime: fv3r_pe_test 00:02:32 -- baseline 00:03:00
+06/02 03:31:50Z -Runtime: fv3r_ifi_missing 00:00:32 -- baseline 00:03:00
+06/02 03:31:50Z -Runtime: fv3hafs_test 00:00:50 -- baseline 00:00:40
+06/02 03:31:50Z -Runtime: fv3hafs_pe_test 00:00:21 -- baseline 00:00:40
+06/02 03:31:50Z -Runtime: rtma_test 00:03:13 -- baseline 00:04:00
+06/02 03:31:50Z -Runtime: rtma_pe_test 00:02:20 -- baseline 00:04:00
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION
+++ b/tests/logs/rt.log.ORION
@@ -1,75 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b3d658c34cc85e519fb9366b287ed628baa76b49
+3e89d51c20108c29943fa7183eb17d99815a1012
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work/noaa/epic/gpetro/orion/RTs/upp-rts/1204/ci/rundir/upp-ORION
+Run directory: /work/noaa/epic/gpetro/orion/RTs/upp-rts/1220/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/UPP
 
-Total runtime: 00h:18m:25s
-Test Date: 20250523 08:57:54
+Total runtime: 00h:20m:35s
+Test Date: 20250601 22:27:08
 Summary Results:
 
-05/23 13:44:23Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/23 13:44:25Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/23 13:44:25Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/23 13:44:34Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
-05/23 13:44:35Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
-05/23 13:44:36Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
-05/23 13:46:39Z -fv3r test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
-05/23 13:46:43Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/23 13:46:48Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
-05/23 13:46:52Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/23 13:46:52Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
-05/23 13:47:47Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
-05/23 13:47:48Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/23 13:47:59Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
-05/23 13:48:01Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
-05/23 13:49:12Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/23 13:49:21Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
-05/23 13:49:24Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/23 13:49:25Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/23 13:49:32Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/23 13:52:02Z -fv3r test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-05/23 13:52:09Z -fv3r pe test: your new post executable did not generate bit-identical PRSLEV10.tm00 as the trunk
-05/23 13:52:56Z -rtma pe test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
-05/23 13:52:57Z -rtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the trunk
-05/23 13:53:55Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
-05/23 13:53:56Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
-05/23 13:53:58Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
-05/23 13:55:02Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/23 13:55:03Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/23 13:55:03Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/23 13:56:40Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
-05/23 13:56:41Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
-05/23 13:56:41Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
-05/23 13:57:42Z -fv3r test: your new post executable did not generate bit-identical NATLEV10.tm00 as the trunk
-05/23 13:57:47Z -fv3r pe test: your new post executable did not generate bit-identical NATLEV10.tm00 as the trunk
-05/23 13:44:36Z -Runtime: nmmb_test 00:01:45 -- baseline 00:03:00
-05/23 13:44:36Z -Runtime: nmmb_pe_test 00:01:34 -- baseline 00:03:00
-05/23 13:46:51Z -Runtime: fv3gefs_test 00:00:26 -- baseline 01:20:00
-05/23 13:46:51Z -Runtime: fv3gefs_pe_test 00:00:30 -- baseline 01:20:00
-05/23 13:48:06Z -Runtime: rap_test 00:01:43 -- baseline 00:02:00
-05/23 13:48:07Z -Runtime: rap_pe_test 00:01:30 -- baseline 00:02:00
-05/23 13:54:07Z -Runtime: hrrr_test 00:07:40 -- baseline 00:02:00
-05/23 13:54:07Z -Runtime: hrrr_pe_test 00:03:15 -- baseline 00:02:00
-05/23 13:56:53Z -Runtime: fv3gfs_test 00:10:23 -- baseline 00:18:00
-05/23 13:56:53Z -Runtime: fv3gfs_pe_test 00:08:45 -- baseline 00:18:00
-05/23 13:57:53Z -Runtime: fv3r_test 00:11:24 -- baseline 00:03:00
-05/23 13:57:53Z -Runtime: fv3r_pe_test 00:11:29 -- baseline 00:03:00
-05/23 13:57:53Z -Runtime: fv3r_ifi_missing 00:00:21 -- baseline 00:03:00
-05/23 13:57:53Z -Runtime: fv3hafs_test 00:00:35 -- baseline 00:00:40
-05/23 13:57:53Z -Runtime: fv3hafs_pe_test 00:00:35 -- baseline 00:00:40
-05/23 13:57:53Z -Runtime: rtma_test 00:06:39 -- baseline 00:04:00
-05/23 13:57:54Z -Runtime: rtma_pe_test 00:06:38 -- baseline 00:04:00
-There are changes in results for case rtma_pe_test in /work/noaa/epic/gpetro/orion/RTs/upp-rts/1204/ci/rundir/upp-ORION/rtma_2023040400_pe_test/PRSLEV00.tm00
-There are changes in results for case fv3r_pe_test in /work/noaa/epic/gpetro/orion/RTs/upp-rts/1204/ci/rundir/upp-ORION/fv3r_2023062800_pe_test/PRSLEV10.tm00
-There are changes in results for case fv3r_pe_test in /work/noaa/epic/gpetro/orion/RTs/upp-rts/1204/ci/rundir/upp-ORION/fv3r_2023062800_pe_test/NATLEV10.tm00
-There are changes in results for case rtma in /work/noaa/epic/gpetro/orion/RTs/upp-rts/1204/ci/rundir/upp-ORION/rtma_2023040400/PRSLEV00.tm00
-There are changes in results for case fv3r in /work/noaa/epic/gpetro/orion/RTs/upp-rts/1204/ci/rundir/upp-ORION/fv3r_2023062800/NATLEV10.tm00
-There are changes in results for case fv3r in /work/noaa/epic/gpetro/orion/RTs/upp-rts/1204/ci/rundir/upp-ORION/fv3r_2023062800/PRSLEV10.tm00
-Refer to .diff files in rundir: /work/noaa/epic/gpetro/orion/RTs/upp-rts/1204/ci/rundir/upp-ORION for details on differences in results for each case.
+06/02 03:14:13Z -fv3r test: your new post executable generates bit-identical IFIFIP10.tm00 as the trunk
+06/02 03:14:49Z -nmmb pe test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/02 03:14:51Z -nmmb pe test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/02 03:14:51Z -nmmb pe test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/02 03:14:53Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the trunk
+06/02 03:14:54Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the trunk
+06/02 03:14:54Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the trunk
+06/02 03:16:09Z -fv3r pe test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/02 03:16:12Z -fv3r pe test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/02 03:16:21Z -fv3gefs test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/02 03:16:29Z -fv3gefs pe test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the trunk
+06/02 03:16:32Z -fv3hafs pe test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/02 03:16:38Z -fv3hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the trunk
+06/02 03:16:49Z -rap pe test: your new post executable did generate changed results in WRFPRS.GrbF16
+06/02 03:16:50Z -rap pe test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/02 03:17:02Z -rtma pe test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/02 03:17:04Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF16 as the trunk
+06/02 03:17:05Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF16 as the trunk
+06/02 03:17:05Z -rtma pe test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/02 03:17:32Z -rtma test: your new post executable generates bit-identical NATLEV00.tm00 as the trunk
+06/02 03:17:35Z -rtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the trunk
+06/02 03:17:56Z -fv3r test: your new post executable generates bit-identical PRSLEV10.tm00 as the trunk
+06/02 03:18:07Z -hrrr pe test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/02 03:18:08Z -hrrr pe test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/02 03:18:10Z -hrrr pe test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/02 03:18:29Z -fv3r test: your new post executable generates bit-identical NATLEV10.tm00 as the trunk
+06/02 03:23:00Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/02 03:23:01Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/02 03:23:01Z -fv3gfs pe test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/02 03:24:08Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the trunk
+06/02 03:24:09Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the trunk
+06/02 03:24:09Z -fv3gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the trunk
+06/02 03:26:57Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF04 as the trunk
+06/02 03:27:03Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF04 as the trunk
+06/02 03:27:05Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF04 as the trunk
+06/02 03:15:00Z -Runtime: nmmb_test 00:01:24 -- baseline 00:03:00
+06/02 03:15:00Z -Runtime: nmmb_pe_test 00:01:21 -- baseline 00:03:00
+06/02 03:16:30Z -Runtime: fv3gefs_test 00:01:01 -- baseline 01:20:00
+06/02 03:16:30Z -Runtime: fv3gefs_pe_test 00:01:17 -- baseline 01:20:00
+06/02 03:17:15Z -Runtime: rap_test 00:01:53 -- baseline 00:02:00
+06/02 03:17:16Z -Runtime: rap_pe_test 00:01:58 -- baseline 00:02:00
+06/02 03:27:07Z -Runtime: hrrr_test 00:11:49 -- baseline 00:02:00
+06/02 03:27:07Z -Runtime: hrrr_pe_test 00:03:14 -- baseline 00:02:00
+06/02 03:27:07Z -Runtime: fv3gfs_test 00:10:17 -- baseline 00:18:00
+06/02 03:27:07Z -Runtime: fv3gfs_pe_test 00:09:19 -- baseline 00:18:00
+06/02 03:27:07Z -Runtime: fv3r_test 00:04:47 -- baseline 00:03:00
+06/02 03:27:07Z -Runtime: fv3r_pe_test 00:02:20 -- baseline 00:03:00
+06/02 03:27:07Z -Runtime: fv3r_ifi_missing 00:00:21 -- baseline 00:03:00
+06/02 03:27:07Z -Runtime: fv3hafs_test 00:01:18 -- baseline 00:00:40
+06/02 03:27:07Z -Runtime: fv3hafs_pe_test 00:01:20 -- baseline 00:00:40
+06/02 03:27:07Z -Runtime: rtma_test 00:03:22 -- baseline 00:04:00
+06/02 03:27:07Z -Runtime: rtma_pe_test 00:02:52 -- baseline 00:04:00
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
This PR resolves issue #1217 and contains the same code change that was made in PR #1216 to release/rrfs_v1.

The UPP code currently hard-codes a 6-hour accumulation bucket for GEFS/REFS ensemble products (see [here](https://github.com/NOAA-EMC/UPP/blob/develop/sorc/ncep_post.fd/xml_perl_data.f#L241)). This limitation should be removed to encode accumulation/time-averaged ensemble products with a bucket interval which is read in from the model output attribute "fhzero".

The UPP RTs were run on WCOSS2 and no baseline changes are expected with this PR.  Test results and working directories are located here on Cactus:
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_regression_test

