### PR TITLE
CAPE/CINH using 2-m fields: 3DRTMA

### DIFF
--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -49,6 +49,7 @@
 !!   2024-01-07 | H LIN | Add CIT output in NCAR GTG turbulence calculation
 !!   2024-01-09 | Y Mao | Correct the height level of EDPARM (ID=467) on 0m to index 52 from the control file, instead of 0.
 !!   2024-04-09 | Y Mao | Change the mnemonics of EDPARM (ID=467) on 0m to MXEDPRM (ID=476) on the entire atmoshpere       
+!!   2025-07-22 | K Halbert / E Colon | Updated mixed-layer CAPE/CINH to include 2m field
 !> 
 !> @author RUSS TREADON 
 !> @date 1992-12-20
@@ -61,10 +62,10 @@
       use vrbls3d,    only: pmid, uh, vh, t, zmid, zint, pint, alpint, q, omga
       use vrbls3d,    only: catedr,mwt,gtg, cit
       use vrbls2d,    only: pblh, cprate, fis, T500, T700, Z500, Z700,&
-                            teql,ieql, cape,cin
+                            teql,ieql, cape,cin,tshltr,pshltr,qshltr
       use masks,      only: lmh
       use params_mod, only: d00, d50, h99999, h100, h1, h1m12, pq0, a2, a3, a4,    &
-                            rhmin, rgamog, tfrz, small, g
+                            rhmin, rgamog, tfrz, small, g, capa
       use ctlblk_mod, only: grib, cfld, fld_info, datapd, im, jsta, jend, jm, jsta_m, jend_m, &
                             nbnd, nbin_du, lm, htfd, spval, pthresh, nfd, petabnd, me,&
                             jsta_2l, jend_2u, MODELNAME, SUBMODELNAME, &
@@ -72,7 +73,7 @@
                             ifi_flight_levels, gtg_on
       use rqstfld_mod, only: iget, lvls, id, iavblfld, lvlsxml
       use grib2_module, only: pset
-      use upp_physics, only: FPVSNEW,CALRH_PW,CALCAPE,CALCAPE2,TVIRTUAL
+      use upp_physics, only: FPVSNEW,CALRH_PW,CALCAPE,CALCAPE2
       use gridspec_mod, only: gridtype
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
        implicit none
@@ -138,7 +139,7 @@
       real    DPBND,PKL1,PKU1,FAC1,FAC2,PL,TL,QL,QSAT,RHL,TVRL,TVRBLO, &
               ES1,ES2,QS1,QS2,RH1,RH2,ZSF,DEPTH(2),work1,work2,work3, &
               SCINtmp,MUCAPEtmp,MUCINtmp,MLLCLtmp,ESHRtmp,MLCAPEtmp,STP,&
-              FSHRtmp,MLCINtmp,SLCLtmp,LAPSE,SHIP
+              FSHRtmp,MLCINtmp,SLCLtmp,LAPSE,SHIP,t2m,q2m
 
       integer IE,IW,JN,JS,IVE(JM),IVW(JM),JVN,JVS
       integer ISTART,ISTOP,JSTART,JSTOP
@@ -3093,11 +3094,15 @@
              DO I=ISTA,IEND
                EGRID1(I,J) = -H99999
                EGRID2(I,J) = -H99999
+               q2m = max(0.0, QSHLTR(I,J))
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
+                            PSHLTR(I,J))/4
+               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3) + &
+                            TSHLTR(I,J))/4
+               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
+                            q2m)/4
              ENDDO
            ENDDO
 !
@@ -3590,9 +3595,12 @@
 !          DO I=ISTA,IEND
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
+                            PSHLTR(I,J))/4
+               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3) + &
+                            TSHLTR(I, J))/4
+               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
+                            QSHLTR(I, J))/4
              ENDDO
            ENDDO
 
@@ -4221,7 +4229,7 @@
              endif
            ENDIF
 
-!Effective Layer Supercell Parameter
+!Effective Layer Significant Tornado Parameter
             IF (IGET(991)>0) THEN
             DO J=JSTA,JEND
                DO I=ISTA,IEND
@@ -4280,11 +4288,12 @@
                EGRID8(I,J) = -H99999
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-               T1D(I,J)  = (TVIRTUAL(TBND(I,J,1),QBND(I,J,1)) +       &
-                            TVIRTUAL(TBND(I,J,2),QBND(I,J,2)) +       &
-                            TVIRTUAL(TBND(I,J,3),QBND(I,J,3)))/3
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
+                            PSHLTR(I, J))/4
+               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
+                            TBND(I,J,3) + TSHLTR(I,J))/4
+               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
+                            QSHLTR(I,J))/4
              ENDDO
            ENDDO
 

--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -568,6 +568,7 @@
 !> 2015-??-?? | S Moorthi     | Optimization and threading
 !> 2021-07-28 | W Meng        | Restrict computation from undefined grids
 !> 2021-09-01 | E Colon       | Equivalent level height index for RTMA
+!> 2025-07-22 | K Halbert / E Colon | CAPE/CINH use shelter fields
 !>
 !> @author Russ Treadon W/NP2 @date 1993-02-10
       SUBROUTINE CALCAPE(ITYPE,DPBND,P1D,T1D,Q1D,L1D,CAPE,    &  
@@ -651,7 +652,7 @@
           THUNDER(I,J) = .TRUE.
         ENDDO
       ENDDO
-!
+
 !$omp  parallel do
       DO L=1,LM
         DO J=JSTA,JEND
@@ -694,8 +695,14 @@
               IF (ITYPE ==2 .OR.                                                &
                  (ITYPE == 1 .AND. (PKL >= PSFCK-DPBND .AND. PKL <= PSFCK)))THEN
                 IF (ITYPE == 1) THEN
-                  TBTK   = T(I,J,KB)
-                  QBTK   = max(0.0, Q(I,J,KB))
+                  IF (KB == LM) THEN
+                      PKL = PSHLTR(I,J)
+                      TBTK = TSHLTR(I,J)
+                      QBTK = max(0.0, QSHLTR(I,J))
+                  ELSE
+                      TBTK   = T(I,J,KB)
+                      QBTK   = max(0.0, Q(I,J,KB))
+                  ENDIF
                   APEBTK = (H10E5/PKL)**CAPA
                 ELSE
                   PKL    = P1D(I,J)
@@ -1052,7 +1059,7 @@
                           CAPE,CINS,LFC,ESRHL,ESRHH,      &
                           DCAPE,DGLD,ESP)
       use vrbls3d,    only: pmid, t, q, zint
-      use vrbls2d,    only: fis,ieql
+      use vrbls2d,    only: fis,ieql,pshltr,tshltr,qshltr
       use gridspec_mod, only: gridtype
       use masks,      only: lmh
       use params_mod, only: d00, h1m12, h99999, h10e5, capa, elocp, eps,  &
@@ -1254,8 +1261,14 @@
               IF (ITYPE ==2 .OR.                                                &
                  (ITYPE == 1 .AND. (PKL >= PSFCK-DPBND .AND. PKL <= PSFCK)))THEN
                 IF (ITYPE == 1) THEN
-                  TBTK   = T(I,J,KB)
-                  QBTK   = max(0.0, Q(I,J,KB))
+                  IF (KB == LM) THEN 
+                      PKL = PSHLTR(I,J)
+                      TBTK = TSHLTR(I,J)
+                      QBTK = max(0.0, QSHLTR(I,J))
+                  ELSE 
+                      TBTK   = T(I,J,KB)
+                      QBTK   = max(0.0, Q(I,J,KB))
+                  ENDIF
                   APEBTK = (H10E5/PKL)**CAPA
                 ELSE
                   PKL    = P1D(I,J)

--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -574,7 +574,7 @@
       SUBROUTINE CALCAPE(ITYPE,DPBND,P1D,T1D,Q1D,L1D,CAPE,    &  
                          CINS,PPARC,ZEQL,THUND)
       use vrbls3d,    only: pmid, t, q, zint
-      use vrbls2d,    only: teql,ieql
+      use vrbls2d,    only: teql,ieql,tshltr,pshltr,qshltr
       use masks,      only: lmh
       use params_mod, only: d00, h1m12, h99999, h10e5, capa, elocp, eps,  &
                             oneps, g


### PR DESCRIPTION
This PR is a work in progress for issue #1273 .  We want to target the release/3drtma_v1 branch for these initial updates to the CAPE/CINH routines.

From @keltonhalbert : The last thing that needs to be figured out is how to include the shelter fields in the vertical loops for the effective inflow layer and best boundary layer CAPE.

Best Boundary Layer CAPE
https://github.com/keltonhalbert/UPP/blob/581d81acdbeac1e08b1fa1d33e85663476823944/sorc/ncep_post.fd/MISCLN.f#L2059-L2078

Effective Inflow Layer
https://github.com/keltonhalbert/UPP/blob/581d81acdbeac1e08b1fa1d33e85663476823944/sorc/ncep_post.fd/MISCLN.f#L3459-L3478

Both of these are loops over a vertical coordinate, with the best boundary layer being over NBND and the effective inflow layer being over LM. Neither of these pose easy ability to add the shelter fields to the loop indices, but there are probably a few options. I'm having a hard time deciphering the "best boundary layer CAPE", but I am assuming it is taking the maximum value... so there should be a way to compare the shelter field CAPE with the model levels and take the maximum. The effective inflow layer would be a bit more tricky, since it is also using the equilibrium level value based on the effective inflow criteria.

For further details/discussion, refer to PR #1275 