### PR TITLE
Update g2tmpl to version 1.15.0 on WCOSS2 for RRFSv1

### DIFF
--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -24,7 +24,7 @@ load(pathJoin("libpng", libpng_ver))
 load(pathJoin("zlib", zlib_ver))
 
 g2_ver=os.getenv("g2_ver") or "3.4.5"
-g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.12.0"
+g2tmpl_ver="1.15.0"
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 ip_ver=os.getenv("ip_ver") or "3.3.3"
 sp_ver=os.getenv("sp_ver") or "2.3.3"


### PR DESCRIPTION
In this PR, g2tmpl is updated to version 1.15.0 on WCOSS2 only.  g2tmpl can be updated on the R&D machines with a future release of spack-stack.  This updated version of g2tmpl is needed for the RRFSv1 implementation in order to properly set the generating processing ID for REFS grib2 output as 136, according to [office note 388 Table A](https://www.nco.ncep.noaa.gov/pmb/docs/on388/tablea.html).

A standalone UPP test for REFS was completed on Dogwood, and I confirmed that the REFS grib2 output is using 136 for the generating process ID within the product definition template.  Here is the working directory:
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_refs_2025040112

This change is related to issue #1229 .  The g2tmpl version for WCOSS2 will also be changed in the UPP develop branch after it is merged into release/rrfs_v1, so this issue can remain open until the change is merged into develop.

Since this change is for release/rrfs_v1 the UPP RTs are not required for this PR.