### PR TITLE
Add DAFS regression test

### DIFF
--- a/ci/jobs-dev/run_post_dafs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_dafs_WCOSS2.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#PBS -o out.post.rrfs_ifi_missing
-#PBS -e out.post.rrfs_ifi_missing
-#PBS -N rrfs_ifi_mis
+#PBS -o out.post.dafs
+#PBS -e out.post.dafs
+#PBS -N dafs_test
 #PBS -l walltime=00:30:00
 #PBS -q debug
 #PBS -A GFS-DEV
-#PBS -l place=vscatter,select=2:ncpus=48
+#PBS -l place=vscatter,select=2:ncpus=60:mem=300GB
 #PBS -V
 
-set -x 
+set -x
 
 # specify computation resources
 export threads=1
 export OMP_NUM_THREADS=$threads
-export APRUN="mpiexec -l -n 96 -ppn 48"
+export APRUN="mpiexec -l -n 120 -ppn 60"
 
 echo "starting time"
 date
@@ -31,22 +31,21 @@ module load prod_util/2.0.14
 module load wgrib2/2.0.8
 module list
 
-msg="Starting rrfs_ifi_missing test"
+msg="Starting dafs test"
 postmsg "$logfile" "$msg"
 
-export POSTGPEXEC=${svndir}/exec/upp_no_ifi_gtg.x
+export POSTGPEXEC=${svndir}/exec/upp.x
 
 # specify forecast start time and hour for running your post job
-export startdate=2025040112
-export fhr=018
-export tmmark=tm00
+export startdate=2025061712
+export fhr=08
 
 # specify your running and output directory
-export DATA=$rundir/rrfs_ifi_missing_${startdate}
+export DATA=$rundir/dafs_${startdate}
 rm -rf $DATA; mkdir -p $DATA
 cd $DATA
 
-export NEWDATE=`${NDATE} +${fhr} $startdate` 
+export NEWDATE=`${NDATE} +${fhr} $startdate`
 export YY=`echo $NEWDATE | cut -c1-4`
 export MM=`echo $NEWDATE | cut -c5-6`
 export DD=`echo $NEWDATE | cut -c7-8`
@@ -54,26 +53,27 @@ export HH=`echo $NEWDATE | cut -c9-10`
 
 cat > itag <<EOF
 &model_inputs
-fileName='$homedir/data_in/rrfs/dynf${fhr}.nc'
+fileName='$homedir/data_in/dafs/wrfout_d01_${YY}-${MM}-${DD}_${HH}_00_00'
 IOFORM='netcdf'
 grib='grib2'
 DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
-MODELNAME='FV3R'
-fileNameFlux='$homedir/data_in/rrfs/phyf${fhr}.nc'
+MODELNAME='RAPR'
+SUBMODELNAME='RAPR'
 /
 &NAMPGB
-KPO=47,PO=1000.,975.,950.,925.,900.,875.,850.,825.,800.,775.,750.,725.,700.,675.,650.,625.,600.,575.,550.,525.,500.,475.,450.,425.,400.,375.,350.,325.,300.,275.,250.,225.,200.,175.,150.,125.,100.,70.,50.,30.,20.,10.,7.,5.,3.,2.,1.,
-write_ifi_debug_files=.true.
+KPO=47,PO=2.,5.,7.,10.,20.,30.,50.,70.,75.,100.,125.,150.,175.,200.,225.,250.,275.,300.,325.,350.,375.,400.,425.,450.,475.,500.,525.,550.,575.,600.,625.,650.,675.,700.,725.,750.,775.,800.,825.,850.,875.,900.,925.,950.,975.,1000.,1013.2,gtg_on=.true.,
 /
 EOF
 
 # copy fix data
-cp ${svndir}/fix/nam_micro_lookup.dat ./eta_micro_lookup.dat
-cp ${svndir}/parm/postxconfig-NT-ifi.txt ./postxconfig-NT.txt
-cp ${svndir}/parm/params_grib2_tbl_new ./params_grib2_tbl_new
+cp ${svndir}/fix/nam_micro_lookup.dat                      ./eta_micro_lookup.dat
+cp ${svndir}/parm/dafs/postxconfig-NT-hrrr_dafs.txt        ./postxconfig-NT.txt
+cp ${svndir}/parm/params_grib2_tbl_new                     ./params_grib2_tbl_new
+cp ${svndir}/sorc/ncep_post.fd/post_gtg.fd/gtg.config.hrrr ./gtg.config.hrrr
+cp ${svndir}/sorc/ncep_post.fd/post_gtg.fd/gtg.input.hrrr  ./gtg.input.hrrr
 
 # Run the UPP
-${APRUN} ${POSTGPEXEC} < itag > outpost_rrfs_ifi_missing_${NEWDATE}
+${APRUN} ${POSTGPEXEC} < itag > outpost_dafs_${NEWDATE}
 
 ################################################
 # Compare with baseline data
@@ -81,8 +81,9 @@ ${APRUN} ${POSTGPEXEC} < itag > outpost_rrfs_ifi_missing_${NEWDATE}
 fhr=`expr $fhr + 0`
 fhr2=`printf "%02d" $fhr`
 
-# RRFS_IFI_missing post processing generates 1 file
-filelist="IFIFIP${fhr2}.${tmmark}"
+# DAFS post processing generates 2 files
+filelist="AVIATION.GrbF${fhr2} \
+          IFIFIP.GrbF${fhr2}"
 
 for file in $filelist; do
 export filein2=$file
@@ -92,22 +93,22 @@ export err=$?
 if [ $err = "0" ] ; then
 
  # use cmp to see if new pgb files are identical to the control one
- cmp ${filein2} $homedir/data_out/rrfs_ifi_missing/${filein2}.${machine}
+ cmp ${filein2} $homedir/data_out/dafs/${filein2}.${machine}
 
  # if not bit-identical, use cmp_grib2_grib2 to compare each grib record
  export err1=$?
  if [ $err1 -eq 0 ] ; then
-  msg="rrfs_ifi_missing test: your new post executable generates bit-identical ${filein2} as the develop branch"
+  msg="dafs test: your new post executable generates bit-identical ${filein2} as the develop branch"
   echo $msg
  else
-  msg="rrfs_ifi_missing test: your new post executable did not generate bit-identical ${filein2} as the develop branch"
+  msg="dafs test: your new post executable did not generate bit-identical ${filein2} as the develop branch"
   echo $msg
   echo " start comparing each grib record and write the comparison result to *diff files"
   echo " check these *diff files to make sure your new post only change variables which you intend to change"
-  $cmp_grib2_grib2 $homedir/data_out/rrfs_ifi_missing/${filein2}.${machine} ${filein2} > ${filein2}.diff
+  $cmp_grib2_grib2 $homedir/data_out/dafs/${filein2}.${machine} ${filein2} > ${filein2}.diff
  fi
 else
- msg="rrfs_ifi_missing test: post failed using your new post executable to generate ${filein2}"
+ msg="dafs test: post failed using your new post executable to generate ${filein2}"
  echo $msg 2>&1 | tee -a TEST_ERROR
 fi
 
@@ -115,5 +116,5 @@ postmsg "$logfile" "$msg"
 done
 
 echo "PROGRAM IS COMPLETE!!!!!" 2>&1 | tee SUCCESS
-msg="Ending rrfs_ifi_missing test"
+msg="Ending rrfs_ifi test"
 postmsg "$logfile" "$msg"

--- a/ci/jobs-dev/run_post_rrfs_ifi_missing_template.sh
+++ b/ci/jobs-dev/run_post_rrfs_ifi_missing_template.sh
@@ -35,7 +35,7 @@ module list
 msg="Starting rrfs_ifi_missing test"
 postmsg "$logfile" "$msg"
 
-export POSTGPEXEC=${svndir}/exec/upp_no_ifi.x
+export POSTGPEXEC=${svndir}/exec/upp_no_ifi_gtg.x
 
 # specify forecast start time and hour for running your post job
 export startdate=2025040112

--- a/ci/rt.sh
+++ b/ci/rt.sh
@@ -17,6 +17,7 @@ git_branch="develop"
 git_url="https://github.com/NOAA-EMC/UPP.git"
 clone_on="no"
 disable_ifi="no" # don't use libIFI, even if it is present
+disable_gtg="no" # don't use post_gtg, even if it is present
 print_full_help="no"
 build_exe="yes" #build executable
 compiler="MISSING"
@@ -28,6 +29,7 @@ usage() {
 
 Usage: rt.sh -a account -C compiler -r /path/to/scrub/space [-options] [compiler]
 Executes UPP regression tests. Includes IFI tests if ../sorc/libIFI.fd exists.
+Includes GTG tests if ../sorc/ncep_post.fd/post_gtg.fd exists.
 
 Results are here:
   ../tests/logs/MACHINE_compiler.log = report of regression tests for each machine and compiler.
@@ -40,6 +42,7 @@ Always set these:
 
 General options:
   -d = disable ifi tests even if ifi is available
+  -g = disable gtg tests even if gtg is available
   -e = don't build the UPP executable
   -h homedir = path to the regression test data
   -w workdir = directory to store per-job batch and log files.
@@ -113,11 +116,13 @@ check_valid_tests() {
 
 set +x
 export OPTERR=1
-while getopts a:w:h:r:l:t:b:u:C:cdHe opt; do
+while getopts a:w:h:r:l:t:b:u:C:cdgHe opt; do
   case $opt in
     C) compiler=${OPTARG} ; check_for_dash
         ;;
     d) disable_ifi=yes
+        ;;
+    g) disable_gtg=yes
         ;;
     a) accnr=${OPTARG} ; check_for_dash
         ;;
@@ -183,6 +188,12 @@ if [[ -d $svndir/sorc/libIFI.fd/src/ ]] ; then
     export have_ifi=yes
 else
     export have_ifi=no
+fi
+
+if [[ -f $svndir/sorc/ncep_post.fd/post_gtg.fd/gtg.config.hrrr ]] ; then
+    export have_gtg=yes
+else
+    export have_gtg=no
 fi
 
 #find machine
@@ -292,7 +303,7 @@ if [ "$build_exe" == "yes" ]; then
   cd ${test_v}
   mkdir -p ${test_v}/exec
   cd ${test_v}/tests
-  ./compile_upp.sh -o upp_no_ifi.x -c "$compiler"
+  ./compile_upp.sh -o upp_no_ifi_gtg.x -c "$compiler"
   status=$?
   if [ $status -eq 0 ]; then
     msg="Building executable successfully"
@@ -302,7 +313,24 @@ if [ "$build_exe" == "yes" ]; then
     exit 2
   fi
 
-  if [[ "$have_ifi" == "yes" && "$disable_ifi" == "no" ]] ; then
+  if [[ "$have_ifi" == "yes" && "$disable_ifi" == "no" && "$have_gtg" == "yes" && "$disable_gtg" == "no" ]] ; then
+    if [[ "${machine}" == "WCOSS2" ]]; then ##GTG tests only supported on WCOSS2
+      ./compile_upp.sh -a -o upp_with_ifi_gtg.x -I -g -c "$compiler"
+      status=$?
+    else
+      msg="GTG tests are not currently supported on machines other than WCOSS2, exiting"
+      postmsg "$logfile" "$msg"
+      exit 2
+    fi
+    if [ "$status" -eq 0 ]; then
+      msg="Built UPP+IFI+GTG executables successfully"
+    else
+      msg="Built UPP+IFI+GTG executables with failure"
+      postmsg "$logfile" "$msg"
+      exit 2
+    fi
+    ln -s upp_with_ifi_gtg.x $svndir/exec/upp.x
+  elif [[ "$have_ifi" == "yes" && "$disable_ifi" == "no" && "$have_gtg" == "no" ]] ; then
     if [[ "${machine}" == "WCOSS2" ]]; then ##No ifi standalone executable
       ./compile_upp.sh -a -o upp_with_ifi.x -I -c "$compiler"
       status=$?
@@ -318,8 +346,25 @@ if [ "$build_exe" == "yes" ]; then
       exit 2
     fi
     ln -s upp_with_ifi.x $svndir/exec/upp.x
+  elif [[ "$have_gtg" == "yes" && "$disable_gtg" == "no" && "$have_ifi" == "no" ]] ; then
+    if [[ "${machine}" == "WCOSS2" ]]; then ##GTG tests only supported on WCOSS2
+      ./compile_upp.sh -a -o upp_with_gtg.x -g -c "$compiler"
+      status=$?
+    else
+      msg="GTG tests are not currently supported on machines other than WCOSS2, exiting"
+      postmsg "$logfile" "$msg"
+      exit 2
+    fi
+    if [ "$status" -eq 0 ]; then
+      msg="Built UPP+GTG executables successfully"
+    else
+      msg="Built UPP+GTG executables with failure"
+      postmsg "$logfile" "$msg"
+      exit 2
+    fi
+    ln -s upp_with_gtg.x $svndir/exec/upp.x
   else
-    ln -s upp_no_ifi.x $svndir/exec/upp.x
+    ln -s upp_no_ifi_gtg.x $svndir/exec/upp.x
   fi
 
   postmsg "$logfile" "$msg"

--- a/ci/runtime.log.WCOSS2_intel
+++ b/ci/runtime.log.WCOSS2_intel
@@ -2,6 +2,7 @@ sfs_test 00:00:50
 gefsv12_test 00:01:20
 gefsv13_test 00:02:00
 nmmb_test 00:02:20
+dafs_test 00:02:00
 rap_test 00:02:00
 hrrr_test 00:03:40
 hrrr_ifi_test 00:02:00

--- a/ci/submit_jobs_WCOSS2.sh
+++ b/ci/submit_jobs_WCOSS2.sh
@@ -25,7 +25,7 @@ if [[ "$have_ifi" == "yes" && "$disable_ifi" == "no" ]] ; then
 fi
 
 # Run additional GTG tests
-if [[ "$have_gtg" == "yes" && "$disable_gtg" == "no" ]] ; then
+if [[ "$have_ifi" == "yes" && "$disable_ifi" == "no" && "$have_gtg" == "yes" && "$disable_gtg" == "no" ]] ; then
   for gtg_test in dafs; do
     cp $svndir/ci/jobs-dev/run_post_${gtg_test}_${machine}.sh .
     job_id=$(qsub -A "${accnr}" run_post_${gtg_test}_${machine}.sh)

--- a/ci/submit_jobs_WCOSS2.sh
+++ b/ci/submit_jobs_WCOSS2.sh
@@ -14,13 +14,23 @@ job_id=$(qsub -A "${accnr}" run_post_${test}_${machine}.sh)
 jobid_list="${jobid_list} ${job_id}"
 done
 
-#Run additional ifi tests
+# Run additional IFI tests
 if [[ "$have_ifi" == "yes" && "$disable_ifi" == "no" ]] ; then
   for ifi_test in hrrr_ifi rrfs_ifi; do
     cp $svndir/ci/jobs-dev/run_post_${ifi_test}_${machine}.sh .
     job_id=$(qsub -A "${accnr}" run_post_${ifi_test}_${machine}.sh)
     jobid_list="${jobid_list} ${job_id}"
     test_list=${test_list}" ${ifi_test}"
+  done
+fi
+
+# Run additional GTG tests
+if [[ "$have_gtg" == "yes" && "$disable_gtg" == "no" ]] ; then
+  for gtg_test in dafs; do
+    cp $svndir/ci/jobs-dev/run_post_${gtg_test}_${machine}.sh .
+    job_id=$(qsub -A "${accnr}" run_post_${gtg_test}_${machine}.sh)
+    jobid_list="${jobid_list} ${job_id}"
+    test_list=${test_list}" ${gtg_test}"
   done
 fi
 

--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,62 +1,58 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-3a393f40a074bb339552c8446acdba65f1f2ffdf
+5f052a064d52282884cb7d8ba53a4821f684711b
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1344_hercules_intel/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:35m:06s
-Test Date: 20251015 23:11:19
+Total runtime: 00h:09m:47s
+Test Date: 20251022 03:40:42
 Summary Results:
 
-10/16 03:38:23Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/16 03:38:33Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/16 03:39:00Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/16 03:39:23Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/16 03:39:24Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/16 03:39:24Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/16 03:39:25Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/16 03:39:47Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/16 03:39:48Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/16 03:40:14Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/16 03:40:16Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/16 03:40:17Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/16 03:40:38Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/16 03:40:39Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/16 03:40:39Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/16 03:40:45Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/16 03:40:46Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/16 03:40:47Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/16 03:42:37Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/16 03:43:08Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/16 03:44:02Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/16 03:48:54Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/16 03:48:56Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/16 03:48:56Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/16 03:54:23Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/16 04:11:12Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/16 03:38:47Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
-10/16 03:38:47Z -Runtime: gefsv12_test 00:00:16 -- baseline 00:01:00
-10/16 03:39:02Z -Runtime: gefsv13_test 00:00:43 -- baseline 00:02:00
-10/16 03:39:32Z -Runtime: nmmb_test 00:01:07 -- baseline 00:03:00
-10/16 03:40:02Z -Runtime: rap_test 00:00:54 -- baseline 00:02:00
-10/16 03:40:47Z -Runtime: hrrr_test 00:01:53 -- baseline 00:06:00
-10/16 03:40:47Z -Runtime: hafs_test 00:00:31 -- baseline 00:01:00
-10/16 03:44:02Z -Runtime: 3drtma_test 00:05:43 -- baseline 00:03:00
-10/16 03:44:02Z -Runtime: mpas_test 00:02:20 -- baseline 00:02:30
-10/16 03:44:02Z -Runtime: mpas_hfip_test 00:01:58 -- baseline 00:05:00
-10/16 04:11:19Z -Runtime: rrfs_test 00:32:53 -- baseline 00:12:00
-10/16 04:11:19Z -Runtime: rrfs_ifi_missing 00:04:15 -- baseline 00:04:00
-10/16 04:11:19Z -Runtime: gfs_test 00:10:37 -- baseline 00:25:00
+10/22 08:33:03Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/22 08:33:13Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/22 08:33:26Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/22 08:33:40Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/22 08:33:55Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/22 08:33:55Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/22 08:33:55Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/22 08:33:56Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/22 08:33:56Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/22 08:34:07Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/22 08:34:08Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/22 08:34:08Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/22 08:34:24Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/22 08:34:25Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/22 08:34:47Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/22 08:34:47Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/22 08:34:48Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/22 08:35:13Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/22 08:35:14Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/22 08:35:14Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/22 08:35:15Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/22 08:39:07Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/22 08:39:17Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/22 08:40:27Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/22 08:40:27Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/22 08:40:28Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/22 08:33:26Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
+10/22 08:33:26Z -Runtime: gefsv12_test 00:00:16 -- baseline 00:01:00
+10/22 08:33:41Z -Runtime: gefsv13_test 00:00:43 -- baseline 00:02:00
+10/22 08:33:56Z -Runtime: nmmb_test 00:00:59 -- baseline 00:03:00
+10/22 08:33:56Z -Runtime: rap_test 00:00:58 -- baseline 00:02:00
+10/22 08:34:56Z -Runtime: hrrr_test 00:01:51 -- baseline 00:06:00
+10/22 08:34:56Z -Runtime: hafs_test 00:00:29 -- baseline 00:01:00
+10/22 08:34:56Z -Runtime: 3drtma_test 00:01:28 -- baseline 00:03:00
+10/22 08:34:56Z -Runtime: mpas_test 00:01:11 -- baseline 00:02:30
+10/22 08:35:26Z -Runtime: mpas_hfip_test 00:02:18 -- baseline 00:05:00
+10/22 08:39:26Z -Runtime: rrfs_test 00:06:20 -- baseline 00:12:00
+10/22 08:39:26Z -Runtime: rrfs_ifi_missing 00:02:17 -- baseline 00:04:00
+10/22 08:40:42Z -Runtime: gfs_test 00:07:31 -- baseline 00:25:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES/rrfs_2025040112/NATLEV18.tm00
-Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1340_hercules_intel/ci/rundir/upp-HERCULES for details on differences in results for each case.
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,62 +1,58 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-3a393f40a074bb339552c8446acdba65f1f2ffdf
+5f052a064d52282884cb7d8ba53a4821f684711b
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1344_orion_intel/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 01h:03m:00s
-Test Date: 20251015 23:39:23
+Total runtime: 00h:18m:24s
+Test Date: 20251021 16:05:00
 Summary Results:
 
-10/16 03:39:48Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/16 03:40:00Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/16 03:40:16Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/16 03:40:35Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/16 03:41:07Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/16 03:41:08Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/16 03:41:08Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/16 03:42:56Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/16 03:42:56Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/16 03:42:57Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/16 03:43:02Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/16 03:43:04Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/16 03:43:04Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/16 03:44:52Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/16 03:44:53Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/16 03:45:38Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/16 03:46:18Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/16 03:46:51Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/16 03:46:51Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/16 03:46:52Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/16 03:48:53Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/16 03:52:33Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/16 03:52:35Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/16 03:52:35Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/16 04:08:43Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/16 04:39:08Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/16 03:40:02Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
-10/16 03:40:02Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:01:00
-10/16 03:40:47Z -Runtime: gefsv13_test 00:00:55 -- baseline 00:02:00
-10/16 03:41:17Z -Runtime: nmmb_test 00:01:28 -- baseline 00:03:00
-10/16 03:45:02Z -Runtime: rap_test 00:01:48 -- baseline 00:02:00
-10/16 03:47:03Z -Runtime: hrrr_test 00:03:47 -- baseline 00:08:00
-10/16 03:47:03Z -Runtime: hafs_test 00:00:36 -- baseline 00:01:00
-10/16 03:49:03Z -Runtime: 3drtma_test 00:09:13 -- baseline 00:03:00
-10/16 03:49:03Z -Runtime: mpas_test 00:01:55 -- baseline 00:02:30
-10/16 03:49:03Z -Runtime: mpas_hfip_test 00:03:34 -- baseline 00:05:00
-10/16 04:39:23Z -Runtime: rrfs_test 00:58:06 -- baseline 00:12:00
-10/16 04:39:23Z -Runtime: rrfs_ifi_missing 00:02:33 -- baseline 00:04:00
-10/16 04:39:23Z -Runtime: gfs_test 00:11:33 -- baseline 00:26:00
+10/21 20:51:04Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/21 20:53:37Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/21 20:53:51Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/21 20:54:23Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/21 20:54:55Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/21 20:54:56Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/21 20:54:56Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/21 20:54:59Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/21 20:55:00Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/21 20:55:00Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/21 20:55:11Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/21 20:55:12Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/21 20:55:38Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/21 20:55:40Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/21 20:56:02Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/21 20:56:03Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/21 20:56:05Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/21 20:56:05Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/21 20:57:06Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/21 20:57:06Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/21 20:57:07Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/21 21:03:01Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/21 21:03:16Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/21 21:04:57Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/21 21:04:59Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/21 21:04:59Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/21 20:53:43Z -Runtime: sfs_test 00:00:10 -- baseline 00:01:20
+10/21 20:53:58Z -Runtime: gefsv12_test 00:00:24 -- baseline 00:01:00
+10/21 20:54:28Z -Runtime: gefsv13_test 00:00:57 -- baseline 00:02:00
+10/21 20:55:13Z -Runtime: nmmb_test 00:01:33 -- baseline 00:03:00
+10/21 20:55:13Z -Runtime: rap_test 00:01:45 -- baseline 00:02:00
+10/21 20:57:14Z -Runtime: hrrr_test 00:03:40 -- baseline 00:08:00
+10/21 20:57:14Z -Runtime: hafs_test 00:00:37 -- baseline 00:01:00
+10/21 20:57:14Z -Runtime: 3drtma_test 00:02:42 -- baseline 00:03:00
+10/21 20:57:14Z -Runtime: mpas_test 00:01:58 -- baseline 00:02:30
+10/21 20:57:14Z -Runtime: mpas_hfip_test 00:03:31 -- baseline 00:05:00
+10/21 21:03:30Z -Runtime: rrfs_test 00:10:27 -- baseline 00:12:00
+10/21 21:03:30Z -Runtime: rrfs_ifi_missing 00:02:35 -- baseline 00:04:00
+10/21 21:05:00Z -Runtime: gfs_test 00:11:32 -- baseline 00:26:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case rrfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION/rrfs_2025040112/NATLEV18.tm00
-Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/orion/1340_orion_intel/ci/rundir/upp-ORION for details on differences in results for each case.
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,62 +1,58 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-3a393f40a074bb339552c8446acdba65f1f2ffdf
+5f052a064d52282884cb7d8ba53a4821f684711b
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1344_ursa_intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:26m:59s
-Test Date: 20251016 01:52:01
+Total runtime: 00h:07m:10s
+Test Date: 20251021 20:06:07
 Summary Results:
 
-10/16 01:26:50Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/16 01:26:58Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/16 01:27:05Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/16 01:27:06Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/16 01:27:06Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/16 01:27:09Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/16 01:27:19Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/16 01:27:29Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/16 01:27:29Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/16 01:27:46Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/16 01:27:47Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/16 01:27:48Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/16 01:28:08Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/16 01:28:09Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/16 01:28:10Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/16 01:28:32Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/16 01:29:09Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/16 01:29:45Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/16 01:29:47Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/16 01:29:47Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/16 01:30:08Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/16 01:32:03Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/16 01:32:03Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/16 01:32:03Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/16 01:38:54Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/16 01:51:52Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/16 01:27:14Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-10/16 01:27:14Z -Runtime: gefsv12_test 00:00:14 -- baseline 00:02:00
-10/16 01:27:29Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
-10/16 01:27:29Z -Runtime: nmmb_test 00:00:22 -- baseline 00:02:00
-10/16 01:27:44Z -Runtime: rap_test 00:00:45 -- baseline 00:02:00
-10/16 01:28:14Z -Runtime: hrrr_test 00:01:26 -- baseline 00:03:00
-10/16 01:28:14Z -Runtime: hafs_test 00:00:25 -- baseline 00:01:30
-10/16 01:30:14Z -Runtime: 3drtma_test 00:03:24 -- baseline 00:02:00
-10/16 01:30:14Z -Runtime: mpas_test 00:01:04 -- baseline 00:02:30
-10/16 01:30:14Z -Runtime: mpas_hfip_test 00:03:04 -- baseline 00:05:00
-10/16 01:52:01Z -Runtime: rrfs_test 00:25:08 -- baseline 00:07:00
-10/16 01:52:01Z -Runtime: rrfs_ifi_missing 00:01:46 -- baseline 00:03:00
-10/16 01:52:01Z -Runtime: gfs_test 00:05:17 -- baseline 00:15:00
+10/21 20:00:45Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/21 20:00:53Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/21 20:01:01Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/21 20:01:02Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/21 20:01:02Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/21 20:01:07Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/21 20:01:15Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/21 20:01:25Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/21 20:01:26Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/21 20:01:31Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/21 20:01:33Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/21 20:01:41Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/21 20:01:42Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/21 20:01:42Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/21 20:02:01Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/21 20:02:02Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/21 20:02:03Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/21 20:02:25Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/21 20:03:37Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/21 20:03:39Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/21 20:03:40Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/21 20:05:15Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/21 20:05:35Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/21 20:05:56Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/21 20:05:57Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/21 20:05:57Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/21 20:01:06Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
+10/21 20:01:06Z -Runtime: gefsv12_test 00:00:14 -- baseline 00:02:00
+10/21 20:01:21Z -Runtime: gefsv13_test 00:00:36 -- baseline 00:02:00
+10/21 20:01:21Z -Runtime: nmmb_test 00:00:23 -- baseline 00:02:00
+10/21 20:01:36Z -Runtime: rap_test 00:00:47 -- baseline 00:02:00
+10/21 20:02:06Z -Runtime: hrrr_test 00:01:24 -- baseline 00:03:00
+10/21 20:02:07Z -Runtime: hafs_test 00:00:28 -- baseline 00:01:30
+10/21 20:02:07Z -Runtime: 3drtma_test 00:00:54 -- baseline 00:02:00
+10/21 20:02:07Z -Runtime: mpas_test 00:01:03 -- baseline 00:02:30
+10/21 20:03:52Z -Runtime: mpas_hfip_test 00:03:02 -- baseline 00:05:00
+10/21 20:05:37Z -Runtime: rrfs_test 00:04:56 -- baseline 00:07:00
+10/21 20:05:37Z -Runtime: rrfs_ifi_missing 00:01:46 -- baseline 00:03:00
+10/21 20:06:07Z -Runtime: gfs_test 00:05:18 -- baseline 00:15:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA/rrfs_2025040112/NATLEV18.tm00
-There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA/3drtma_2023040400/PRSLEV00.tm00
-Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intel/ci/rundir/upp-URSA for details on differences in results for each case.
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,62 +1,58 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-3a393f40a074bb339552c8446acdba65f1f2ffdf
+5f052a064d52282884cb7d8ba53a4821f684711b
 
 Submodule hashes:
 -179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1344_ursa_intelllvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:25m:37s
-Test Date: 20251016 02:26:00
+Total runtime: 00h:05m:52s
+Test Date: 20251021 20:13:40
 Summary Results:
 
-10/16 02:01:21Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/16 02:01:28Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/16 02:01:34Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/16 02:01:35Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/16 02:01:35Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/16 02:01:42Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/16 02:01:50Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/16 02:01:52Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/16 02:01:53Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/16 02:02:12Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/16 02:02:13Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/16 02:02:13Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/16 02:02:20Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/16 02:02:22Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/16 02:02:23Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/16 02:02:59Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/16 02:03:37Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/16 02:04:15Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/16 02:04:18Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/16 02:04:18Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/16 02:04:36Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/16 02:06:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/16 02:06:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/16 02:06:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/16 02:13:09Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/16 02:26:00Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/16 02:01:43Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-10/16 02:01:43Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
-10/16 02:01:58Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
-10/16 02:01:58Z -Runtime: nmmb_test 00:00:20 -- baseline 00:01:30
-10/16 02:01:58Z -Runtime: rap_test 00:00:38 -- baseline 00:02:00
-10/16 02:02:28Z -Runtime: hrrr_test 00:01:08 -- baseline 00:02:30
-10/16 02:02:28Z -Runtime: hafs_test 00:00:27 -- baseline 00:01:30
-10/16 02:04:43Z -Runtime: 3drtma_test 00:03:21 -- baseline 00:02:30
-10/16 02:04:43Z -Runtime: mpas_test 00:00:58 -- baseline 00:02:30
-10/16 02:04:43Z -Runtime: mpas_hfip_test 00:03:04 -- baseline 00:05:00
-10/16 02:26:00Z -Runtime: rrfs_test 00:24:45 -- baseline 00:06:00
-10/16 02:26:00Z -Runtime: rrfs_ifi_missing 00:01:44 -- baseline 00:03:00
-10/16 02:26:00Z -Runtime: gfs_test 00:04:56 -- baseline 00:15:00
+10/21 20:08:43Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/21 20:08:56Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/21 20:09:01Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/21 20:09:02Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/21 20:09:03Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/21 20:09:10Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/21 20:09:17Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/21 20:09:20Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/21 20:09:21Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/21 20:09:31Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/21 20:09:33Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/21 20:09:40Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/21 20:09:41Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/21 20:09:41Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/21 20:09:46Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/21 20:09:47Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/21 20:09:48Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/21 20:10:25Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/21 20:11:44Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/21 20:11:46Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/21 20:11:47Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/21 20:13:09Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/21 20:13:25Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/21 20:13:34Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/21 20:13:35Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/21 20:13:36Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/21 20:09:09Z -Runtime: sfs_test 00:00:04 -- baseline 00:01:20
+10/21 20:09:09Z -Runtime: gefsv12_test 00:00:14 -- baseline 00:02:00
+10/21 20:09:24Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
+10/21 20:09:24Z -Runtime: nmmb_test 00:00:21 -- baseline 00:01:30
+10/21 20:09:24Z -Runtime: rap_test 00:00:39 -- baseline 00:02:00
+10/21 20:09:54Z -Runtime: hrrr_test 00:01:06 -- baseline 00:02:30
+10/21 20:09:54Z -Runtime: hafs_test 00:00:28 -- baseline 00:01:30
+10/21 20:09:54Z -Runtime: 3drtma_test 00:00:51 -- baseline 00:02:30
+10/21 20:09:54Z -Runtime: mpas_test 00:00:59 -- baseline 00:02:30
+10/21 20:11:54Z -Runtime: mpas_hfip_test 00:03:05 -- baseline 00:05:00
+10/21 20:13:40Z -Runtime: rrfs_test 00:04:43 -- baseline 00:06:00
+10/21 20:13:40Z -Runtime: rrfs_ifi_missing 00:01:43 -- baseline 00:03:00
+10/21 20:13:40Z -Runtime: gfs_test 00:04:54 -- baseline 00:15:00
 Check tests:
 ['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA/rrfs_2025040112/NATLEV18.tm00
-There are changes in results for case rrfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA/rrfs_2025040112/PRSLEV18.tm00
-Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1340_ursa_intelllvm/ci/rundir/upp-URSA for details on differences in results for each case.
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,62 +1,65 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b9312fe6cf37e6bbd7b13369f0d65f9cf23c78d5
+fb6085a9e705859e4491bd8ad04b0b8c89d1805a
 
 Submodule hashes:
--179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd
--3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
+ 179cae1dd84401cf25d250bd9102e66560a9d328 sorc/libIFI.fd (before-3km-fixes-45-g179cae1)
+ 3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd (ncep_post_gtg.v1.0.6-64-g3d35332)
 
 Run directory: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:43m:30s
-Test Date: 20251015 19:10:25
+Total runtime: 00h:18m:18s
+Test Date: 20251021 14:35:42
 Summary Results:
 
-10/15 18:30:58Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-10/15 18:31:53Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-10/15 18:31:57Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-10/15 18:32:12Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-10/15 18:32:15Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-10/15 18:32:18Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-10/15 18:32:48Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-10/15 18:32:55Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-10/15 18:33:01Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-10/15 18:33:58Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-10/15 18:33:59Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-10/15 18:34:04Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-10/15 18:34:18Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-10/15 18:34:20Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-10/15 18:34:21Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-10/15 18:35:16Z -3drtma test: your new post executable did not generate bit-identical NATLEV00.tm00 as the develop branch
-10/15 18:36:11Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-10/15 18:36:19Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-10/15 18:36:21Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-10/15 18:36:38Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-10/15 18:36:57Z -3drtma test: your new post executable did not generate bit-identical PRSLEV00.tm00 as the develop branch
-10/15 18:41:41Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-10/15 18:41:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-10/15 18:41:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-10/15 18:50:34Z -rrfs test: your new post executable did not generate bit-identical PRSLEV18.tm00 as the develop branch
-10/15 19:09:45Z -rrfs test: your new post executable did not generate bit-identical NATLEV18.tm00 as the develop branch
-10/15 18:31:20Z -Runtime: sfs_test 00:00:36 -- baseline 00:00:50
-10/15 18:32:12Z -Runtime: gefsv12_test 00:01:35 -- baseline 00:01:20
-10/15 18:32:49Z -Runtime: gefsv13_test 00:01:59 -- baseline 00:02:00
-10/15 18:34:46Z -Runtime: nmmb_test 00:04:01 -- baseline 00:02:20
-10/15 18:34:50Z -Runtime: rap_test 00:01:58 -- baseline 00:02:00
-10/15 18:34:54Z -Runtime: hrrr_test 00:03:47 -- baseline 00:03:40
-10/15 18:34:59Z -Runtime: hafs_test 00:01:39 -- baseline 00:02:00
-10/15 18:37:28Z -Runtime: 3drtma_test 00:06:40 -- baseline 00:04:40
-10/15 18:37:32Z -Runtime: mpas_test 00:02:43 -- baseline 00:02:40
-10/15 18:37:36Z -Runtime: mpas_hfip.test 00:06:04 -- baseline 00:05:00
-10/15 19:10:16Z -Runtime: rrfs_test 00:39:31 -- baseline 00:10:00
-10/15 19:10:20Z -Runtime: rrfs_ifi_mis 00:06:19 -- baseline 00:08:00
-10/15 19:10:24Z -Runtime: gfs_test 00:11:28 -- baseline 00:15:00
+10/21 14:23:33Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+10/21 14:23:58Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+10/21 14:24:22Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+10/21 14:24:38Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
+10/21 14:24:39Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+10/21 14:24:40Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+10/21 14:24:42Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
+10/21 14:24:43Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
+10/21 14:24:45Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+10/21 14:24:54Z -3drtma test: your new post executable generates bit-identical NATLEV00.tm00 as the develop branch
+10/21 14:25:00Z -3drtma test: your new post executable generates bit-identical PRSLEV00.tm00 as the develop branch
+10/21 14:25:08Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+10/21 14:25:12Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+10/21 14:25:12Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+10/21 14:25:14Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+10/21 14:25:14Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+10/21 14:25:15Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+10/21 14:26:07Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+10/21 14:26:09Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+10/21 14:26:13Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+10/21 14:27:41Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+10/21 14:27:52Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+10/21 14:27:55Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+10/21 14:28:35Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/21 14:30:44Z -rrfs_ifi test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+10/21 14:32:16Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+10/21 14:32:56Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+10/21 14:34:36Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+10/21 14:34:40Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+10/21 14:34:40Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+10/21 14:23:52Z -Runtime: sfs_test 00:00:38 -- baseline 00:00:50
+10/21 14:24:28Z -Runtime: gefsv12_test 00:01:09 -- baseline 00:01:20
+10/21 14:25:05Z -Runtime: gefsv13_test 00:01:55 -- baseline 00:02:00
+10/21 14:25:46Z -Runtime: nmmb_test 00:02:28 -- baseline 00:02:20
+10/21 14:25:50Z -Runtime: rap_test 00:01:51 -- baseline 00:02:00
+10/21 14:26:44Z -Runtime: hrrr_test 00:03:24 -- baseline 00:03:40
+10/21 14:26:48Z -Runtime: hafs_test 00:01:31 -- baseline 00:02:00
+10/21 14:26:52Z -Runtime: 3drtma_test 00:02:11 -- baseline 00:04:40
+10/21 14:26:57Z -Runtime: mpas_test 00:02:27 -- baseline 00:02:40
+10/21 14:28:21Z -Runtime: mpas_hfip.test 00:05:10 -- baseline 00:05:00
+10/21 14:33:31Z -Runtime: rrfs_test 00:10:15 -- baseline 00:10:00
+10/21 14:33:36Z -Runtime: rrfs_ifi_mis 00:05:47 -- baseline 00:08:00
+10/21 14:35:16Z -Runtime: gfs_test 00:11:54 -- baseline 00:15:00
+10/21 14:35:24Z -Runtime: hrrr_ifi_test 00:01:47 -- baseline 00:02:00
+10/21 14:35:37Z -Runtime: rrfs_ifi_test 00:07:51 -- baseline 00:08:10
+10/21 14:35:41Z -Runtime: dafs_test 00:01:53 -- baseline 00:02:00
 Check tests:
-['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs']
-There are changes in results for case 3drtma in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/3drtma_2023040400/NATLEV00.tm00
-There are changes in results for case 3drtma in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/3drtma_2023040400/PRSLEV00.tm00
-There are changes in results for case rrfs in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/rrfs_2025040112/PRSLEV18.tm00
-There are changes in results for case rrfs in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/rrfs_2025040112/NATLEV18.tm00
-Refer to .diff files in rundir: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2 for details on differences in results for each case.
+['sfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'hrrr_ifi', 'rrfs_ifi', 'dafs']
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
A DAFS regression test is added to UPP.  Currently, DAFS is only supported on WCOSS2.  

DAFS requires access to the restricted GTG code, so new script logic (have_gtg, disable_gtg) has been added to rt.sh.  I attempted to follow what was previously done for IFI (have_ifi, disable_ifi) for consistency.  Now there are 4 possibilities for compiling the UPP executable depending on the presence of the GTG/IFI codes:
```
1. UPP+IFI+GTG               upp_with_ifi_gtg.x
2. UPP+IFI (no GTG)         upp_with_ifi.x
3. UPP+GTG (no IFI)         upp_with_gtg.x
4. UPP (no IFI or GTG)      upp_no_ifi_gtg.x  (it is currently upp_no_ifi.x)

```
I tested all 4 of these configurations on WCOSS2 and they complete successfully.  

If the GTG code is found, you are not on WCOSS2, and you have not set disable_gtg to yes, then rt.sh will exit with an error indicating that the GTG tests are only supported on WCOSS2.  I tested this functionality on Ursa with disable_gtg=no and then disable_gtg=yes, and it worked as expected for me.

@WenMeng-NOAA the RTs for my most recent test (UPP+GTG) are here on Cactus:
/lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2-dafs
The DAFS test created .diff files because we don't have a test_suite/data_out/dafs directory yet.
