### PR TITLE
Change BRTMP into BRTEMP for GFS, GEFS, SFS

### DIFF
--- a/ci/jobs-dev/run_post_gfs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_gfs_WCOSS2.sh
@@ -37,7 +37,7 @@ postmsg "$logfile" "$msg"
 export POSTGPEXEC=$svndir/exec/upp.x
 
 # specify forecast start time and hour
-export startdate=2024120500
+export startdate=2025012600
 export fhr=006
 export cyc=`echo $startdate |cut -c9-10`
 

--- a/ci/jobs-dev/run_post_gfs_template.sh
+++ b/ci/jobs-dev/run_post_gfs_template.sh
@@ -38,7 +38,7 @@ postmsg "$logfile" "$msg"
 export POSTGPEXEC=${svndir}/exec/upp.x
 
 # specify forecast start time and hour for running your post job
-export startdate=2024120500
+export startdate=2025012600
 export fhr=006
 export cyc=`echo $startdate |cut -c9-10`
 

--- a/ci/jobs-dev/test.sh
+++ b/ci/jobs-dev/test.sh
@@ -62,11 +62,11 @@ gefsv13() {
 gfs() {
    case $machine in
       ORION|HERCULES)
-         export NODES='-N 6'
+         export NODES='-N 3'
          export N_TASKS_PER_NODE='--ntasks-per-node=40'
       ;;
       URSA)
-         export N_TASKS='--ntasks 400'
+         export N_TASKS='--ntasks 120'
          export TASKS_PER_NODE='--tasks-per-node 40'
       ;;
    esac

--- a/ci/runtime.log.WCOSS2_intel
+++ b/ci/runtime.log.WCOSS2_intel
@@ -12,4 +12,4 @@ mpas_hfip_test 00:05:00
 rrfs_test 00:10:00
 rrfs_ifi_test 00:08:10
 rrfs_ifi_missing 00:08:00
-gfs_test 00:29:30
+gfs_test 00:15:00

--- a/parm/gefs/postxconfig-NT-gefs-aerosol.txt
+++ b/parm/gefs/postxconfig-NT-gefs-aerosol.txt
@@ -2794,7 +2794,7 @@ BRTMP_ON_TOP_OF_ATMOS
 ?
 1
 tmpl4_0
-BRTMP
+BRTEMP
 ?
 ?
 top_of_atmos

--- a/parm/gefs/postxconfig-NT-gefs-f00-aerosol.txt
+++ b/parm/gefs/postxconfig-NT-gefs-f00-aerosol.txt
@@ -1912,7 +1912,7 @@ BRTMP_ON_TOP_OF_ATMOS
 ?
 1
 tmpl4_0
-BRTMP
+BRTEMP
 ?
 ?
 top_of_atmos

--- a/parm/gefs/postxconfig-NT-gefs-f00.txt
+++ b/parm/gefs/postxconfig-NT-gefs-f00.txt
@@ -1912,7 +1912,7 @@ BRTMP_ON_TOP_OF_ATMOS
 ?
 1
 tmpl4_0
-BRTMP
+BRTEMP
 ?
 ?
 top_of_atmos

--- a/parm/gefs/postxconfig-NT-gefs.txt
+++ b/parm/gefs/postxconfig-NT-gefs.txt
@@ -2920,7 +2920,7 @@ BRTMP_ON_TOP_OF_ATMOS
 ?
 1
 tmpl4_0
-BRTMP
+BRTEMP
 ?
 ?
 top_of_atmos

--- a/parm/gfs/postxconfig-NT-gfs-f00-two.txt
+++ b/parm/gfs/postxconfig-NT-gfs-f00-two.txt
@@ -2332,7 +2332,7 @@ BRTMP_ON_TOP_OF_ATMOS
 ?
 1
 tmpl4_0
-BRTMP
+BRTEMP
 ?
 ?
 top_of_atmos

--- a/parm/gfs/postxconfig-NT-gfs-two.txt
+++ b/parm/gfs/postxconfig-NT-gfs-two.txt
@@ -3172,7 +3172,7 @@ BRTMP_ON_TOP_OF_ATMOS
 ?
 1
 tmpl4_0
-BRTMP
+BRTEMP
 ?
 ?
 top_of_atmos

--- a/parm/post_avblflds.xml
+++ b/parm/post_avblflds.xml
@@ -2363,7 +2363,7 @@
     <param>
        <post_avblfldidx>275</post_avblfldidx>
        <shortname>BRTMP_ON_TOP_OF_ATMOS</shortname>
-       <pname>BRTMP</pname>
+       <pname>BRTEMP</pname>
        <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
        <scale>3.0</scale>
     </param>

--- a/parm/sfs/postxconfig-NT-sfs.txt
+++ b/parm/sfs/postxconfig-NT-sfs.txt
@@ -2793,7 +2793,7 @@ BRTMP_ON_TOP_OF_ATMOS
 ?
 1
 tmpl4_0
-BRTMP
+BRTEMP
 ?
 ?
 top_of_atmos

--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,70 +1,61 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-8548c8abb3abafb1892253f8045e5957de9b63b2
+2a022cd8515549745329ce5c4a1dbf9ed101e0c7
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:35m:24s
-Test Date: 20251009 08:28:48
+Total runtime: 00h:12m:06s
+Test Date: 20251014 12:22:47
 Summary Results:
 
-10/09 12:55:51Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/09 12:56:00Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/09 12:56:23Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/09 12:56:28Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/09 12:56:45Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/09 12:56:45Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/09 12:56:45Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/09 12:56:57Z -rap test: your new post executable did not generate bit-identical WRFPRS.GrbF06 as the develop branch
-10/09 12:56:57Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/09 12:56:58Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/09 12:57:12Z -mpas test: your new post executable did not generate bit-identical POSTTWO18.tm00 as the develop branch
-10/09 12:57:14Z -rap test: your new post executable did not generate bit-identical WRFNAT.GrbF06 as the develop branch
-10/09 12:57:28Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/09 12:57:30Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/09 12:57:43Z -mpas_hfip test: your new post executable did not generate bit-identical 2DFLD.GrbF48 as the develop branch
-10/09 12:57:50Z -hrrr test: your new post executable did not generate bit-identical WRFTWO.GrbF10 as the develop branch
-10/09 12:57:50Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/09 12:57:51Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/09 12:58:07Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/09 12:59:50Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/09 13:01:15Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/09 13:11:56Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/09 13:17:38Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/09 13:18:10Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/09 13:18:12Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/09 13:28:42Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/09 12:56:13Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
-10/09 12:56:13Z -Runtime: gefsv12_test 00:00:16 -- baseline 00:01:00
-10/09 12:56:28Z -Runtime: gefsv13_test 00:00:44 -- baseline 00:02:00
-10/09 12:56:58Z -Runtime: nmmb_test 00:01:01 -- baseline 00:03:00
-10/09 12:57:29Z -Runtime: rap_test 00:01:30 -- baseline 00:02:00
-10/09 12:57:59Z -Runtime: hrrr_test 00:02:07 -- baseline 00:06:00
-10/09 12:57:59Z -Runtime: hafs_test 00:00:39 -- baseline 00:01:00
-10/09 13:01:29Z -Runtime: 3drtma_test 00:05:31 -- baseline 00:03:00
-10/09 13:01:29Z -Runtime: mpas_test 00:01:28 -- baseline 00:02:30
-10/09 13:01:29Z -Runtime: mpas_hfip_test 00:02:00 -- baseline 00:05:00
-10/09 13:28:48Z -Runtime: rrfs_test 00:32:58 -- baseline 00:12:00
-10/09 13:28:48Z -Runtime: rrfs_ifi_missing 00:02:23 -- baseline 00:04:00
-10/09 13:28:48Z -Runtime: gfs_test 00:22:28 -- baseline 00:25:00
+10/14 17:12:53Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/14 17:13:01Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/14 17:13:17Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/14 17:13:46Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/14 17:13:46Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/14 17:13:53Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/14 17:13:53Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/14 17:13:53Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/14 17:13:56Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/14 17:14:38Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/14 17:14:39Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/14 17:14:40Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/14 17:14:49Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/14 17:14:51Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/14 17:14:51Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/14 17:14:57Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/14 17:14:57Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/14 17:14:58Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/14 17:15:10Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/14 17:15:12Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/14 17:16:10Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/14 17:22:08Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/14 17:22:10Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/14 17:22:10Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/14 17:22:27Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/14 17:22:36Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/14 17:13:16Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
+10/14 17:13:16Z -Runtime: gefsv12_test 00:00:15 -- baseline 00:01:00
+10/14 17:14:01Z -Runtime: gefsv13_test 00:01:10 -- baseline 00:02:00
+10/14 17:14:01Z -Runtime: nmmb_test 00:01:07 -- baseline 00:03:00
+10/14 17:14:01Z -Runtime: rap_test 00:01:00 -- baseline 00:02:00
+10/14 17:14:46Z -Runtime: hrrr_test 00:01:54 -- baseline 00:06:00
+10/14 17:14:46Z -Runtime: hafs_test 00:00:31 -- baseline 00:01:00
+10/14 17:15:16Z -Runtime: 3drtma_test 00:01:26 -- baseline 00:03:00
+10/14 17:15:16Z -Runtime: mpas_test 00:01:12 -- baseline 00:02:30
+10/14 17:15:16Z -Runtime: mpas_hfip_test 00:02:02 -- baseline 00:05:00
+10/14 17:22:47Z -Runtime: rrfs_test 00:09:47 -- baseline 00:12:00
+10/14 17:22:47Z -Runtime: rrfs_ifi_missing 00:02:18 -- baseline 00:04:00
+10/14 17:22:47Z -Runtime: gfs_test 00:08:53 -- baseline 00:25:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case mpas in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/mpas_hfip_2024100700/2DFLD.GrbF48
-There are changes in results for case hrrr in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/hrrr_2025063004/WRFTWO.GrbF10
-There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/rrfs_2025040112/NATLEV18.tm00
-There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/gfs_2024120500/gfs.t00z.special.grb2f006
-There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/gfs_2024120500/gfs.t00z.master.grb2f006
-There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/gfs_2024120500/gfs.t00z.sfluxgrbf006.grib2
-There are changes in results for case rap in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/rap_2025070115/WRFPRS.GrbF06
-There are changes in results for case rap in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/rap_2025070115/WRFNAT.GrbF06
-There are changes in results for case mpas in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES/mpas_2025071400/POSTTWO18.tm00
-Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1281_hercules_intel/ci/rundir/upp-HERCULES for details on differences in results for each case.
+There are changes in results for case gefsv13 in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES/gefsv13_2023080300/gefs.t00z.master.grb2f009
+There are changes in results for case sfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES/sfs_2017050100/sfs.t00z.master.grb2f048
+There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES/gfs_2025012600/gfs.t00z.master.grb2f006
+Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,70 +1,61 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-8548c8abb3abafb1892253f8045e5957de9b63b2
+2a022cd8515549745329ce5c4a1dbf9ed101e0c7
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 01h:01m:16s
-Test Date: 20251009 09:48:47
+Total runtime: 00h:15m:42s
+Test Date: 20251014 12:26:16
 Summary Results:
 
-10/09 13:50:50Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/09 13:51:02Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/09 13:51:17Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/09 13:51:36Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/09 13:51:37Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/09 13:51:37Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/09 13:51:37Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/09 13:52:34Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/09 13:52:35Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/09 13:53:02Z -mpas test: your new post executable did not generate bit-identical POSTTWO18.tm00 as the develop branch
-10/09 13:53:14Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/09 13:53:16Z -rap test: your new post executable did not generate bit-identical WRFPRS.GrbF06 as the develop branch
-10/09 13:53:37Z -rap test: your new post executable did not generate bit-identical WRFNAT.GrbF06 as the develop branch
-10/09 13:54:07Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/09 13:54:09Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/09 13:54:31Z -mpas_hfip test: your new post executable did not generate bit-identical 2DFLD.GrbF48 as the develop branch
-10/09 13:54:42Z -hrrr test: your new post executable did not generate bit-identical WRFTWO.GrbF10 as the develop branch
-10/09 13:54:42Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/09 13:54:43Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/09 13:57:16Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/09 13:59:49Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/09 14:18:10Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/09 14:19:23Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/09 14:20:02Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/09 14:20:04Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/09 14:48:39Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/09 13:51:10Z -Runtime: sfs_test 00:00:09 -- baseline 00:01:20
-10/09 13:51:10Z -Runtime: gefsv12_test 00:00:21 -- baseline 00:01:00
-10/09 13:51:40Z -Runtime: gefsv13_test 00:00:56 -- baseline 00:02:00
-10/09 13:51:41Z -Runtime: nmmb_test 00:00:56 -- baseline 00:03:00
-10/09 13:53:41Z -Runtime: rap_test 00:02:57 -- baseline 00:02:00
-10/09 13:54:56Z -Runtime: hrrr_test 00:04:02 -- baseline 00:08:00
-10/09 13:54:56Z -Runtime: hafs_test 00:00:36 -- baseline 00:01:00
-10/09 13:59:57Z -Runtime: 3drtma_test 00:09:08 -- baseline 00:03:00
-10/09 13:59:57Z -Runtime: mpas_test 00:02:21 -- baseline 00:02:30
-10/09 13:59:57Z -Runtime: mpas_hfip_test 00:03:50 -- baseline 00:05:00
-10/09 14:48:46Z -Runtime: rrfs_test 00:57:59 -- baseline 00:12:00
-10/09 14:48:47Z -Runtime: rrfs_ifi_missing 00:02:33 -- baseline 00:04:00
-10/09 14:48:47Z -Runtime: gfs_test 00:29:23 -- baseline 00:26:00
+10/14 17:15:10Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/14 17:15:19Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/14 17:15:37Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/14 17:16:18Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/14 17:16:24Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/14 17:16:25Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/14 17:16:26Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/14 17:16:28Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/14 17:16:29Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/14 17:16:29Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/14 17:16:43Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/14 17:16:43Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/14 17:17:12Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/14 17:17:14Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/14 17:17:33Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/14 17:17:33Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/14 17:17:35Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/14 17:17:35Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/14 17:18:33Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/14 17:18:33Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/14 17:18:34Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/14 17:24:58Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/14 17:25:11Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/14 17:26:02Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/14 17:26:04Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/14 17:26:04Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/14 17:15:14Z -Runtime: sfs_test 00:00:10 -- baseline 00:01:20
+10/14 17:15:29Z -Runtime: gefsv12_test 00:00:19 -- baseline 00:01:00
+10/14 17:16:29Z -Runtime: gefsv13_test 00:01:18 -- baseline 00:02:00
+10/14 17:16:44Z -Runtime: nmmb_test 00:01:29 -- baseline 00:03:00
+10/14 17:16:44Z -Runtime: rap_test 00:01:43 -- baseline 00:02:00
+10/14 17:18:44Z -Runtime: hrrr_test 00:03:34 -- baseline 00:08:00
+10/14 17:18:44Z -Runtime: hafs_test 00:00:37 -- baseline 00:01:00
+10/14 17:18:44Z -Runtime: 3drtma_test 00:02:43 -- baseline 00:03:00
+10/14 17:18:44Z -Runtime: mpas_test 00:01:55 -- baseline 00:02:30
+10/14 17:18:44Z -Runtime: mpas_hfip_test 00:03:29 -- baseline 00:05:00
+10/14 17:25:15Z -Runtime: rrfs_test 00:10:52 -- baseline 00:12:00
+10/14 17:25:15Z -Runtime: rrfs_ifi_missing 00:02:33 -- baseline 00:04:00
+10/14 17:26:15Z -Runtime: gfs_test 00:11:39 -- baseline 00:26:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case mpas in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/mpas_hfip_2024100700/2DFLD.GrbF48
-There are changes in results for case hrrr in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/hrrr_2025063004/WRFTWO.GrbF10
-There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/rrfs_2025040112/NATLEV18.tm00
-There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/gfs_2024120500/gfs.t00z.special.grb2f006
-There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/gfs_2024120500/gfs.t00z.master.grb2f006
-There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/gfs_2024120500/gfs.t00z.sfluxgrbf006.grib2
-There are changes in results for case rap in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/rap_2025070115/WRFPRS.GrbF06
-There are changes in results for case rap in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/rap_2025070115/WRFNAT.GrbF06
-There are changes in results for case mpas in /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION/mpas_2025071400/POSTTWO18.tm00
-Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/orion/1281_orion_intel/ci/rundir/upp-ORION for details on differences in results for each case.
+There are changes in results for case gefsv13 in /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION/gefsv13_2023080300/gefs.t00z.master.grb2f009
+There are changes in results for case sfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION/sfs_2017050100/sfs.t00z.master.grb2f048
+There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION/gfs_2025012600/gfs.t00z.master.grb2f006
+Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,70 +1,61 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-8548c8abb3abafb1892253f8045e5957de9b63b2
+e7d31e19023c4cdb94b3e2999523179f778ea43c
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:29m:40s
-Test Date: 20251009 14:26:58
+Total runtime: 00h:09m:09s
+Test Date: 20251010 16:37:52
 Summary Results:
 
-10/09 13:59:05Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/09 13:59:32Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/09 14:00:07Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/09 14:00:08Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/09 14:00:19Z -mpas test: your new post executable did not generate bit-identical POSTTWO18.tm00 as the develop branch
-10/09 14:01:31Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/09 14:02:30Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/09 14:04:11Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/09 14:05:35Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/09 14:05:39Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/09 14:06:26Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/09 14:06:29Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/09 14:06:41Z -mpas_hfip test: your new post executable did not generate bit-identical 2DFLD.GrbF48 as the develop branch
-10/09 14:06:41Z -rap test: your new post executable did not generate bit-identical WRFPRS.GrbF06 as the develop branch
-10/09 14:06:54Z -rap test: your new post executable did not generate bit-identical WRFNAT.GrbF06 as the develop branch
-10/09 14:06:56Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/09 14:06:57Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/09 14:06:58Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/09 14:07:24Z -hrrr test: your new post executable did not generate bit-identical WRFTWO.GrbF10 as the develop branch
-10/09 14:07:25Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/09 14:07:26Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/09 14:13:35Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/09 14:19:31Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/09 14:19:56Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/09 14:19:58Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/09 14:26:44Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/09 13:59:25Z -Runtime: sfs_test 00:00:09 -- baseline 00:01:20
-10/09 14:04:26Z -Runtime: gefsv12_test 00:00:16 -- baseline 00:02:00
-10/09 14:05:41Z -Runtime: gefsv13_test 00:00:39 -- baseline 00:02:00
-10/09 14:07:11Z -Runtime: nmmb_test 00:01:13 -- baseline 00:02:00
-10/09 14:07:11Z -Runtime: rap_test 00:01:09 -- baseline 00:02:00
-10/09 14:07:26Z -Runtime: hrrr_test 00:01:41 -- baseline 00:03:00
-10/09 14:07:26Z -Runtime: hafs_test 00:00:36 -- baseline 00:01:30
-10/09 14:07:26Z -Runtime: 3drtma_test 00:03:34 -- baseline 00:02:00
-10/09 14:07:26Z -Runtime: mpas_test 00:01:23 -- baseline 00:02:30
-10/09 14:07:26Z -Runtime: mpas_hfip_test 00:03:22 -- baseline 00:05:00
-10/09 14:26:58Z -Runtime: rrfs_test 00:25:22 -- baseline 00:07:00
-10/09 14:26:58Z -Runtime: rrfs_ifi_missing 00:01:47 -- baseline 00:03:00
-10/09 14:26:58Z -Runtime: gfs_test 00:16:26 -- baseline 00:15:00
+10/10 16:31:05Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/10 16:31:13Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/10 16:31:14Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/10 16:31:23Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/10 16:31:28Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/10 16:31:29Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/10 16:31:29Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/10 16:31:45Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/10 16:32:10Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/10 16:32:11Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/10 16:32:13Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/10 16:32:14Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/10 16:32:14Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/10 16:32:15Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/10 16:32:54Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/10 16:32:55Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/10 16:32:56Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/10 16:33:06Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/10 16:33:33Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/10 16:33:38Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/10 16:33:39Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/10 16:35:00Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/10 16:35:18Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/10 16:37:38Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/10 16:37:38Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/10 16:37:38Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/10 16:31:36Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
+10/10 16:31:51Z -Runtime: gefsv12_test 00:00:18 -- baseline 00:02:00
+10/10 16:32:21Z -Runtime: gefsv13_test 00:00:48 -- baseline 00:02:00
+10/10 16:32:21Z -Runtime: nmmb_test 00:00:24 -- baseline 00:02:00
+10/10 16:32:21Z -Runtime: rap_test 00:00:39 -- baseline 00:02:00
+10/10 16:33:06Z -Runtime: hrrr_test 00:01:26 -- baseline 00:03:00
+10/10 16:33:06Z -Runtime: hafs_test 00:00:43 -- baseline 00:01:30
+10/10 16:33:06Z -Runtime: 3drtma_test 00:00:52 -- baseline 00:02:00
+10/10 16:33:06Z -Runtime: mpas_test 00:01:07 -- baseline 00:02:30
+10/10 16:33:51Z -Runtime: mpas_hfip_test 00:03:17 -- baseline 00:05:00
+10/10 16:35:21Z -Runtime: rrfs_test 00:04:56 -- baseline 00:07:00
+10/10 16:35:21Z -Runtime: rrfs_ifi_missing 00:01:51 -- baseline 00:03:00
+10/10 16:37:52Z -Runtime: gfs_test 00:06:52 -- baseline 00:15:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case mpas in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/mpas_hfip_2024100700/2DFLD.GrbF48
-There are changes in results for case hrrr in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/hrrr_2025063004/WRFTWO.GrbF10
-There are changes in results for case rap in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/rap_2025070115/WRFNAT.GrbF06
-There are changes in results for case rap in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/rap_2025070115/WRFPRS.GrbF06
-There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/rrfs_2025040112/NATLEV18.tm00
-There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/gfs_2024120500/gfs.t00z.master.grb2f006
-There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/gfs_2024120500/gfs.t00z.special.grb2f006
-There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/gfs_2024120500/gfs.t00z.sfluxgrbf006.grib2
-There are changes in results for case mpas in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA/mpas_2025071400/POSTTWO18.tm00
-Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intel/ci/rundir/upp-URSA for details on differences in results for each case.
+There are changes in results for case sfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA/sfs_2017050100/sfs.t00z.master.grb2f048
+There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA/gfs_2025012600/gfs.t00z.master.grb2f006
+There are changes in results for case gefsv13 in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA/gefsv13_2023080300/gefs.t00z.master.grb2f009
+Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,70 +1,61 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-8548c8abb3abafb1892253f8045e5957de9b63b2
+2a022cd8515549745329ce5c4a1dbf9ed101e0c7
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:32m:37s
-Test Date: 20251009 14:30:45
+Total runtime: 00h:08m:07s
+Test Date: 20251010 16:37:18
 Summary Results:
 
-10/09 13:59:31Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/09 14:00:20Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/09 14:00:21Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/09 14:00:31Z -mpas test: your new post executable did not generate bit-identical POSTTWO18.tm00 as the develop branch
-10/09 14:01:27Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/09 14:02:26Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/09 14:05:51Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/09 14:06:02Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/09 14:06:30Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/09 14:06:32Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/09 14:06:37Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/09 14:06:44Z -mpas_hfip test: your new post executable did not generate bit-identical 2DFLD.GrbF48 as the develop branch
-10/09 14:07:03Z -rap test: your new post executable did not generate bit-identical WRFPRS.GrbF06 as the develop branch
-10/09 14:07:05Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/09 14:07:05Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/09 14:07:06Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/09 14:07:16Z -rap test: your new post executable did not generate bit-identical WRFNAT.GrbF06 as the develop branch
-10/09 14:07:31Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/09 14:07:32Z -hrrr test: your new post executable did not generate bit-identical WRFTWO.GrbF10 as the develop branch
-10/09 14:07:33Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/09 14:07:34Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/09 14:17:40Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/09 14:19:36Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/09 14:20:01Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/09 14:20:02Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/09 14:30:35Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/09 14:05:58Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-10/09 14:06:13Z -Runtime: gefsv12_test 00:00:09 -- baseline 00:02:00
-10/09 14:06:43Z -Runtime: gefsv13_test 00:00:34 -- baseline 00:02:00
-10/09 14:07:13Z -Runtime: nmmb_test 00:00:24 -- baseline 00:01:30
-10/09 14:07:28Z -Runtime: rap_test 00:01:03 -- baseline 00:02:00
-10/09 14:07:43Z -Runtime: hrrr_test 00:01:21 -- baseline 00:02:30
-10/09 14:07:43Z -Runtime: hafs_test 00:00:32 -- baseline 00:01:30
-10/09 14:07:43Z -Runtime: 3drtma_test 00:03:18 -- baseline 00:02:30
-10/09 14:07:43Z -Runtime: mpas_test 00:01:23 -- baseline 00:02:30
-10/09 14:07:43Z -Runtime: mpas_hfip_test 00:03:24 -- baseline 00:05:00
-10/09 14:30:45Z -Runtime: rrfs_test 00:24:55 -- baseline 00:06:00
-10/09 14:30:45Z -Runtime: rrfs_ifi_missing 00:01:46 -- baseline 00:03:00
-10/09 14:30:45Z -Runtime: gfs_test 00:16:11 -- baseline 00:15:00
+10/10 16:30:11Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/10 16:30:32Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/10 16:30:40Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/10 16:30:54Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/10 16:30:56Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/10 16:31:11Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/10 16:31:12Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/10 16:31:13Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/10 16:31:23Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/10 16:31:23Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/10 16:31:24Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/10 16:31:25Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/10 16:31:29Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/10 16:31:29Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/10 16:31:29Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/10 16:31:30Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/10 16:31:30Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/10 16:32:07Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/10 16:33:06Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/10 16:33:08Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/10 16:33:08Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/10 16:34:23Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/10 16:34:43Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/10 16:37:14Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/10 16:37:15Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/10 16:37:15Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/10 16:30:32Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
+10/10 16:30:32Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:02:00
+10/10 16:31:32Z -Runtime: gefsv13_test 00:00:50 -- baseline 00:02:00
+10/10 16:31:32Z -Runtime: nmmb_test 00:00:27 -- baseline 00:01:30
+10/10 16:31:32Z -Runtime: rap_test 00:00:44 -- baseline 00:02:00
+10/10 16:31:32Z -Runtime: hrrr_test 00:01:15 -- baseline 00:02:30
+10/10 16:31:32Z -Runtime: hafs_test 00:00:37 -- baseline 00:01:30
+10/10 16:31:32Z -Runtime: 3drtma_test 00:00:53 -- baseline 00:02:30
+10/10 16:31:33Z -Runtime: mpas_test 00:01:22 -- baseline 00:02:30
+10/10 16:33:18Z -Runtime: mpas_hfip_test 00:03:05 -- baseline 00:05:00
+10/10 16:34:48Z -Runtime: rrfs_test 00:04:40 -- baseline 00:06:00
+10/10 16:34:48Z -Runtime: rrfs_ifi_missing 00:01:45 -- baseline 00:03:00
+10/10 16:37:18Z -Runtime: gfs_test 00:06:29 -- baseline 00:15:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case mpas in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/mpas_hfip_2024100700/2DFLD.GrbF48
-There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/rrfs_2025040112/NATLEV18.tm00
-There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case mpas in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/mpas_2025071400/POSTTWO18.tm00
-There are changes in results for case hrrr in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/hrrr_2025063004/WRFTWO.GrbF10
-There are changes in results for case rap in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/rap_2025070115/WRFPRS.GrbF06
-There are changes in results for case rap in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/rap_2025070115/WRFNAT.GrbF06
-There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/gfs_2024120500/gfs.t00z.special.grb2f006
-There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/gfs_2024120500/gfs.t00z.master.grb2f006
-There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA/gfs_2024120500/gfs.t00z.sfluxgrbf006.grib2
-Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1281_ursa_intelllvm/ci/rundir/upp-URSA for details on differences in results for each case.
+There are changes in results for case sfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA/sfs_2017050100/sfs.t00z.master.grb2f048
+There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA/gfs_2025012600/gfs.t00z.master.grb2f006
+There are changes in results for case gefsv13 in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA/gefsv13_2023080300/gefs.t00z.master.grb2f009
+Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,6 +1,6 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-c5c4dd12e3a36146e9fa2fd96bc3018616d0fa1c
+2a022cd8515549745329ce5c4a1dbf9ed101e0c7
 
 Submodule hashes:
  179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd (before-3km-fixes-45-g179cae1)
@@ -9,66 +9,57 @@ Submodule hashes:
 Run directory: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:45m:07s
-Test Date: 20251008 12:53:54
+Total runtime: 00h:19m:15s
+Test Date: 20251010 13:31:15
 Summary Results:
 
-10/08 12:14:53Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/08 12:15:06Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/08 12:15:36Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/08 12:15:47Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
-10/08 12:15:49Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/08 12:15:50Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/08 12:15:51Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/08 12:15:55Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/08 12:16:03Z -rap test: your new post executable did not generate bit-identical WRFPRS.GrbF06 as the develop branch
-10/08 12:16:17Z -rap test: your new post executable did not generate bit-identical WRFNAT.GrbF06 as the develop branch
-10/08 12:16:24Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/08 12:16:28Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/08 12:16:46Z -mpas test: your new post executable did not generate bit-identical POSTTWO18.tm00 as the develop branch
-10/08 12:17:37Z -hrrr test: your new post executable did not generate bit-identical WRFTWO.GrbF10 as the develop branch
-10/08 12:17:39Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/08 12:17:41Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/08 12:18:40Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/08 12:18:51Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/08 12:18:58Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/08 12:19:41Z -mpas_hfip test: your new post executable did not generate bit-identical 2DFLD.GrbF48 as the develop branch
-10/08 12:19:46Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/08 12:20:17Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/08 12:21:09Z -rrfs_ifi test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/08 12:34:01Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/08 12:46:15Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/08 12:46:43Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/08 12:46:44Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/08 12:52:59Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/08 12:15:14Z -Runtime: sfs_test 00:00:50 -- baseline 00:00:50
-10/08 12:15:40Z -Runtime: gefsv12_test 00:01:08 -- baseline 00:01:20
-10/08 12:16:22Z -Runtime: gefsv13_test 00:01:57 -- baseline 00:02:00
-10/08 12:16:26Z -Runtime: nmmb_test 00:01:53 -- baseline 00:02:20
-10/08 12:16:46Z -Runtime: rap_test 00:02:20 -- baseline 00:02:00
-10/08 12:18:11Z -Runtime: hrrr_test 00:03:43 -- baseline 00:03:40
-10/08 12:18:15Z -Runtime: hafs_test 00:01:36 -- baseline 00:02:00
-10/08 12:20:44Z -Runtime: 3drtma_test 00:06:19 -- baseline 00:04:40
-10/08 12:20:49Z -Runtime: mpas_test 00:02:48 -- baseline 00:02:40
-10/08 12:20:53Z -Runtime: mpas_hfip.test 00:05:49 -- baseline 00:05:00
-10/08 12:53:36Z -Runtime: rrfs_test 00:39:07 -- baseline 00:10:00
-10/08 12:53:41Z -Runtime: rrfs_ifi_mis 00:05:46 -- baseline 00:08:00
-10/08 12:53:45Z -Runtime: gfs_test 00:32:53 -- baseline 00:29:30
-10/08 12:53:50Z -Runtime: hrrr_ifi_test 00:01:48 -- baseline 00:02:00
-10/08 12:53:54Z -Runtime: rrfs_ifi_test 00:07:10 -- baseline 00:08:10
+10/10 13:17:52Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/10 13:18:24Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/10 13:18:49Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
+10/10 13:18:51Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/10 13:19:02Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/10 13:19:03Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/10 13:19:14Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/10 13:19:18Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/10 13:19:19Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/10 13:19:20Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/10 13:19:22Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/10 13:19:29Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/10 13:19:30Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/10 13:19:32Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/10 13:19:35Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/10 13:20:37Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/10 13:20:39Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/10 13:20:40Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/10 13:21:52Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/10 13:21:58Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/10 13:22:00Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/10 13:23:01Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/10 13:24:04Z -rrfs_ifi test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/10 13:26:28Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/10 13:26:50Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/10 13:30:29Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/10 13:30:32Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/10 13:30:32Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/10 13:18:09Z -Runtime: sfs_test 00:00:39 -- baseline 00:00:50
+10/10 13:18:46Z -Runtime: gefsv12_test 00:01:14 -- baseline 00:01:20
+10/10 13:19:55Z -Runtime: gefsv13_test 00:02:18 -- baseline 00:02:00
+10/10 13:19:59Z -Runtime: nmmb_test 00:02:10 -- baseline 00:02:20
+10/10 13:20:03Z -Runtime: rap_test 00:01:53 -- baseline 00:02:00
+10/10 13:21:12Z -Runtime: hrrr_test 00:03:32 -- baseline 00:03:40
+10/10 13:21:16Z -Runtime: hafs_test 00:01:41 -- baseline 00:02:00
+10/10 13:21:20Z -Runtime: 3drtma_test 00:02:14 -- baseline 00:04:40
+10/10 13:21:25Z -Runtime: mpas_test 00:02:27 -- baseline 00:02:40
+10/10 13:22:17Z -Runtime: mpas_hfip.test 00:04:51 -- baseline 00:05:00
+10/10 13:27:28Z -Runtime: rrfs_test 00:09:48 -- baseline 00:10:00
+10/10 13:27:33Z -Runtime: rrfs_ifi_mis 00:05:50 -- baseline 00:08:00
+10/10 13:31:06Z -Runtime: gfs_test 00:13:28 -- baseline 00:15:00
+10/10 13:31:10Z -Runtime: hrrr_ifi_test 00:01:40 -- baseline 00:02:00
+10/10 13:31:14Z -Runtime: rrfs_ifi_test 00:06:54 -- baseline 00:08:10
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'hrrr_ifi', 'rrfs_ifi']
-There are changes in results for case mpas in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/mpas_hfip_2024100700/2DFLD.GrbF48
-There are changes in results for case mpas in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/mpas_2025071400/POSTTWO18.tm00
-There are changes in results for case 3drtma in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case gfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/gfs_2024120500/gfs.t00z.master.grb2f006
-There are changes in results for case gfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/gfs_2024120500/gfs.t00z.special.grb2f006
-There are changes in results for case gfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/gfs_2024120500/gfs.t00z.sfluxgrbf006.grib2
-There are changes in results for case hrrr in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/hrrr_2025063004/WRFTWO.GrbF10
-There are changes in results for case rrfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case rrfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/rrfs_2025040112/NATLEV18.tm00
-There are changes in results for case rap in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/rap_2025070115/WRFPRS.GrbF06
-There are changes in results for case rap in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/rap_2025070115/WRFNAT.GrbF06
+There are changes in results for case sfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/sfs_2017050100/sfs.t00z.master.grb2f048
+There are changes in results for case gefsv13 in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/gefsv13_2023080300/gefs.t00z.master.grb2f009
+There are changes in results for case gfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/gfs_2025012600/gfs.t00z.master.grb2f006
 Refer to .diff files in rundir: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2 for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
Change BRTMP into BRTEMP for GFS, GEFS, SFS to solve issue #1338.
**The RRFS control files will remain unchanged until the start of RRFS v1.1.