### PR TITLE
Add option to read earth radius from namelist and encode in GRIB2 files

### DIFF
--- a/sorc/ncep_post.fd/CTLBLK.f
+++ b/sorc/ncep_post.fd/CTLBLK.f
@@ -18,6 +18,7 @@
 !>  2023-04-17 | Eric James | Adding 160 and 320 m above ground to HTFD for RRFS output.
 !>  2023-08-16 | Yali Mao   | Add gtg_on logical option
 !>  2023-11-24 | Eric James | Add method_blsn logical option
+!>  2025-07-25 | Jaymes Kenyon | Add "earth_radius" namelist option
 !-----------------------------------------------------------------------
 !> @defgroup CTLBLK CTLBLK
 !> Sets default parameters that are used throughout the UPP code
@@ -53,6 +54,7 @@
   character(len=8)   :: FULLMODELNAME              !< No longer used/supported.
   character(len=20)  :: IOFORM                     !< Input file format.
   character(len=4)   :: VTIMEUNITS                 !< Valid time units.
+  real :: earth_radius                             !< Radius of the earth (meters), as optionally specified in the namelist
 ! 
   character(5) :: grib                          !< Grib type (Note that UPP only supports Grib2 currently).
   type(field_info),allocatable :: fld_info(:)   !< _____?

--- a/sorc/ncep_post.fd/WRFPOST.F
+++ b/sorc/ncep_post.fd/WRFPOST.F
@@ -39,6 +39,7 @@
 !> 2023-11-29 | Eric James                | Add method_blsn logical option
 !> 2024-08-19 | Jaymes Kenyon             | Adding a call to INITPOST_MPAS
 !> 2024-10-29 | Wen Meng                  | Set iSF_SURFACE_PHYSICS: 1 for NOAH; 2 for NOAH MP; 3 for RUC
+!> 2025-07-25 | Jaymes Kenyon             | Add "earth_radius" namelist option
 !> @author Mike Bladwin NSSL/SPC @date 2002-06-18
 !---------------------------------------------------------------------
 !> @return wrfpost
@@ -123,7 +124,8 @@
 #endif
       use CTLBLK_mod,    only: filenameaer, me, num_procs, num_servers, mpi_comm_comp, datestr,      &
               mpi_comm_inter, filename, ioform, grib, idat, filenameflux, filenamed3d, gdsdegr,      &
-              spldef, modelname, ihrst, lsmdef,vtimeunits, tprec, pthresh, datahandle, im, jm, lm,   &
+              spldef, modelname, ihrst, lsmdef,vtimeunits, earth_radius,                             &
+              tprec, pthresh, datahandle, im, jm, lm,                                                &
               lp1, lm1, im_jm, isf_surface_physics, nsoil, spl, lsmp1, global, imp_physics,          &
               ista, iend, ista_m, iend_m, ista_2l, iend_2u,                                          &
               jsta, jend, jsta_m, jend_m, jsta_2l, jend_2u, novegtype, icount_calmict, npset, datapd,&
@@ -162,7 +164,7 @@
       namelist/nampgb/kpo,po,kth,th,kpv,pv,fileNameAER,d3d_on,gocart_on,gccpp_on, nasa_on,gtg_on,method_blsn,popascal &
                      ,hyb_sigp,rdaod,d2d_chem, aqf_on,slrutah_on, vtimeunits,numx,write_ifi_debug_files
       integer      :: itag_ierr
-      namelist/model_inputs/fileName,IOFORM,grib,DateStr,MODELNAME,SUBMODELNAME &
+      namelist/model_inputs/fileName,IOFORM,grib,DateStr,MODELNAME,SUBMODELNAME,earth_radius &
                      ,fileNameFlux,fileNameFlat
 
       character startdate*19,SysDepInfo*80,IOWRFNAME*3,post_fname*255
@@ -203,8 +205,9 @@
 !
 !**************************************************************************
 !KaYee: Read itag in Fortran Namelist format
-!Set default 
+!Set defaults
        SUBMODELNAME='NONE'
+       earth_radius=0.
 !Set control file name
        fileNameFlat='postxconfig-NT.txt'
        numx=1
@@ -317,6 +320,12 @@
           numx=1
           if(me == 0) print*,'2D decomposition only supports GFS and FV3R.'
           if(me == 0) print*,'Reset numx= ',numx
+        ENDIF
+
+        IF (earth_radius > 0.) THEN
+          if(me == 0) print*,'Found earth_radius in namelist: using this value according to GRIB2 Table 3.2, Code Figure 1'
+        ELSE
+          if(me == 0) print*,'No earth_radius found in namelist: encoding a standard value from GRIB2 Table 3.2'
         ENDIF
 
 ! set up pressure level from POSTGPVARS or DEFAULT

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -13,6 +13,7 @@
 !> June  2024   | Sam Trahan | Bug fix for g2tmpl error messages
 !> August 2024  | Li Pan     | Enable template 4-49 to obtain aerosol ensemble information
 !> April 2025   | Eric James | Use PDT 4.1 for encoding REFS grib2 output
+!> July 2025    | J Kenyon   | Add "earth_radius" namelist option
 !-------------------------------------------------------------------------
   module grib2_module
 !
@@ -1746,7 +1747,7 @@
 !> @brief getgds() Set up Grid Description Section (GDS) kpds (Product Definition Section?) to call Boi's code ?
       subroutine getgds(ldfgrd,len3,ifield3len,igds,ifield3)
 
-      use CTLBLK_mod,  only : im,jm,gdsdegr,modelname
+      use CTLBLK_mod,  only : im,jm,gdsdegr,modelname,earth_radius
       use gridspec_mod, only: DXVAL,DYVAL,CENLAT,CENLON,LATSTART,LONSTART,LATLAST,     &
      &                        LONLAST,MAPTYPE,STANDLON,latstartv,cenlatv,lonstartv,    &
                               cenlonv,TRUELAT1,TRUELAT2,LATSTART_R,LONSTART_R,         &
@@ -1976,7 +1977,28 @@
         ifield3(19) = 0       !for NS scan
        endif
 
-     ENDIF
+     ENDIF ! MAPTYPE branching
+
+     IF (earth_radius > 0.) THEN
+
+       ! J Kenyon (25 Jul 2025): earth_radius > 0 indicates that a namelist-specified earth radius is
+       ! present. Accordingly, the GRIB2 files will be generated to reflect this radius. This is
+       ! accomplished by updating elements 1-3 of the "ifield3()" array.  These three elements correspond 
+       ! to the first three rows of 
+       !    https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp3-0.shtml 
+       ! (also applies to other projections besides lat-lon). Specifically:
+ 
+       !   For element 1: the "Shape of the Earth"
+           ifield3(1) = 1 ! 1 indicates "Earth assumed spherical with radius specified (in m) by data producer";
+                          ! see https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table3-2.shtml
+ 
+       !   For element 2: the "Scale Factor of radius of spherical Earth" 
+           ifield3(2) = 0 ! 0 indicates that no scale factor is applied 
+ 
+       !   For element 3: the "Scale value of radius of spherical Earth" 
+           ifield3(3) = earth_radius ! assign the value (meters) from the namelist
+
+     ENDIF ! namelist-specified earth_radius
 
 !    write(*,*)'igds=',igds,'igdstempl=',ifield3(1:ifield3len)
      end subroutine getgds

--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,57 +1,57 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-61fe8f6be30d5d0675d1e7a560050489f1fa18d6
+d27ec517932a808ea9c288d2530919306c4681a9
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/gpetro/hercules/RTs/upp-rts/1279/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/gpetro/hercules/RTs/upp-rts/1282/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:23m:45s
-Test Date: 20250729 11:49:55
+Total runtime: 00h:23m:51s
+Test Date: 20250804 09:58:40
 Summary Results:
 
-07/29 16:29:35Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-07/29 16:29:36Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-07/29 16:29:36Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-07/29 16:30:10Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
-07/29 16:30:11Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
-07/29 16:30:11Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
-07/29 16:30:14Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-07/29 16:30:20Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-07/29 16:30:22Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-07/29 16:30:23Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-07/29 16:30:23Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-07/29 16:30:33Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-07/29 16:30:36Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-07/29 16:30:53Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-07/29 16:31:04Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-07/29 16:31:05Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-07/29 16:31:08Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-07/29 16:31:58Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-07/29 16:34:30Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-07/29 16:34:31Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-07/29 16:34:31Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-07/29 16:35:33Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-07/29 16:35:42Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-07/29 16:49:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-07/29 16:49:46Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-07/29 16:49:46Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-07/29 16:30:21Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-07/29 16:30:36Z -Runtime: gefsv12_test 00:00:15 -- baseline 00:01:00
-07/29 16:31:22Z -Runtime: gefsv13_test 00:00:42 -- baseline 00:02:00
-07/29 16:31:22Z -Runtime: nmmb_test 00:01:15 -- baseline 00:03:00
-07/29 16:31:22Z -Runtime: rap_test 00:00:57 -- baseline 00:02:00
-07/29 16:34:37Z -Runtime: hrrr_test 00:04:23 -- baseline 00:06:00
-07/29 16:34:37Z -Runtime: hafs_test 00:00:27 -- baseline 00:01:00
-07/29 16:34:37Z -Runtime: 3drtma_test 00:01:35 -- baseline 00:03:00
-07/29 16:34:37Z -Runtime: mpas_test 00:01:10 -- baseline 00:02:30
-07/29 16:34:38Z -Runtime: mpas_hfip_test 00:02:01 -- baseline 00:05:00
-07/29 16:35:53Z -Runtime: rrfs_test 00:07:20 -- baseline 00:12:00
-07/29 16:35:53Z -Runtime: rrfs_ifi_mis 00:02:57 -- baseline 00:04:00
-07/29 16:49:55Z -Runtime: gfs_test 00:20:46 -- baseline 00:25:00
+08/04 14:37:11Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+08/04 14:37:23Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/04 14:37:40Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+08/04 14:37:51Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/04 14:38:03Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/04 14:38:04Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/04 14:38:09Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/04 14:38:10Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/04 14:38:10Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/04 14:38:18Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
+08/04 14:38:19Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
+08/04 14:38:20Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
+08/04 14:38:41Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+08/04 14:38:42Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+08/04 14:39:11Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/04 14:39:12Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/04 14:39:13Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/04 14:39:35Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+08/04 14:41:27Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/04 14:41:27Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/04 14:41:28Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/04 14:44:24Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+08/04 14:44:40Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+08/04 14:58:24Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+08/04 14:58:25Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+08/04 14:58:25Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+08/04 14:37:36Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
+08/04 14:37:36Z -Runtime: gefsv12_test 00:00:17 -- baseline 00:01:00
+08/04 14:37:51Z -Runtime: gefsv13_test 00:00:43 -- baseline 00:02:00
+08/04 14:38:21Z -Runtime: nmmb_test 00:01:02 -- baseline 00:03:00
+08/04 14:38:21Z -Runtime: rap_test 00:00:56 -- baseline 00:02:00
+08/04 14:41:37Z -Runtime: hrrr_test 00:04:20 -- baseline 00:06:00
+08/04 14:41:37Z -Runtime: hafs_test 00:00:32 -- baseline 00:01:00
+08/04 14:41:37Z -Runtime: 3drtma_test 00:01:34 -- baseline 00:03:00
+08/04 14:41:37Z -Runtime: mpas_test 00:01:12 -- baseline 00:02:30
+08/04 14:41:37Z -Runtime: mpas_hfip_test 00:02:05 -- baseline 00:05:00
+08/04 14:44:53Z -Runtime: rrfs_test 00:07:32 -- baseline 00:12:00
+08/04 14:44:53Z -Runtime: rrfs_ifi_mis 00:02:27 -- baseline 00:04:00
+08/04 14:58:40Z -Runtime: gfs_test 00:21:17 -- baseline 00:25:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'rtma']
 No changes in test results detected.

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,57 +1,57 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-61fe8f6be30d5d0675d1e7a560050489f1fa18d6
+d27ec517932a808ea9c288d2530919306c4681a9
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/gpetro/orion/RTs/upp-rts/1279/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/gpetro/orion/RTs/upp-rts/1282/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 00h:26m:39s
-Test Date: 20250729 11:52:52
+Total runtime: 00h:26m:40s
+Test Date: 20250804 10:01:45
 Summary Results:
 
-07/29 16:29:27Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-07/29 16:29:40Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-07/29 16:29:54Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-07/29 16:30:14Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-07/29 16:30:40Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-07/29 16:30:41Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-07/29 16:30:41Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-07/29 16:31:02Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-07/29 16:31:03Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-07/29 16:31:09Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
-07/29 16:31:09Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
-07/29 16:31:10Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
-07/29 16:32:08Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-07/29 16:32:10Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-07/29 16:32:27Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-07/29 16:33:05Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-07/29 16:33:07Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-07/29 16:33:08Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-07/29 16:36:43Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-07/29 16:36:44Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-07/29 16:36:45Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-07/29 16:39:43Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-07/29 16:39:55Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-07/29 16:52:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-07/29 16:52:45Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-07/29 16:52:45Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-07/29 16:29:49Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
-07/29 16:29:49Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:01:00
-07/29 16:30:19Z -Runtime: gefsv13_test 00:00:54 -- baseline 00:02:00
-07/29 16:30:49Z -Runtime: nmmb_test 00:01:22 -- baseline 00:03:00
-07/29 16:31:04Z -Runtime: rap_test 00:01:43 -- baseline 00:02:00
-07/29 16:36:50Z -Runtime: hrrr_test 00:07:25 -- baseline 00:08:00
-07/29 16:36:50Z -Runtime: hafs_test 00:00:34 -- baseline 00:01:00
-07/29 16:36:50Z -Runtime: 3drtma_test 00:02:50 -- baseline 00:03:00
-07/29 16:36:50Z -Runtime: mpas_test 00:01:50 -- baseline 00:02:30
-07/29 16:36:50Z -Runtime: mpas_hfip_test 00:03:48 -- baseline 00:05:00
-07/29 16:40:05Z -Runtime: rrfs_test 00:10:35 -- baseline 00:12:00
-07/29 16:40:05Z -Runtime: rrfs_ifi_mis 00:03:07 -- baseline 00:04:00
-07/29 16:52:51Z -Runtime: gfs_test 00:23:25 -- baseline 00:26:00
+08/04 14:38:21Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+08/04 14:38:33Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/04 14:38:48Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+08/04 14:39:08Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/04 14:39:37Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/04 14:39:38Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/04 14:39:38Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/04 14:39:55Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/04 14:39:56Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/04 14:40:04Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
+08/04 14:40:05Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
+08/04 14:40:05Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
+08/04 14:41:00Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+08/04 14:41:01Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+08/04 14:41:24Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+08/04 14:42:04Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/04 14:42:07Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/04 14:42:08Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/04 14:45:51Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/04 14:45:52Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/04 14:45:53Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/04 14:48:34Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+08/04 14:48:47Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+08/04 15:01:33Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+08/04 15:01:35Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+08/04 15:01:36Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+08/04 14:38:42Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
+08/04 14:38:42Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:01:00
+08/04 14:39:12Z -Runtime: gefsv13_test 00:00:55 -- baseline 00:02:00
+08/04 14:39:42Z -Runtime: nmmb_test 00:01:26 -- baseline 00:03:00
+08/04 14:39:57Z -Runtime: rap_test 00:01:43 -- baseline 00:02:00
+08/04 14:45:58Z -Runtime: hrrr_test 00:07:40 -- baseline 00:08:00
+08/04 14:45:58Z -Runtime: hafs_test 00:00:35 -- baseline 00:01:00
+08/04 14:45:58Z -Runtime: 3drtma_test 00:02:48 -- baseline 00:03:00
+08/04 14:45:58Z -Runtime: mpas_test 00:01:52 -- baseline 00:02:30
+08/04 14:45:58Z -Runtime: mpas_hfip_test 00:03:55 -- baseline 00:05:00
+08/04 14:48:58Z -Runtime: rrfs_test 00:10:34 -- baseline 00:12:00
+08/04 14:48:58Z -Runtime: rrfs_ifi_mis 00:03:11 -- baseline 00:04:00
+08/04 15:01:45Z -Runtime: gfs_test 00:23:23 -- baseline 00:26:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'rtma']
 No changes in test results detected.

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,57 +1,57 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-61fe8f6be30d5d0675d1e7a560050489f1fa18d6
+d27ec517932a808ea9c288d2530919306c4681a9
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch3/NAGAPE/epic/Gillian.Petro/ursa/RTs/upp-rts/1279-intel/ci/rundir/upp-URSA
+Run directory: /scratch3/NAGAPE/epic/Gillian.Petro/ursa/RTs/upp-rts/1282-intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:14m:25s
-Test Date: 20250729 16:40:40
+Total runtime: 00h:14m:22s
+Test Date: 20250804 14:47:51
 Summary Results:
 
-07/29 16:28:43Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-07/29 16:29:16Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-07/29 16:29:18Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-07/29 16:29:27Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
-07/29 16:29:28Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
-07/29 16:29:28Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
-07/29 16:30:08Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-07/29 16:30:23Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-07/29 16:30:30Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-07/29 16:30:50Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-07/29 16:30:58Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-07/29 16:30:59Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-07/29 16:31:08Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-07/29 16:31:09Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-07/29 16:31:09Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-07/29 16:31:40Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-07/29 16:31:42Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-07/29 16:31:43Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-07/29 16:31:47Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-07/29 16:31:48Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-07/29 16:31:49Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-07/29 16:33:03Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-07/29 16:33:18Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-07/29 16:40:25Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-07/29 16:40:26Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-07/29 16:40:26Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-07/29 16:30:23Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-07/29 16:30:38Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
-07/29 16:30:53Z -Runtime: gefsv13_test 00:00:33 -- baseline 00:02:00
-07/29 16:31:23Z -Runtime: nmmb_test 00:00:52 -- baseline 00:02:00
-07/29 16:31:23Z -Runtime: rap_test 00:00:42 -- baseline 00:02:00
-07/29 16:31:53Z -Runtime: hrrr_test 00:01:32 -- baseline 00:03:00
-07/29 16:31:54Z -Runtime: hafs_test 00:00:26 -- baseline 00:01:30
-07/29 16:31:54Z -Runtime: 3drtma_test 00:01:01 -- baseline 00:02:00
-07/29 16:31:54Z -Runtime: mpas_test 00:01:11 -- baseline 00:02:30
-07/29 16:31:54Z -Runtime: mpas_hfip_test 00:03:26 -- baseline 00:05:00
-07/29 16:33:24Z -Runtime: rrfs_test 00:05:01 -- baseline 00:07:00
-07/29 16:33:24Z -Runtime: rrfs_ifi_missing 00:01:51 -- baseline 00:03:00
-07/29 16:40:39Z -Runtime: gfs_test 00:12:09 -- baseline 00:15:00
+08/04 14:35:30Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+08/04 14:35:42Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/04 14:35:47Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+08/04 14:35:52Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/04 14:35:53Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/04 14:35:53Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/04 14:35:59Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/04 14:36:08Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/04 14:36:09Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/04 14:36:18Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+08/04 14:36:19Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+08/04 14:36:29Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
+08/04 14:36:30Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
+08/04 14:36:30Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
+08/04 14:36:52Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/04 14:36:53Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/04 14:36:54Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/04 14:37:14Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+08/04 14:38:46Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/04 14:38:48Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/04 14:38:49Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/04 14:40:03Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+08/04 14:40:16Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+08/04 14:47:46Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+08/04 14:47:47Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+08/04 14:47:47Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+08/04 14:35:49Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
+08/04 14:35:49Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:02:00
+08/04 14:36:04Z -Runtime: gefsv13_test 00:00:37 -- baseline 00:02:00
+08/04 14:36:04Z -Runtime: nmmb_test 00:00:26 -- baseline 00:02:00
+08/04 14:36:19Z -Runtime: rap_test 00:00:47 -- baseline 00:02:00
+08/04 14:37:04Z -Runtime: hrrr_test 00:01:32 -- baseline 00:03:00
+08/04 14:37:04Z -Runtime: hafs_test 00:00:25 -- baseline 00:01:30
+08/04 14:37:04Z -Runtime: 3drtma_test 00:00:57 -- baseline 00:02:00
+08/04 14:37:04Z -Runtime: mpas_test 00:01:08 -- baseline 00:02:30
+08/04 14:38:50Z -Runtime: mpas_hfip_test 00:03:27 -- baseline 00:05:00
+08/04 14:40:20Z -Runtime: rrfs_test 00:04:54 -- baseline 00:07:00
+08/04 14:40:20Z -Runtime: rrfs_ifi_missing 00:01:52 -- baseline 00:03:00
+08/04 14:47:51Z -Runtime: gfs_test 00:12:25 -- baseline 00:15:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'rtma']
 No changes in test results detected.

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,57 +1,57 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-61fe8f6be30d5d0675d1e7a560050489f1fa18d6
+d27ec517932a808ea9c288d2530919306c4681a9
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch3/NAGAPE/epic/Gillian.Petro/ursa/RTs/upp-rts/1279-llvm/ci/rundir/upp-URSA
+Run directory: /scratch3/NAGAPE/epic/Gillian.Petro/ursa/RTs/upp-rts/1282-llvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:13m:38s
-Test Date: 20250729 16:40:27
+Total runtime: 00h:13m:15s
+Test Date: 20250804 14:47:11
 Summary Results:
 
-07/29 16:28:43Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-07/29 16:29:12Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-07/29 16:29:14Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-07/29 16:29:21Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
-07/29 16:29:22Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
-07/29 16:29:22Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
-07/29 16:29:23Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-07/29 16:29:31Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-07/29 16:29:52Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-07/29 16:29:56Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-07/29 16:29:57Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-07/29 16:30:05Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-07/29 16:31:06Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-07/29 16:31:06Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-07/29 16:31:07Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-07/29 16:31:27Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-07/29 16:31:27Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-07/29 16:31:29Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-07/29 16:31:39Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-07/29 16:31:41Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-07/29 16:31:41Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-07/29 16:32:46Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-07/29 16:33:01Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-07/29 16:40:22Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-07/29 16:40:24Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-07/29 16:40:24Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-07/29 16:29:25Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-07/29 16:29:41Z -Runtime: gefsv12_test 00:00:14 -- baseline 00:02:00
-07/29 16:29:56Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
-07/29 16:31:11Z -Runtime: nmmb_test 00:00:50 -- baseline 00:01:30
-07/29 16:31:11Z -Runtime: rap_test 00:00:40 -- baseline 00:02:00
-07/29 16:31:41Z -Runtime: hrrr_test 00:01:12 -- baseline 00:02:30
-07/29 16:31:41Z -Runtime: hafs_test 00:00:26 -- baseline 00:01:30
-07/29 16:31:41Z -Runtime: 3drtma_test 00:00:57 -- baseline 00:02:30
-07/29 16:31:41Z -Runtime: mpas_test 00:01:05 -- baseline 00:02:30
-07/29 16:31:56Z -Runtime: mpas_hfip_test 00:03:25 -- baseline 00:05:00
-07/29 16:33:11Z -Runtime: rrfs_test 00:04:44 -- baseline 00:06:00
-07/29 16:33:11Z -Runtime: rrfs_ifi_missing 00:01:48 -- baseline 00:03:00
-07/29 16:40:27Z -Runtime: gfs_test 00:12:07 -- baseline 00:15:00
+08/04 14:35:01Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+08/04 14:35:08Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/04 14:35:18Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+08/04 14:35:29Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/04 14:35:33Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/04 14:35:34Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/04 14:35:47Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+08/04 14:35:49Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/04 14:35:49Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+08/04 14:35:50Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/04 14:35:50Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/04 14:35:56Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
+08/04 14:35:57Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
+08/04 14:35:57Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
+08/04 14:36:09Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/04 14:36:10Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/04 14:36:11Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/04 14:36:43Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+08/04 14:38:12Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/04 14:38:14Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/04 14:38:14Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/04 14:39:23Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+08/04 14:39:36Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+08/04 14:47:07Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+08/04 14:47:08Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+08/04 14:47:08Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+08/04 14:35:24Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
+08/04 14:35:24Z -Runtime: gefsv12_test 00:00:14 -- baseline 00:02:00
+08/04 14:35:39Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
+08/04 14:35:54Z -Runtime: nmmb_test 00:00:56 -- baseline 00:01:30
+08/04 14:35:54Z -Runtime: rap_test 00:00:40 -- baseline 00:02:00
+08/04 14:36:24Z -Runtime: hrrr_test 00:01:17 -- baseline 00:02:30
+08/04 14:36:24Z -Runtime: hafs_test 00:00:25 -- baseline 00:01:30
+08/04 14:36:24Z -Runtime: 3drtma_test 00:00:54 -- baseline 00:02:30
+08/04 14:36:24Z -Runtime: mpas_test 00:01:02 -- baseline 00:02:30
+08/04 14:38:24Z -Runtime: mpas_hfip_test 00:03:19 -- baseline 00:05:00
+08/04 14:39:39Z -Runtime: rrfs_test 00:04:41 -- baseline 00:06:00
+08/04 14:39:39Z -Runtime: rrfs_ifi_missing 00:01:48 -- baseline 00:03:00
+08/04 14:47:11Z -Runtime: gfs_test 00:12:13 -- baseline 00:15:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'rtma']
 No changes in test results detected.

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,6 +1,6 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b0606f5abc09299387f9ed3efa8243b427f0654b
+848d55e5403e129a38c2855919fb2f6c8954022d
 
 Submodule hashes:
  179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd (before-3km-fixes-45-g179cae1)
@@ -9,53 +9,53 @@ Submodule hashes:
 Run directory: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2
 Baseline directory: /u/wen.meng/noscrub/test_suite
 
-Total runtime: 00h:36m:20s
-Test Date: 20250729 12:38:19
+Total runtime: 00h:29m:29s
+Test Date: 20250804 12:21:02
 Summary Results:
 
-07/29 12:07:52Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-07/29 12:08:09Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-07/29 12:08:34Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-07/29 12:08:44Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
-07/29 12:08:50Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-07/29 12:08:51Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-07/29 12:08:52Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-07/29 12:08:53Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-07/29 12:08:53Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-07/29 12:08:56Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-07/29 12:09:11Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-07/29 12:09:13Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-07/29 12:09:28Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
-07/29 12:09:30Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
-07/29 12:09:30Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
-07/29 12:10:24Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-07/29 12:10:25Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-07/29 12:10:26Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-07/29 12:11:43Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-07/29 12:11:46Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-07/29 12:11:48Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-07/29 12:13:57Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-07/29 12:14:46Z -rrfs_ifi test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-07/29 12:16:27Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-07/29 12:16:40Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-07/29 12:37:36Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-07/29 12:37:38Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-07/29 12:37:38Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-07/29 12:08:04Z -Runtime: sfs_test 00:00:46 -- baseline 00:00:50
-07/29 12:08:25Z -Runtime: gefsv12_test 00:01:08 -- baseline 00:01:20
-07/29 12:09:18Z -Runtime: gefsv13_test 00:01:55 -- baseline 00:02:00
-07/29 12:09:23Z -Runtime: nmmb_test 00:01:52 -- baseline 00:02:20
-07/29 12:09:27Z -Runtime: rap_test 00:01:50 -- baseline 00:02:00
-07/29 12:10:52Z -Runtime: hrrr_test 00:03:26 -- baseline 00:03:40
-07/29 12:10:56Z -Runtime: hafs_test 00:01:33 -- baseline 00:02:00
-07/29 12:11:00Z -Runtime: 3drtma_test 00:02:13 -- baseline 00:04:40
-07/29 12:11:04Z -Runtime: mpas_test 00:02:31 -- baseline 00:02:40
-07/29 12:12:13Z -Runtime: mpas_hfip.test 00:04:49 -- baseline 00:05:00
-07/29 12:17:07Z -Runtime: rrfs_test 00:09:44 -- baseline 00:10:00
-07/29 12:17:11Z -Runtime: rrfs_ifi_mis 00:06:55 -- baseline 00:08:00
-07/29 12:38:10Z -Runtime: gfs_test 00:30:43 -- baseline 00:29:30
-07/29 12:38:14Z -Runtime: hrrr_ifi_test 00:01:43 -- baseline 00:02:00
-07/29 12:38:19Z -Runtime: rrfs_ifi_test 00:07:42 -- baseline 00:08:10
+08/04 11:52:17Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+08/04 11:52:37Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/04 11:53:02Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+08/04 11:53:08Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
+08/04 11:53:17Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/04 11:53:23Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/04 11:53:24Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/04 11:53:27Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/04 11:53:28Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/04 11:53:28Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/04 11:53:40Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+08/04 11:53:43Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+08/04 11:53:50Z -mpas test: your new post executable generates bit-identical POSTNAT02.tm00 as the develop branch
+08/04 11:53:52Z -mpas test: your new post executable generates bit-identical POSTPRS02.tm00 as the develop branch
+08/04 11:53:53Z -mpas test: your new post executable generates bit-identical POSTTWO02.tm00 as the develop branch
+08/04 11:54:44Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/04 11:54:46Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/04 11:54:47Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/04 11:56:35Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/04 11:56:40Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/04 11:56:41Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/04 11:58:21Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+08/04 11:59:35Z -rrfs_ifi test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+08/04 12:00:51Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+08/04 12:01:18Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+08/04 12:20:23Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+08/04 12:20:25Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+08/04 12:20:26Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+08/04 11:52:43Z -Runtime: sfs_test 00:00:47 -- baseline 00:00:50
+08/04 11:53:03Z -Runtime: gefsv12_test 00:01:13 -- baseline 00:01:20
+08/04 11:53:40Z -Runtime: gefsv13_test 00:01:52 -- baseline 00:02:00
+08/04 11:54:00Z -Runtime: nmmb_test 00:02:04 -- baseline 00:02:20
+08/04 11:54:04Z -Runtime: rap_test 00:01:59 -- baseline 00:02:00
+08/04 11:55:13Z -Runtime: hrrr_test 00:03:24 -- baseline 00:03:40
+08/04 11:55:17Z -Runtime: hafs_test 00:01:37 -- baseline 00:02:00
+08/04 11:55:32Z -Runtime: 3drtma_test 00:02:20 -- baseline 00:04:40
+08/04 11:55:37Z -Runtime: mpas_test 00:02:30 -- baseline 00:02:40
+08/04 11:57:01Z -Runtime: mpas_hfip.test 00:05:17 -- baseline 00:05:00
+08/04 12:01:55Z -Runtime: rrfs_test 00:10:01 -- baseline 00:10:00
+08/04 12:02:00Z -Runtime: rrfs_ifi_mis 00:06:56 -- baseline 00:08:00
+08/04 12:20:53Z -Runtime: gfs_test 00:29:08 -- baseline 00:29:30
+08/04 12:20:57Z -Runtime: hrrr_ifi_test 00:01:45 -- baseline 00:02:00
+08/04 12:21:01Z -Runtime: rrfs_ifi_test 00:08:09 -- baseline 00:08:10
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'hrrr_ifi', 'rrfs_ifi', 'rtma']
 No changes in test results detected.


### PR DESCRIPTION
This addresses issue #1271 (copying @guoqing-noaa).  Specifically, UPP now checks for an optional "**earth_radius**" value in the namelist; e.g.,

```
&model_inputs
fileName='/mnt/lfs5/BMC/rtwbl/kenyon/mpas_upp/rrfs/2025050515/MPAS-A_out.2025-05-05_17.00.00.nc'
fileNameFlux='/mnt/lfs5/BMC/rtwbl/kenyon/mpas_upp/rrfs/2025050515/MPAS-A_out.2025-05-05_17.00.00.nc'
IOFORM='netcdfpara'
grib='grib2'
DateStr='2025-05-05_17:00:00'
MODELNAME='RAPR'
SUBMODELNAME='MPAS'
earth_radius=6370000.
fileNameFlat='postxconfig-NT.txt'
/
```
When an **earth_radius** value is provided, GRIB2 files are generated using this value; e.g.,
```
> wgrib2 POSTTWO.GrbF02 -d 1 -radius
1:0:code3.2=1 radius_maj=6370000.000000 radiusmin=6370000.000000 is_spherical=1
```
This PR has been tested on Jet using a RRFS-MPAS test case (CONUS domain, Lambert conformal projection).