### PR TITLE
Use WMO IDs for RSMIN and RLYRS in RRFS

### DIFF
--- a/parm/rrfs/postxconfig-NT-refs.txt
+++ b/parm/rrfs/postxconfig-NT-refs.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-refs_f00.txt
+++ b/parm/rrfs/postxconfig-NT-refs_f00.txt
@@ -2628,7 +2628,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2670,7 +2670,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15245,7 +15245,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15287,7 +15287,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-refs_f01.txt
+++ b/parm/rrfs/postxconfig-NT-refs_f01.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19779,7 +19779,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19821,7 +19821,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_f00.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_f00.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15747,7 +15747,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15789,7 +15789,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_f01.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_f01.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19527,7 +19527,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19569,7 +19569,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_firewx.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_firewx.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19191,7 +19191,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19233,7 +19233,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_firewx_f00.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_firewx_f00.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15243,7 +15243,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15285,7 +15285,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_firewx_f01.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_firewx_f01.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -18939,7 +18939,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -18981,7 +18981,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/refs_postcntrl.xml
+++ b/parm/rrfs/refs_postcntrl.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/refs_postcntrl_f00.xml
+++ b/parm/rrfs/refs_postcntrl_f00.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -2475,14 +2473,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/refs_postcntrl_f01.xml
+++ b/parm/rrfs/refs_postcntrl_f01.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl.xml
+++ b/parm/rrfs/rrfs_postcntrl.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3133,14 +3131,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_f00.xml
+++ b/parm/rrfs/rrfs_postcntrl_f00.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -2553,14 +2551,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_f01.xml
+++ b/parm/rrfs/rrfs_postcntrl_f01.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3101,14 +3099,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_firewx.xml
+++ b/parm/rrfs/rrfs_postcntrl_firewx.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3046,14 +3044,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_firewx_f00.xml
+++ b/parm/rrfs/rrfs_postcntrl_firewx_f00.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -2475,14 +2473,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_firewx_f01.xml
+++ b/parm/rrfs/rrfs_postcntrl_firewx_f01.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3015,14 +3013,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 


### PR DESCRIPTION
The UPP control files for RRFS have been updated to use the WMO IDs for the following two parameters:

**RSMIN - Minimal Stomatal Resistance** - [Table 4.2-2-0](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-2-0.shtml) - parameter 16 is now used instead of parameter 200
**RLYRS - Number of Soil Layers in Root Zone** - [Table 4.2-2-3](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-2-3.shtml) - parameter 6 is now used instead of parameter 193

@WenMeng-NOAA I completed a standalone RRFS test on WCOSS2 and confirmed that the parameters are encoded correctly with wgrib2 (e.g. `wgrib2 -var -lev -v -code_table_0.0 -code_table_4.2`).  Here is my working directory on Cactus:
/lfs/h2/emc/ptmp/Benjamin.Blake/post_rrfs_2025040112_018

These changes will also be added to the UPP develop branch in a future PR.