### PR TITLE
Use WMO IDs for RSMIN and RLYRS in RRFS (develop branch)

### DIFF
--- a/parm/rrfs/postxconfig-NT-refs.txt
+++ b/parm/rrfs/postxconfig-NT-refs.txt
@@ -2628,7 +2628,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2670,7 +2670,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19193,7 +19193,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19235,7 +19235,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-refs_f00.txt
+++ b/parm/rrfs/postxconfig-NT-refs_f00.txt
@@ -2628,7 +2628,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2670,7 +2670,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15245,7 +15245,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15287,7 +15287,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-refs_f01.txt
+++ b/parm/rrfs/postxconfig-NT-refs_f01.txt
@@ -2628,7 +2628,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2670,7 +2670,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -18941,7 +18941,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -18983,7 +18983,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19779,7 +19779,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19821,7 +19821,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_f00.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_f00.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15747,7 +15747,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15789,7 +15789,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_f01.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_f01.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19527,7 +19527,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19569,7 +19569,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_firewx.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_firewx.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19191,7 +19191,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -19233,7 +19233,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_firewx_f00.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_firewx_f00.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15243,7 +15243,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -15285,7 +15285,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/postxconfig-NT-rrfs_firewx_f01.txt
+++ b/parm/rrfs/postxconfig-NT-rrfs_firewx_f01.txt
@@ -2627,7 +2627,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0
@@ -2669,7 +2669,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -18939,7 +18939,7 @@ RSMIN_ON_SURFACE
 1
 tmpl4_0
 RSMIN
-NCEP
+?
 ?
 surface
 0
@@ -18981,7 +18981,7 @@ RLYRS_ON_SURFACE
 1
 tmpl4_0
 RLYRS
-NCEP
+?
 ?
 surface
 0

--- a/parm/rrfs/refs_postcntrl.xml
+++ b/parm/rrfs/refs_postcntrl.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3046,14 +3044,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/refs_postcntrl_f00.xml
+++ b/parm/rrfs/refs_postcntrl_f00.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -2475,14 +2473,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/refs_postcntrl_f01.xml
+++ b/parm/rrfs/refs_postcntrl_f01.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3015,14 +3013,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl.xml
+++ b/parm/rrfs/rrfs_postcntrl.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3133,14 +3131,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_f00.xml
+++ b/parm/rrfs/rrfs_postcntrl_f00.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -2553,14 +2551,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_f01.xml
+++ b/parm/rrfs/rrfs_postcntrl_f01.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3101,14 +3099,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_firewx.xml
+++ b/parm/rrfs/rrfs_postcntrl_firewx.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3046,14 +3044,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_firewx_f00.xml
+++ b/parm/rrfs/rrfs_postcntrl_firewx_f00.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -2475,14 +2473,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/parm/rrfs/rrfs_postcntrl_firewx_f01.xml
+++ b/parm/rrfs/rrfs_postcntrl_firewx_f01.xml
@@ -465,14 +465,12 @@
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
@@ -3015,14 +3013,12 @@
        <param>
        <shortname>RSMIN_ON_SURFACE</shortname>
        <pname>RSMIN</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 
        <param>
        <shortname>RLYRS_ON_SURFACE</shortname>
        <pname>RLYRS</pname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
        </param>
 

--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,61 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-2a022cd8515549745329ce5c4a1dbf9ed101e0c7
+3a393f40a074bb339552c8446acdba65f1f2ffdf
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:12m:06s
-Test Date: 20251014 12:22:47
+Total runtime: 00h:35m:06s
+Test Date: 20251015 23:11:19
 Summary Results:
 
-10/14 17:12:53Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/14 17:13:01Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/14 17:13:17Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/14 17:13:46Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/14 17:13:46Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/14 17:13:53Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/14 17:13:53Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/14 17:13:53Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/14 17:13:56Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/14 17:14:38Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/14 17:14:39Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/14 17:14:40Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/14 17:14:49Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/14 17:14:51Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/14 17:14:51Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/14 17:14:57Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/14 17:14:57Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/14 17:14:58Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/14 17:15:10Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-10/14 17:15:12Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-10/14 17:16:10Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/14 17:22:08Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/14 17:22:10Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/14 17:22:10Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/14 17:22:27Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-10/14 17:22:36Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-10/14 17:13:16Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
-10/14 17:13:16Z -Runtime: gefsv12_test 00:00:15 -- baseline 00:01:00
-10/14 17:14:01Z -Runtime: gefsv13_test 00:01:10 -- baseline 00:02:00
-10/14 17:14:01Z -Runtime: nmmb_test 00:01:07 -- baseline 00:03:00
-10/14 17:14:01Z -Runtime: rap_test 00:01:00 -- baseline 00:02:00
-10/14 17:14:46Z -Runtime: hrrr_test 00:01:54 -- baseline 00:06:00
-10/14 17:14:46Z -Runtime: hafs_test 00:00:31 -- baseline 00:01:00
-10/14 17:15:16Z -Runtime: 3drtma_test 00:01:26 -- baseline 00:03:00
-10/14 17:15:16Z -Runtime: mpas_test 00:01:12 -- baseline 00:02:30
-10/14 17:15:16Z -Runtime: mpas_hfip_test 00:02:02 -- baseline 00:05:00
-10/14 17:22:47Z -Runtime: rrfs_test 00:09:47 -- baseline 00:12:00
-10/14 17:22:47Z -Runtime: rrfs_ifi_missing 00:02:18 -- baseline 00:04:00
-10/14 17:22:47Z -Runtime: gfs_test 00:08:53 -- baseline 00:25:00
+10/16 03:38:23Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/16 03:38:33Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/16 03:39:00Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/16 03:39:23Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/16 03:39:24Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/16 03:39:24Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/16 03:39:25Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/16 03:39:47Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/16 03:39:48Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/16 03:40:14Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/16 03:40:16Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/16 03:40:17Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/16 03:40:38Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/16 03:40:39Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/16 03:40:39Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/16 03:40:45Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/16 03:40:46Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/16 03:40:47Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/16 03:42:37Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
+10/16 03:43:08Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/16 03:44:02Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
+10/16 03:48:54Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/16 03:48:56Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/16 03:48:56Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/16 03:54:23Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
+10/16 04:11:12Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
+10/16 03:38:47Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
+10/16 03:38:47Z -Runtime: gefsv12_test 00:00:16 -- baseline 00:01:00
+10/16 03:39:02Z -Runtime: gefsv13_test 00:00:43 -- baseline 00:02:00
+10/16 03:39:32Z -Runtime: nmmb_test 00:01:07 -- baseline 00:03:00
+10/16 03:40:02Z -Runtime: rap_test 00:00:54 -- baseline 00:02:00
+10/16 03:40:47Z -Runtime: hrrr_test 00:01:53 -- baseline 00:06:00
+10/16 03:40:47Z -Runtime: hafs_test 00:00:31 -- baseline 00:01:00
+10/16 03:44:02Z -Runtime: 3drtma_test 00:05:43 -- baseline 00:03:00
+10/16 03:44:02Z -Runtime: mpas_test 00:02:20 -- baseline 00:02:30
+10/16 03:44:02Z -Runtime: mpas_hfip_test 00:01:58 -- baseline 00:05:00
+10/16 04:11:19Z -Runtime: rrfs_test 00:32:53 -- baseline 00:12:00
+10/16 04:11:19Z -Runtime: rrfs_ifi_missing 00:04:15 -- baseline 00:04:00
+10/16 04:11:19Z -Runtime: gfs_test 00:10:37 -- baseline 00:25:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case gefsv13 in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES/gefsv13_2023080300/gefs.t00z.master.grb2f009
-There are changes in results for case sfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES/sfs_2017050100/sfs.t00z.master.grb2f048
-There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES/gfs_2025012600/gfs.t00z.master.grb2f006
-Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1339_hercules_intel/ci/rundir/upp-HERCULES for details on differences in results for each case.
+There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES/3drtma_2023040400/NATLEV00.tm00
+There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES/3drtma_2023040400/PRSLEV00.tm00
+There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES/rrfs_2025040112/PRSLEV18.tm00
+There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES/rrfs_2025040112/NATLEV18.tm00
+Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,61 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-2a022cd8515549745329ce5c4a1dbf9ed101e0c7
+3a393f40a074bb339552c8446acdba65f1f2ffdf
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 00h:15m:42s
-Test Date: 20251014 12:26:16
+Total runtime: 01h:03m:00s
+Test Date: 20251015 23:39:23
 Summary Results:
 
-10/14 17:15:10Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/14 17:15:19Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/14 17:15:37Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/14 17:16:18Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/14 17:16:24Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/14 17:16:25Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/14 17:16:26Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/14 17:16:28Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/14 17:16:29Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/14 17:16:29Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/14 17:16:43Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/14 17:16:43Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/14 17:17:12Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-10/14 17:17:14Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-10/14 17:17:33Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/14 17:17:33Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/14 17:17:35Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/14 17:17:35Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/14 17:18:33Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/14 17:18:33Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/14 17:18:34Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/14 17:24:58Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-10/14 17:25:11Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-10/14 17:26:02Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/14 17:26:04Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/14 17:26:04Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/14 17:15:14Z -Runtime: sfs_test 00:00:10 -- baseline 00:01:20
-10/14 17:15:29Z -Runtime: gefsv12_test 00:00:19 -- baseline 00:01:00
-10/14 17:16:29Z -Runtime: gefsv13_test 00:01:18 -- baseline 00:02:00
-10/14 17:16:44Z -Runtime: nmmb_test 00:01:29 -- baseline 00:03:00
-10/14 17:16:44Z -Runtime: rap_test 00:01:43 -- baseline 00:02:00
-10/14 17:18:44Z -Runtime: hrrr_test 00:03:34 -- baseline 00:08:00
-10/14 17:18:44Z -Runtime: hafs_test 00:00:37 -- baseline 00:01:00
-10/14 17:18:44Z -Runtime: 3drtma_test 00:02:43 -- baseline 00:03:00
-10/14 17:18:44Z -Runtime: mpas_test 00:01:55 -- baseline 00:02:30
-10/14 17:18:44Z -Runtime: mpas_hfip_test 00:03:29 -- baseline 00:05:00
-10/14 17:25:15Z -Runtime: rrfs_test 00:10:52 -- baseline 00:12:00
-10/14 17:25:15Z -Runtime: rrfs_ifi_missing 00:02:33 -- baseline 00:04:00
-10/14 17:26:15Z -Runtime: gfs_test 00:11:39 -- baseline 00:26:00
+10/16 03:39:48Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/16 03:40:00Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/16 03:40:16Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/16 03:40:35Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/16 03:41:07Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/16 03:41:08Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/16 03:41:08Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/16 03:42:56Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/16 03:42:56Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/16 03:42:57Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/16 03:43:02Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/16 03:43:04Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/16 03:43:04Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/16 03:44:52Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/16 03:44:53Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/16 03:45:38Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/16 03:46:18Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
+10/16 03:46:51Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/16 03:46:51Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/16 03:46:52Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/16 03:48:53Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
+10/16 03:52:33Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/16 03:52:35Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/16 03:52:35Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/16 04:08:43Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
+10/16 04:39:08Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
+10/16 03:40:02Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
+10/16 03:40:02Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:01:00
+10/16 03:40:47Z -Runtime: gefsv13_test 00:00:55 -- baseline 00:02:00
+10/16 03:41:17Z -Runtime: nmmb_test 00:01:28 -- baseline 00:03:00
+10/16 03:45:02Z -Runtime: rap_test 00:01:48 -- baseline 00:02:00
+10/16 03:47:03Z -Runtime: hrrr_test 00:03:47 -- baseline 00:08:00
+10/16 03:47:03Z -Runtime: hafs_test 00:00:36 -- baseline 00:01:00
+10/16 03:49:03Z -Runtime: 3drtma_test 00:09:13 -- baseline 00:03:00
+10/16 03:49:03Z -Runtime: mpas_test 00:01:55 -- baseline 00:02:30
+10/16 03:49:03Z -Runtime: mpas_hfip_test 00:03:34 -- baseline 00:05:00
+10/16 04:39:23Z -Runtime: rrfs_test 00:58:06 -- baseline 00:12:00
+10/16 04:39:23Z -Runtime: rrfs_ifi_missing 00:02:33 -- baseline 00:04:00
+10/16 04:39:23Z -Runtime: gfs_test 00:11:33 -- baseline 00:26:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case gefsv13 in /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION/gefsv13_2023080300/gefs.t00z.master.grb2f009
-There are changes in results for case sfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION/sfs_2017050100/sfs.t00z.master.grb2f048
-There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION/gfs_2025012600/gfs.t00z.master.grb2f006
-Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/orion/1339_orion_intel/ci/rundir/upp-ORION for details on differences in results for each case.
+There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION/3drtma_2023040400/NATLEV00.tm00
+There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION/3drtma_2023040400/PRSLEV00.tm00
+There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION/rrfs_2025040112/PRSLEV18.tm00
+There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION/rrfs_2025040112/NATLEV18.tm00
+Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,61 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-e7d31e19023c4cdb94b3e2999523179f778ea43c
+3a393f40a074bb339552c8446acdba65f1f2ffdf
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:09m:09s
-Test Date: 20251010 16:37:52
+Total runtime: 00h:26m:59s
+Test Date: 20251016 01:52:01
 Summary Results:
 
-10/10 16:31:05Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/10 16:31:13Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-10/10 16:31:14Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-10/10 16:31:23Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/10 16:31:28Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/10 16:31:29Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/10 16:31:29Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/10 16:31:45Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/10 16:32:10Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/10 16:32:11Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/10 16:32:13Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/10 16:32:14Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/10 16:32:14Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/10 16:32:15Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/10 16:32:54Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/10 16:32:55Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/10 16:32:56Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/10 16:33:06Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/10 16:33:33Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/10 16:33:38Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/10 16:33:39Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/10 16:35:00Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-10/10 16:35:18Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-10/10 16:37:38Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/10 16:37:38Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/10 16:37:38Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/10 16:31:36Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
-10/10 16:31:51Z -Runtime: gefsv12_test 00:00:18 -- baseline 00:02:00
-10/10 16:32:21Z -Runtime: gefsv13_test 00:00:48 -- baseline 00:02:00
-10/10 16:32:21Z -Runtime: nmmb_test 00:00:24 -- baseline 00:02:00
-10/10 16:32:21Z -Runtime: rap_test 00:00:39 -- baseline 00:02:00
-10/10 16:33:06Z -Runtime: hrrr_test 00:01:26 -- baseline 00:03:00
-10/10 16:33:06Z -Runtime: hafs_test 00:00:43 -- baseline 00:01:30
-10/10 16:33:06Z -Runtime: 3drtma_test 00:00:52 -- baseline 00:02:00
-10/10 16:33:06Z -Runtime: mpas_test 00:01:07 -- baseline 00:02:30
-10/10 16:33:51Z -Runtime: mpas_hfip_test 00:03:17 -- baseline 00:05:00
-10/10 16:35:21Z -Runtime: rrfs_test 00:04:56 -- baseline 00:07:00
-10/10 16:35:21Z -Runtime: rrfs_ifi_missing 00:01:51 -- baseline 00:03:00
-10/10 16:37:52Z -Runtime: gfs_test 00:06:52 -- baseline 00:15:00
+10/16 01:26:50Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/16 01:26:58Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/16 01:27:05Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/16 01:27:06Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/16 01:27:06Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/16 01:27:09Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/16 01:27:19Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/16 01:27:29Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/16 01:27:29Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/16 01:27:46Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/16 01:27:47Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/16 01:27:48Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/16 01:28:08Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/16 01:28:09Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/16 01:28:10Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/16 01:28:32Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/16 01:29:09Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
+10/16 01:29:45Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/16 01:29:47Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/16 01:29:47Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/16 01:30:08Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
+10/16 01:32:03Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/16 01:32:03Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/16 01:32:03Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/16 01:38:54Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
+10/16 01:51:52Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
+10/16 01:27:14Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
+10/16 01:27:14Z -Runtime: gefsv12_test 00:00:14 -- baseline 00:02:00
+10/16 01:27:29Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
+10/16 01:27:29Z -Runtime: nmmb_test 00:00:22 -- baseline 00:02:00
+10/16 01:27:44Z -Runtime: rap_test 00:00:45 -- baseline 00:02:00
+10/16 01:28:14Z -Runtime: hrrr_test 00:01:26 -- baseline 00:03:00
+10/16 01:28:14Z -Runtime: hafs_test 00:00:25 -- baseline 00:01:30
+10/16 01:30:14Z -Runtime: 3drtma_test 00:03:24 -- baseline 00:02:00
+10/16 01:30:14Z -Runtime: mpas_test 00:01:04 -- baseline 00:02:30
+10/16 01:30:14Z -Runtime: mpas_hfip_test 00:03:04 -- baseline 00:05:00
+10/16 01:52:01Z -Runtime: rrfs_test 00:25:08 -- baseline 00:07:00
+10/16 01:52:01Z -Runtime: rrfs_ifi_missing 00:01:46 -- baseline 00:03:00
+10/16 01:52:01Z -Runtime: gfs_test 00:05:17 -- baseline 00:15:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case sfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA/sfs_2017050100/sfs.t00z.master.grb2f048
-There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA/gfs_2025012600/gfs.t00z.master.grb2f006
-There are changes in results for case gefsv13 in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA/gefsv13_2023080300/gefs.t00z.master.grb2f009
-Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intel/ci/rundir/upp-URSA for details on differences in results for each case.
+There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA/rrfs_2025040112/NATLEV18.tm00
+There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA/rrfs_2025040112/PRSLEV18.tm00
+There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA/3drtma_2023040400/NATLEV00.tm00
+There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA/3drtma_2023040400/PRSLEV00.tm00
+Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,61 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-2a022cd8515549745329ce5c4a1dbf9ed101e0c7
+3a393f40a074bb339552c8446acdba65f1f2ffdf
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:08m:07s
-Test Date: 20251010 16:37:18
+Total runtime: 00h:25m:37s
+Test Date: 20251016 02:26:00
 Summary Results:
 
-10/10 16:30:11Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/10 16:30:32Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/10 16:30:40Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/10 16:30:54Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-10/10 16:30:56Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-10/10 16:31:11Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/10 16:31:12Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/10 16:31:13Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/10 16:31:23Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/10 16:31:23Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/10 16:31:24Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/10 16:31:25Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/10 16:31:29Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/10 16:31:29Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/10 16:31:29Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/10 16:31:30Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/10 16:31:30Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/10 16:32:07Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/10 16:33:06Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/10 16:33:08Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/10 16:33:08Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/10 16:34:23Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-10/10 16:34:43Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-10/10 16:37:14Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/10 16:37:15Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/10 16:37:15Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/10 16:30:32Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
-10/10 16:30:32Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:02:00
-10/10 16:31:32Z -Runtime: gefsv13_test 00:00:50 -- baseline 00:02:00
-10/10 16:31:32Z -Runtime: nmmb_test 00:00:27 -- baseline 00:01:30
-10/10 16:31:32Z -Runtime: rap_test 00:00:44 -- baseline 00:02:00
-10/10 16:31:32Z -Runtime: hrrr_test 00:01:15 -- baseline 00:02:30
-10/10 16:31:32Z -Runtime: hafs_test 00:00:37 -- baseline 00:01:30
-10/10 16:31:32Z -Runtime: 3drtma_test 00:00:53 -- baseline 00:02:30
-10/10 16:31:33Z -Runtime: mpas_test 00:01:22 -- baseline 00:02:30
-10/10 16:33:18Z -Runtime: mpas_hfip_test 00:03:05 -- baseline 00:05:00
-10/10 16:34:48Z -Runtime: rrfs_test 00:04:40 -- baseline 00:06:00
-10/10 16:34:48Z -Runtime: rrfs_ifi_missing 00:01:45 -- baseline 00:03:00
-10/10 16:37:18Z -Runtime: gfs_test 00:06:29 -- baseline 00:15:00
+10/16 02:01:21Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/16 02:01:28Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/16 02:01:34Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/16 02:01:35Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/16 02:01:35Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/16 02:01:42Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/16 02:01:50Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/16 02:01:52Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/16 02:01:53Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/16 02:02:12Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/16 02:02:13Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/16 02:02:13Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/16 02:02:20Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/16 02:02:22Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/16 02:02:23Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/16 02:02:59Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/16 02:03:37Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
+10/16 02:04:15Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/16 02:04:18Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/16 02:04:18Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/16 02:04:36Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
+10/16 02:06:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/16 02:06:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/16 02:06:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/16 02:13:09Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
+10/16 02:26:00Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
+10/16 02:01:43Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
+10/16 02:01:43Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
+10/16 02:01:58Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
+10/16 02:01:58Z -Runtime: nmmb_test 00:00:20 -- baseline 00:01:30
+10/16 02:01:58Z -Runtime: rap_test 00:00:38 -- baseline 00:02:00
+10/16 02:02:28Z -Runtime: hrrr_test 00:01:08 -- baseline 00:02:30
+10/16 02:02:28Z -Runtime: hafs_test 00:00:27 -- baseline 00:01:30
+10/16 02:04:43Z -Runtime: 3drtma_test 00:03:21 -- baseline 00:02:30
+10/16 02:04:43Z -Runtime: mpas_test 00:00:58 -- baseline 00:02:30
+10/16 02:04:43Z -Runtime: mpas_hfip_test 00:03:04 -- baseline 00:05:00
+10/16 02:26:00Z -Runtime: rrfs_test 00:24:45 -- baseline 00:06:00
+10/16 02:26:00Z -Runtime: rrfs_ifi_missing 00:01:44 -- baseline 00:03:00
+10/16 02:26:00Z -Runtime: gfs_test 00:04:56 -- baseline 00:15:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case sfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA/sfs_2017050100/sfs.t00z.master.grb2f048
-There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA/gfs_2025012600/gfs.t00z.master.grb2f006
-There are changes in results for case gefsv13 in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA/gefsv13_2023080300/gefs.t00z.master.grb2f009
-Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1339_ursa_intelllvm/ci/rundir/upp-URSA for details on differences in results for each case.
+There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA/3drtma_2023040400/NATLEV00.tm00
+There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA/3drtma_2023040400/PRSLEV00.tm00
+There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA/rrfs_2025040112/NATLEV18.tm00
+There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA/rrfs_2025040112/PRSLEV18.tm00
+Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,65 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-2a022cd8515549745329ce5c4a1dbf9ed101e0c7
+b9312fe6cf37e6bbd7b13369f0d65f9cf23c78d5
 
 Submodule hashes:
- 179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd (before-3km-fixes-45-g179cae1)
+-179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2
+Run directory: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:19m:15s
-Test Date: 20251010 13:31:15
+Total runtime: 00h:43m:30s
+Test Date: 20251015 19:10:25
 Summary Results:
 
-10/10 13:17:52Z -sfs test: your new post executable did not generate bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/10 13:18:24Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/10 13:18:49Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
-10/10 13:18:51Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/10 13:19:02Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/10 13:19:03Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/10 13:19:14Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/10 13:19:18Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/10 13:19:19Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
-10/10 13:19:20Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/10 13:19:22Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
-10/10 13:19:29Z -gefsv13 test: your new post executable did not generate bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/10 13:19:30Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/10 13:19:32Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/10 13:19:35Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/10 13:20:37Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/10 13:20:39Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/10 13:20:40Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/10 13:21:52Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/10 13:21:58Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/10 13:22:00Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/10 13:23:01Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/10 13:24:04Z -rrfs_ifi test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/10 13:26:28Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-10/10 13:26:50Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-10/10 13:30:29Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/10 13:30:32Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/10 13:30:32Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/10 13:18:09Z -Runtime: sfs_test 00:00:39 -- baseline 00:00:50
-10/10 13:18:46Z -Runtime: gefsv12_test 00:01:14 -- baseline 00:01:20
-10/10 13:19:55Z -Runtime: gefsv13_test 00:02:18 -- baseline 00:02:00
-10/10 13:19:59Z -Runtime: nmmb_test 00:02:10 -- baseline 00:02:20
-10/10 13:20:03Z -Runtime: rap_test 00:01:53 -- baseline 00:02:00
-10/10 13:21:12Z -Runtime: hrrr_test 00:03:32 -- baseline 00:03:40
-10/10 13:21:16Z -Runtime: hafs_test 00:01:41 -- baseline 00:02:00
-10/10 13:21:20Z -Runtime: 3drtma_test 00:02:14 -- baseline 00:04:40
-10/10 13:21:25Z -Runtime: mpas_test 00:02:27 -- baseline 00:02:40
-10/10 13:22:17Z -Runtime: mpas_hfip.test 00:04:51 -- baseline 00:05:00
-10/10 13:27:28Z -Runtime: rrfs_test 00:09:48 -- baseline 00:10:00
-10/10 13:27:33Z -Runtime: rrfs_ifi_mis 00:05:50 -- baseline 00:08:00
-10/10 13:31:06Z -Runtime: gfs_test 00:13:28 -- baseline 00:15:00
-10/10 13:31:10Z -Runtime: hrrr_ifi_test 00:01:40 -- baseline 00:02:00
-10/10 13:31:14Z -Runtime: rrfs_ifi_test 00:06:54 -- baseline 00:08:10
+10/15 18:30:58Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/15 18:31:53Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/15 18:31:57Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/15 18:32:12Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/15 18:32:15Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/15 18:32:18Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/15 18:32:48Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/15 18:32:55Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/15 18:33:01Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/15 18:33:58Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/15 18:33:59Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/15 18:34:04Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/15 18:34:18Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/15 18:34:20Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/15 18:34:21Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/15 18:35:16Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
+10/15 18:36:11Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/15 18:36:19Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/15 18:36:21Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/15 18:36:38Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/15 18:36:57Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
+10/15 18:41:41Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/15 18:41:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/15 18:41:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/15 18:50:34Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
+10/15 19:09:45Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
+10/15 18:31:20Z -Runtime: sfs_test 00:00:36 -- baseline 00:00:50
+10/15 18:32:12Z -Runtime: gefsv12_test 00:01:35 -- baseline 00:01:20
+10/15 18:32:49Z -Runtime: gefsv13_test 00:01:59 -- baseline 00:02:00
+10/15 18:34:46Z -Runtime: nmmb_test 00:04:01 -- baseline 00:02:20
+10/15 18:34:50Z -Runtime: rap_test 00:01:58 -- baseline 00:02:00
+10/15 18:34:54Z -Runtime: hrrr_test 00:03:47 -- baseline 00:03:40
+10/15 18:34:59Z -Runtime: hafs_test 00:01:39 -- baseline 00:02:00
+10/15 18:37:28Z -Runtime: 3drtma_test 00:06:40 -- baseline 00:04:40
+10/15 18:37:32Z -Runtime: mpas_test 00:02:43 -- baseline 00:02:40
+10/15 18:37:36Z -Runtime: mpas_hfip.test 00:06:04 -- baseline 00:05:00
+10/15 19:10:16Z -Runtime: rrfs_test 00:39:31 -- baseline 00:10:00
+10/15 19:10:20Z -Runtime: rrfs_ifi_mis 00:06:19 -- baseline 00:08:00
+10/15 19:10:24Z -Runtime: gfs_test 00:11:28 -- baseline 00:15:00
 Check tests:
-['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'hrrr_ifi', 'rrfs_ifi']
-There are changes in results for case sfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/sfs_2017050100/sfs.t00z.master.grb2f048
-There are changes in results for case gefsv13 in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/gefsv13_2023080300/gefs.t00z.master.grb2f009
-There are changes in results for case gfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/gfs_2025012600/gfs.t00z.master.grb2f006
-Refer to .diff files in rundir: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2 for details on differences in results for each case.
+['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
+There are changes in results for case 3drtma in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/3drtma_2023040400/NATLEV00.tm00
+There are changes in results for case 3drtma in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/3drtma_2023040400/PRSLEV00.tm00
+There are changes in results for case rrfs in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/rrfs_2025040112/PRSLEV18.tm00
+There are changes in results for case rrfs in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/rrfs_2025040112/NATLEV18.tm00
+Refer to .diff files in rundir: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2 for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
This PR adds the changes from PR #1337 (release/rrfs_v1 branch) to the develop branch.  Resolves issue #1336 

The UPP control files for RRFS have been updated to use the WMO IDs instead of the NCEP local use IDs for the following two parameters:

RSMIN - Minimal Stomatal Resistance - [Table 4.2-2-0](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-2-0.shtml) - parameter 16 is now used instead of parameter 200
RLYRS - Number of Soil Layers in Root Zone - [Table 4.2-2-3](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-2-3.shtml) - parameter 6 is now used instead of parameter 193

Baseline changes to RRFS and 3DRTMA are expected with these parameter updates.