### PR TITLE
Fix surface specific humidity calculation (release/rrfs_v1 branch)

### DIFF
--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -56,6 +56,7 @@
 !> 2024-05-09 | Eric James    | Enable reading of clear-sky downwelling shortwave irradiance
 !> 2024-08-20 | Eric James    | Enable reading of seasonal max/min green vegetation fraction
 !> 2025-04-23 ! Jesse Meng    | Bug fix zmid calculation in very thin layers
+!> 2025-09-11 | Jili Dong     | Read in surface specific humidity from history
 !>
 !> @author Hui-Ya Chuang @date 2016-03-04
 !----------------------------------------------------------------------
@@ -1840,7 +1841,8 @@
 !    write(*,*)' i=',i,' j=',j,' ths=',ths(i,j),' pint=',pint(i,j,lp1)
             ths(i,j) = ths(i,j) * (p1000/pint(i,j,lp1))**capa
           endif
-          QS(i,j)    = SPVAL ! GFS does not have surface specific humidity
+! certain UFS application may have QS available in history files
+!          QS(i,j)    = SPVAL ! GFS does not have surface specific humidity
           twbs(i,j)  = SPVAL ! GFS does not have inst sensible heat flux
           qwbs(i,j)  = SPVAL ! GFS does not have inst latent heat flux
 !assign sst
@@ -1856,6 +1858,11 @@
         enddo
       enddo
      if(debugprint)print*,'sample ',VarName,' = ',ths(isa,jsa)
+
+! surface specific humidity
+      VarName='qs'
+      call read_netcdf_2d_para(ncid2d,ista,ista_2l,iend,iend_2u,jsta,jsta_2l,jend,jend_2u, &
+      spval,VarName,qs)
 
 ! foundation temperature
       VarName='tref'

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -55,6 +55,7 @@
 !> 2024-05-24 | E James    | Modify the run total acc precip fields for 15-min output
 !> 2024-06-11 | E James    | Modifying RRFS hourly average smoke/dust fields to be PM2.5 and PM20
 !> 2025-05-05 | B Blake    | Add sanity checks for RRFSv1 implementation
+!> 2025-09-11 | W Meng     | Set surface spfh to missing when not available
 !>     
 !> @note
 !> USAGE:    CALL SURFCE
@@ -225,8 +226,8 @@
              QSFC(I,J) = spval
              RHSFC(I,J) = spval
              EVP(I,J) = spval
-             IF(TSFC(I,J) < spval) then
-             IF(QS(I,J)<spval) QSFC(I,J)  = MAX(H1M12,QS(I,J))
+             IF(TSFC(I,J) < spval .AND. QS(I,J) < spval) then
+             QSFC(I,J)  = MAX(H1M12,QS(I,J))
              TSFCK      = TSFC(I,J)
      
              IF(MODELNAME == 'RAPR') THEN


### PR DESCRIPTION
This PR resolves issue #1333 

The changes to the UPP develop branch in PR #1325 are incorporated in the release/rrfs_v1 branch for inclusion with the RRFSv1 implementation.  

I ran 4 UPP tests (using RRFS input files with/without QS, and the UPP code with/without Jili's/Wen's changes) and generated comparison plots to confirm the changes are working as intended.

The first set of plots depicts the surface SPFH with Jili's code changes for a RRFS GRIB2 file that contains QS. The top right plot shows more reasonable values than the plot on the top left, which is not calculating SPFH correctly.
<img width="1076" height="964" alt="image" src="https://github.com/user-attachments/assets/8c98c70b-e239-4612-8bc8-b833e6ea5d78" />

The next set of plots depicts the surface SPFH with Jili's code changes for a RRFS GRIB2 file that does not contain QS. The top right plot shows that SPFH is undefined everywhere, which is expected since QS is not being read in from the netcdf file.
<img width="1076" height="964" alt="image" src="https://github.com/user-attachments/assets/302a8854-38c9-44b8-ab71-e18f703c90dd" />
