### PR TITLE
CAPE/CINH (surface and mixed layer) using 2-m fields: 3DRTMA

### DIFF
--- a/sorc/ncep_post.fd/CTLBLK.f
+++ b/sorc/ncep_post.fd/CTLBLK.f
@@ -19,6 +19,7 @@
 !>  2023-08-16 | Yali Mao   | Add gtg_on logical option
 !>  2023-11-24 | Eric James | Add method_blsn logical option
 !>  2025-07-25 | Jaymes Kenyon | Add "earth_radius" namelist option
+!>  2025-12-16 | Ben Blake  | Add capecin_2m logical option
 !-----------------------------------------------------------------------
 !> @defgroup CTLBLK CTLBLK
 !> Sets default parameters that are used throughout the UPP code
@@ -76,6 +77,7 @@
   logical :: slrutah_on    !< Calculate snow to liquid ratio (SLR) using method from University of Utah.
   logical :: gtg_on        !< Turn on GTG (Graphical Turbulence Guidance)
   logical :: method_blsn   !< Turn on blowing snow effect on visibility diagnostic
+  logical :: capecin_2m    !< Turn on option to calculate CAPE and CIN using 2-m fields
 !
   logical :: SIGMA      !< No longer used/supported.
   logical :: RUN        !< No longer used/supported.

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -3110,12 +3110,8 @@
                                 PBND(I,J,3) + PSHLTR(I,J))/4
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
                                 TBND(I,J,3) + TSHLTR(I,J))/4
-                   IF (max(0.0,QSHLTR(I,J)) == 0) THEN
-                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
-                   ELSE
-                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +           &
-                                  QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
-                   ENDIF
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
+                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
                  ELSE
                    P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
@@ -3626,13 +3622,9 @@
                    P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +             &
                                 PBND(I,J,3) + PSHLTR(I,J))/4
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
-                                TBND(I,J,3) + TSHLTR(I, J))/4
-                   IF (max(0.0,QSHLTR(I,J)) == 0) THEN
-                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
-                   ELSE
-                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +           &
-                                  QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
-                   ENDIF
+                                TBND(I,J,3) + TSHLTR(I,J))/4
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
+                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
                  ELSE
                    P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
@@ -4338,15 +4330,11 @@
                    QBND(I,J,3) < spval) THEN
                  IF (capecin_2m) THEN
                    P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +             &
-                                PBND(I,J,3) + PSHLTR(I, J))/4
+                                PBND(I,J,3) + PSHLTR(I,J))/4
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
                                 TBND(I,J,3) + TSHLTR(I,J))/4
-                   IF (max(0.0,QSHLTR(I,J)) == 0) THEN
-                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
-                   ELSE
-                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +           &
-                                  QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
-                   ENDIF
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
+                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
                  ELSE
                    P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -3097,17 +3097,26 @@
                EGRID2(I,J) = -H99999
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +             &
                             LVLBND(I,J,3))/3
-               IF (capecin_2m) THEN
-                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +               &
-                              PBND(I,J,3) + PSHLTR(I,J))/4
-                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
-                              TBND(I,J,3) + TSHLTR(I,J))/4
-                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
-                              QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
-               ELSE
-                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
-                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J) = spval
+               T1D(I,J) = spval
+               Q1D(I,J) = spval
+               IF (PBND(I,J,1) < spval .and. PBND(I,J,2) < spval .and.  &
+                   PBND(I,J,3) < spval .and. TBND(I,J,1) < spval .and.  &
+                   TBND(I,J,2) < spval .and. TBND(I,J,3) < spval .and.  &
+                   QBND(I,J,1) < spval .and. QBND(I,J,2) < spval .and.  &
+                   QBND(I,J,3) < spval) THEN
+                 IF (capecin_2m) THEN
+                   P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +             &
+                                PBND(I,J,3) + PSHLTR(I,J))/4
+                   T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
+                                TBND(I,J,3) + TSHLTR(I,J))/4
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
+                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                 ELSE
+                   P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
+                   T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+                 ENDIF
                ENDIF
              ENDDO
            ENDDO
@@ -3601,17 +3610,26 @@
 !          DO I=ISTA,IEND
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +             &
                             LVLBND(I,J,3))/3
-               IF (capecin_2m) THEN
-                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +               &
-                              PBND(I,J,3) + PSHLTR(I,J))/4
-                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
-                              TBND(I,J,3) + TSHLTR(I, J))/4
-                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
-                              QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
-               ELSE
-                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
-                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J) = spval
+               T1D(I,J) = spval
+               Q1D(I,J) = spval
+               IF (PBND(I,J,1) < spval .and. PBND(I,J,2) < spval .and.  &
+                   PBND(I,J,3) < spval .and. TBND(I,J,1) < spval .and.  &
+                   TBND(I,J,2) < spval .and. TBND(I,J,3) < spval .and.  &
+                   QBND(I,J,1) < spval .and. QBND(I,J,2) < spval .and.  &
+                   QBND(I,J,3) < spval) THEN
+                 IF (capecin_2m) THEN
+                   P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +             &
+                                PBND(I,J,3) + PSHLTR(I,J))/4
+                   T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
+                                TBND(I,J,3) + TSHLTR(I, J))/4
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
+                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                 ELSE
+                   P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
+                   T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+                 ENDIF
                ENDIF
              ENDDO
            ENDDO
@@ -4302,17 +4320,26 @@
                EGRID8(I,J) = -H99999
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +             &
                             LVLBND(I,J,3))/3
-               IF (capecin_2m) THEN
-                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +               &
-                              PBND(I,J,3) + PSHLTR(I, J))/4
-                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
-                              TBND(I,J,3) + TSHLTR(I,J))/4
-                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
-                              QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
-               ELSE
-                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
-                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J) = spval
+               T1D(I,J) = spval
+               Q1D(I,J) = spval
+               IF (PBND(I,J,1) < spval .and. PBND(I,J,2) < spval .and.  &
+                   PBND(I,J,3) < spval .and. TBND(I,J,1) < spval .and.  &
+                   TBND(I,J,2) < spval .and. TBND(I,J,3) < spval .and.  &
+                   QBND(I,J,1) < spval .and. QBND(I,J,2) < spval .and.  &
+                   QBND(I,J,3) < spval) THEN
+                 IF (capecin_2m) THEN
+                   P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +             &
+                                PBND(I,J,3) + PSHLTR(I, J))/4
+                   T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
+                                TBND(I,J,3) + TSHLTR(I,J))/4
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
+                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                 ELSE
+                   P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
+                   T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
+                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+                 ENDIF
                ENDIF
              ENDDO
            ENDDO

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -4311,9 +4311,7 @@
                               QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
                ELSE
                  P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-                 T1D(I,J)  = (TVIRTUAL(TBND(I,J,1),QBND(I,J,1)) +       &
-                              TVIRTUAL(TBND(I,J,2),QBND(I,J,2)) +       &
-                              TVIRTUAL(TBND(I,J,3),QBND(I,J,3)))/3
+                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
                  Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
                ENDIF
              ENDDO

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -49,6 +49,7 @@
 !!   2024-01-07 | H LIN | Add CIT output in NCAR GTG turbulence calculation
 !!   2024-01-09 | Y Mao | Correct the height level of EDPARM (ID=467) on 0m to index 52 from the control file, instead of 0.
 !!   2024-04-09 | Y Mao | Change the mnemonics of EDPARM (ID=467) on 0m to MXEDPRM (ID=476) on the entire atmoshpere       
+!!   2025-07-22 | K Halbert / E Colon | Updated mixed-layer CAPE/CINH to include 2m field
 !> 
 !> @author RUSS TREADON 
 !> @date 1992-12-20
@@ -61,10 +62,10 @@
       use vrbls3d,    only: pmid, uh, vh, t, zmid, zint, pint, alpint, q, omga
       use vrbls3d,    only: catedr,mwt,gtg, cit
       use vrbls2d,    only: pblh, cprate, fis, T500, T700, Z500, Z700,&
-                            teql,ieql, cape,cin
+                            teql,ieql, cape,cin,tshltr,pshltr,qshltr
       use masks,      only: lmh
       use params_mod, only: d00, d50, h99999, h100, h1, h1m12, pq0, a2, a3, a4,    &
-                            rhmin, rgamog, tfrz, small, g
+                            rhmin, rgamog, tfrz, small, g, capa
       use ctlblk_mod, only: grib, cfld, fld_info, datapd, im, jsta, jend, jm, jsta_m, jend_m, &
                             nbnd, nbin_du, lm, htfd, spval, pthresh, nfd, petabnd, me,&
                             jsta_2l, jend_2u, MODELNAME, SUBMODELNAME, &
@@ -72,7 +73,7 @@
                             ifi_flight_levels, gtg_on
       use rqstfld_mod, only: iget, lvls, id, iavblfld, lvlsxml
       use grib2_module, only: pset
-      use upp_physics, only: FPVSNEW,CALRH_PW,CALCAPE,CALCAPE2,TVIRTUAL
+      use upp_physics, only: FPVSNEW,CALRH_PW,CALCAPE,CALCAPE2
       use gridspec_mod, only: gridtype
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
        implicit none
@@ -138,7 +139,7 @@
       real    DPBND,PKL1,PKU1,FAC1,FAC2,PL,TL,QL,QSAT,RHL,TVRL,TVRBLO, &
               ES1,ES2,QS1,QS2,RH1,RH2,ZSF,DEPTH(2),work1,work2,work3, &
               SCINtmp,MUCAPEtmp,MUCINtmp,MLLCLtmp,ESHRtmp,MLCAPEtmp,STP,&
-              FSHRtmp,MLCINtmp,SLCLtmp,LAPSE,SHIP
+              FSHRtmp,MLCINtmp,SLCLtmp,LAPSE,SHIP,t2m,q2m
 
       integer IE,IW,JN,JS,IVE(JM),IVW(JM),JVN,JVS
       integer ISTART,ISTOP,JSTART,JSTOP
@@ -3093,11 +3094,15 @@
              DO I=ISTA,IEND
                EGRID1(I,J) = -H99999
                EGRID2(I,J) = -H99999
+               q2m = max(0.0, QSHLTR(I,J))
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
+                            PSHLTR(I,J))/4
+               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3) + &
+                            TSHLTR(I,J))/4
+               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
+                            q2m)/4
              ENDDO
            ENDDO
 !
@@ -3590,9 +3595,12 @@
 !          DO I=ISTA,IEND
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
+                            PSHLTR(I,J))/4
+               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3) + &
+                            TSHLTR(I, J))/4
+               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
+                            QSHLTR(I, J))/4
              ENDDO
            ENDDO
 
@@ -4221,7 +4229,7 @@
              endif
            ENDIF
 
-!Effective Layer Supercell Parameter
+!Effective Layer Significant Tornado Parameter
             IF (IGET(991)>0) THEN
             DO J=JSTA,JEND
                DO I=ISTA,IEND
@@ -4280,11 +4288,12 @@
                EGRID8(I,J) = -H99999
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
-               T1D(I,J)  = (TVIRTUAL(TBND(I,J,1),QBND(I,J,1)) +       &
-                            TVIRTUAL(TBND(I,J,2),QBND(I,J,2)) +       &
-                            TVIRTUAL(TBND(I,J,3),QBND(I,J,3)))/3
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
+                            PSHLTR(I, J))/4
+               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
+                            TBND(I,J,3) + TSHLTR(I,J))/4
+               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
+                            QSHLTR(I,J))/4
              ENDDO
            ENDDO
 

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -4004,7 +4004,8 @@
              endif
             ENDIF
 
-!Inflow based (ESFC) to (50%) EL shear magnitude
+! Magnitude of effective layer bulk shear
+! Calculated dynamically from the inflow base up to 50% of EL
             IF (IGET(985)>0) THEN
              GRID1=spval
              DO J=JSTA,JEND

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -3110,8 +3110,12 @@
                                 PBND(I,J,3) + PSHLTR(I,J))/4
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
                                 TBND(I,J,3) + TSHLTR(I,J))/4
-                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
-                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                   IF (max(0.0,QSHLTR(I,J)) == 0) THEN
+                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+                   ELSE
+                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +           &
+                                  QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                   ENDIF
                  ELSE
                    P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
@@ -3623,8 +3627,12 @@
                                 PBND(I,J,3) + PSHLTR(I,J))/4
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
                                 TBND(I,J,3) + TSHLTR(I, J))/4
-                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
-                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                   IF (max(0.0,QSHLTR(I,J)) == 0) THEN
+                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+                   ELSE
+                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +           &
+                                  QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                   ENDIF
                  ELSE
                    P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
@@ -4333,8 +4341,12 @@
                                 PBND(I,J,3) + PSHLTR(I, J))/4
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +             &
                                 TBND(I,J,3) + TSHLTR(I,J))/4
-                   Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +             &
-                                QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                   IF (max(0.0,QSHLTR(I,J)) == 0) THEN
+                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+                   ELSE
+                     Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +           &
+                                  QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
+                   ENDIF
                  ELSE
                    P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                    T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -50,6 +50,7 @@
 !!   2024-01-09 | Y Mao | Correct the height level of EDPARM (ID=467) on 0m to index 52 from the control file, instead of 0.
 !!   2024-04-09 | Y Mao | Change the mnemonics of EDPARM (ID=467) on 0m to MXEDPRM (ID=476) on the entire atmoshpere       
 !!   2025-07-22 | K Halbert / E Colon | Updated mixed-layer CAPE/CINH to include 2m field
+!!   2025-12-16 | Ben Blake | Add capecin_2m option to calculate CAPE and CIN with 2-m fields
 !> 
 !> @author RUSS TREADON 
 !> @date 1992-12-20
@@ -70,10 +71,10 @@
                             nbnd, nbin_du, lm, htfd, spval, pthresh, nfd, petabnd, me,&
                             jsta_2l, jend_2u, MODELNAME, SUBMODELNAME, &
                             ista, iend, ista_m, iend_M, ista_2l, iend_2u, &
-                            ifi_flight_levels, gtg_on
+                            ifi_flight_levels, gtg_on, capecin_2m
       use rqstfld_mod, only: iget, lvls, id, iavblfld, lvlsxml
       use grib2_module, only: pset
-      use upp_physics, only: FPVSNEW,CALRH_PW,CALCAPE,CALCAPE2
+      use upp_physics, only: FPVSNEW,CALRH_PW,CALCAPE,CALCAPE2,TVIRTUAL
       use gridspec_mod, only: gridtype
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
        implicit none
@@ -3094,15 +3095,21 @@
              DO I=ISTA,IEND
                EGRID1(I,J) = -H99999
                EGRID2(I,J) = -H99999
-               q2m = max(0.0, QSHLTR(I,J))
-               LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
+               LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +             &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
-                            PSHLTR(I,J))/4
-               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3) + &
-                            TSHLTR(I,J))/4
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
-                            q2m)/4
+               IF (capecin_2m) THEN
+                 q2m = max(0.0, QSHLTR(I,J))
+                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +               &
+                              PBND(I,J,3) + PSHLTR(I,J))/4
+                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
+                              TBND(I,J,3) + TSHLTR(I,J))/4
+                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
+                              QBND(I,J,3) + q2m)/4
+               ELSE
+                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
+                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
+                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               ENDIF
              ENDDO
            ENDDO
 !
@@ -3593,14 +3600,20 @@
 !          ENDDO
 !          DO J=JSTA,JEND
 !          DO I=ISTA,IEND
-               LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
+               LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +             &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
-                            PSHLTR(I,J))/4
-               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3) + &
-                            TSHLTR(I, J))/4
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
-                            QSHLTR(I, J))/4
+               IF (capecin_2m) THEN
+                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +               &
+                              PBND(I,J,3) + PSHLTR(I,J))/4
+                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
+                              TBND(I,J,3) + TSHLTR(I, J))/4
+                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
+                              QBND(I,J,3) + QSHLTR(I, J))/4
+               ELSE
+                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
+                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
+                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               ENDIF
              ENDDO
            ENDDO
 
@@ -4286,14 +4299,22 @@
                EGRID6(I,J) = -H99999
                EGRID7(I,J) = -H99999
                EGRID8(I,J) = -H99999
-               LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +           &
+               LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +             &
                             LVLBND(I,J,3))/3
-               P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3) + &
-                            PSHLTR(I, J))/4
-               T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
-                            TBND(I,J,3) + TSHLTR(I,J))/4
-               Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3) + &
-                            QSHLTR(I,J))/4
+               IF (capecin_2m) THEN
+                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +               &
+                              PBND(I,J,3) + PSHLTR(I, J))/4
+                 T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
+                              TBND(I,J,3) + TSHLTR(I,J))/4
+                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
+                              QBND(I,J,3) + QSHLTR(I,J))/4
+               ELSE
+                 P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
+                 T1D(I,J)  = (TVIRTUAL(TBND(I,J,1),QBND(I,J,1)) +       &
+                              TVIRTUAL(TBND(I,J,2),QBND(I,J,2)) +       &
+                              TVIRTUAL(TBND(I,J,3),QBND(I,J,3)))/3
+                 Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) + QBND(I,J,3))/3
+               ENDIF
              ENDDO
            ENDDO
 

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -3098,13 +3098,12 @@
                LB2(I,J)  = (LVLBND(I,J,1) + LVLBND(I,J,2) +             &
                             LVLBND(I,J,3))/3
                IF (capecin_2m) THEN
-                 q2m = max(0.0, QSHLTR(I,J))
                  P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) +               &
                               PBND(I,J,3) + PSHLTR(I,J))/4
                  T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
                               TBND(I,J,3) + TSHLTR(I,J))/4
                  Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
-                              QBND(I,J,3) + q2m)/4
+                              QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
                ELSE
                  P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                  T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
@@ -3608,7 +3607,7 @@
                  T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
                               TBND(I,J,3) + TSHLTR(I, J))/4
                  Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
-                              QBND(I,J,3) + QSHLTR(I, J))/4
+                              QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
                ELSE
                  P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                  T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) + TBND(I,J,3))/3
@@ -4309,7 +4308,7 @@
                  T1D(I,J)  = (TBND(I,J,1) + TBND(I,J,2) +               &
                               TBND(I,J,3) + TSHLTR(I,J))/4
                  Q1D(I,J)  = (QBND(I,J,1) + QBND(I,J,2) +               &
-                              QBND(I,J,3) + QSHLTR(I,J))/4
+                              QBND(I,J,3) + max(0.0,QSHLTR(I,J)))/4
                ELSE
                  P1D(I,J)  = (PBND(I,J,1) + PBND(I,J,2) + PBND(I,J,3))/3
                  T1D(I,J)  = (TVIRTUAL(TBND(I,J,1),QBND(I,J,1)) +       &

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -3950,8 +3950,8 @@
              endif
             ENDIF
 
-!U inflow based to 50% EL shear vector
-
+! U component of effective layer bulk shear
+! Calculated dynamically from the inflow base up to 50% of EL
             IF (IGET(983)>0) THEN
              GRID1=spval
              DO J=JSTA,JEND
@@ -3977,7 +3977,8 @@
              endif
             ENDIF
 
-!V inflow based to 50% EL shear vector
+! V component of effective layer bulk shear
+! Calculated dynamically from the inflow base up to 50% of EL
             IF (IGET(984)>0) THEN
              GRID1=spval
              DO J=JSTA,JEND

--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -40,6 +40,7 @@
 !> 2024-11-21 | K. Asmar, J. Meng, G. Vandenberghe | CALCHIPSI
 !> 2024-12-12 | Jesse Meng | CALSLR_UUTAH2     
 !> 2025-05-05 | Ben Blake  | Add sanity checks for RRFSv1 implementation
+!> 2025-12-16 | Ben Blake  | Add capecin_2m option to calculate CAPE and CIN with 2-m fields
 !>
 !> @author Jesse Meng @date 2020-05-20
   module upp_physics
@@ -582,7 +583,7 @@
                             plq, ttbl, pl, rdp, the0, sthe, rdthe, ttblq, &
                             itbq, jtbq, rdpq, the0q, stheq, rdtheq
       use ctlblk_mod, only: jsta_2l, jend_2u, lm, jsta, jend, im, me, spval, &
-                            ista_2l, iend_2u, ista, iend
+                            ista_2l, iend_2u, ista, iend, capecin_2m
 !     
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       implicit none
@@ -695,13 +696,18 @@
               IF (ITYPE ==2 .OR.                                                &
                  (ITYPE == 1 .AND. (PKL >= PSFCK-DPBND .AND. PKL <= PSFCK)))THEN
                 IF (ITYPE == 1) THEN
-                  IF (KB == LM) THEN
-                      PKL = PSHLTR(I,J)
-                      TBTK = TSHLTR(I,J)
-                      QBTK = max(0.0, QSHLTR(I,J))
+                  IF (capecin_2m) THEN
+                    IF (KB == LM) THEN
+                        PKL = PSHLTR(I,J)
+                        TBTK = TSHLTR(I,J)
+                        QBTK = max(0.0, QSHLTR(I,J))
+                    ELSE
+                        TBTK   = T(I,J,KB)
+                        QBTK   = max(0.0, Q(I,J,KB))
+                    ENDIF
                   ELSE
-                      TBTK   = T(I,J,KB)
-                      QBTK   = max(0.0, Q(I,J,KB))
+                    TBTK   = T(I,J,KB)
+                    QBTK   = max(0.0, Q(I,J,KB))
                   ENDIF
                   APEBTK = (H10E5/PKL)**CAPA
                 ELSE
@@ -1068,7 +1074,7 @@
                             plq, ttbl, pl, rdp, the0, sthe, rdthe, ttblq, &
                             itbq, jtbq, rdpq, the0q, stheq, rdtheq
       use ctlblk_mod, only: jsta_2l, jend_2u, lm, jsta, jend, im, jm, me, jsta_m, jend_m, spval,&
-                            ista_2l, iend_2u,     ista, iend,             ista_m, iend_m
+                            ista_2l, iend_2u, ista, iend, ista_m, iend_m, capecin_2m
 !     
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       implicit none
@@ -1261,13 +1267,18 @@
               IF (ITYPE ==2 .OR.                                                &
                  (ITYPE == 1 .AND. (PKL >= PSFCK-DPBND .AND. PKL <= PSFCK)))THEN
                 IF (ITYPE == 1) THEN
-                  IF (KB == LM) THEN 
-                      PKL = PSHLTR(I,J)
-                      TBTK = TSHLTR(I,J)
-                      QBTK = max(0.0, QSHLTR(I,J))
-                  ELSE 
-                      TBTK   = T(I,J,KB)
-                      QBTK   = max(0.0, Q(I,J,KB))
+                  IF (capecin_2m) THEN
+                    IF (KB == LM) THEN 
+                        PKL = PSHLTR(I,J)
+                        TBTK = TSHLTR(I,J)
+                        QBTK = max(0.0, QSHLTR(I,J))
+                    ELSE 
+                        TBTK   = T(I,J,KB)
+                        QBTK   = max(0.0, Q(I,J,KB))
+                    ENDIF
+                  ELSE
+                    TBTK   = T(I,J,KB)
+                    QBTK   = max(0.0, Q(I,J,KB))
                   ENDIF
                   APEBTK = (H10E5/PKL)**CAPA
                 ELSE

--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -568,12 +568,13 @@
 !> 2015-??-?? | S Moorthi     | Optimization and threading
 !> 2021-07-28 | W Meng        | Restrict computation from undefined grids
 !> 2021-09-01 | E Colon       | Equivalent level height index for RTMA
+!> 2025-07-22 | K Halbert / E Colon | CAPE/CINH use shelter fields
 !>
 !> @author Russ Treadon W/NP2 @date 1993-02-10
       SUBROUTINE CALCAPE(ITYPE,DPBND,P1D,T1D,Q1D,L1D,CAPE,    &  
                          CINS,PPARC,ZEQL,THUND)
       use vrbls3d,    only: pmid, t, q, zint
-      use vrbls2d,    only: teql,ieql
+      use vrbls2d,    only: teql,ieql,tshltr,pshltr,qshltr
       use masks,      only: lmh
       use params_mod, only: d00, h1m12, h99999, h10e5, capa, elocp, eps,  &
                             oneps, g
@@ -651,7 +652,7 @@
           THUNDER(I,J) = .TRUE.
         ENDDO
       ENDDO
-!
+
 !$omp  parallel do
       DO L=1,LM
         DO J=JSTA,JEND
@@ -694,8 +695,14 @@
               IF (ITYPE ==2 .OR.                                                &
                  (ITYPE == 1 .AND. (PKL >= PSFCK-DPBND .AND. PKL <= PSFCK)))THEN
                 IF (ITYPE == 1) THEN
-                  TBTK   = T(I,J,KB)
-                  QBTK   = max(0.0, Q(I,J,KB))
+                  IF (KB == LM) THEN
+                      PKL = PSHLTR(I,J)
+                      TBTK = TSHLTR(I,J)
+                      QBTK = max(0.0, QSHLTR(I,J))
+                  ELSE
+                      TBTK   = T(I,J,KB)
+                      QBTK   = max(0.0, Q(I,J,KB))
+                  ENDIF
                   APEBTK = (H10E5/PKL)**CAPA
                 ELSE
                   PKL    = P1D(I,J)
@@ -1052,7 +1059,7 @@
                           CAPE,CINS,LFC,ESRHL,ESRHH,      &
                           DCAPE,DGLD,ESP)
       use vrbls3d,    only: pmid, t, q, zint
-      use vrbls2d,    only: fis,ieql
+      use vrbls2d,    only: fis,ieql,pshltr,tshltr,qshltr
       use gridspec_mod, only: gridtype
       use masks,      only: lmh
       use params_mod, only: d00, h1m12, h99999, h10e5, capa, elocp, eps,  &
@@ -1254,8 +1261,14 @@
               IF (ITYPE ==2 .OR.                                                &
                  (ITYPE == 1 .AND. (PKL >= PSFCK-DPBND .AND. PKL <= PSFCK)))THEN
                 IF (ITYPE == 1) THEN
-                  TBTK   = T(I,J,KB)
-                  QBTK   = max(0.0, Q(I,J,KB))
+                  IF (KB == LM) THEN 
+                      PKL = PSHLTR(I,J)
+                      TBTK = TSHLTR(I,J)
+                      QBTK = max(0.0, QSHLTR(I,J))
+                  ELSE 
+                      TBTK   = T(I,J,KB)
+                      QBTK   = max(0.0, Q(I,J,KB))
+                  ENDIF
                   APEBTK = (H10E5/PKL)**CAPA
                 ELSE
                   PKL    = P1D(I,J)

--- a/sorc/ncep_post.fd/UPP_PHYSICS.f
+++ b/sorc/ncep_post.fd/UPP_PHYSICS.f
@@ -696,18 +696,13 @@
               IF (ITYPE ==2 .OR.                                                &
                  (ITYPE == 1 .AND. (PKL >= PSFCK-DPBND .AND. PKL <= PSFCK)))THEN
                 IF (ITYPE == 1) THEN
-                  IF (capecin_2m) THEN
-                    IF (KB == LM) THEN
-                        PKL = PSHLTR(I,J)
-                        TBTK = TSHLTR(I,J)
-                        QBTK = max(0.0, QSHLTR(I,J))
-                    ELSE
-                        TBTK   = T(I,J,KB)
-                        QBTK   = max(0.0, Q(I,J,KB))
-                    ENDIF
+                  IF (capecin_2m .AND. KB == LM) THEN
+                      PKL = PSHLTR(I,J)
+                      TBTK = TSHLTR(I,J)
+                      QBTK = max(0.0, QSHLTR(I,J))
                   ELSE
-                    TBTK   = T(I,J,KB)
-                    QBTK   = max(0.0, Q(I,J,KB))
+                      TBTK   = T(I,J,KB)
+                      QBTK   = max(0.0, Q(I,J,KB))
                   ENDIF
                   APEBTK = (H10E5/PKL)**CAPA
                 ELSE
@@ -1267,18 +1262,13 @@
               IF (ITYPE ==2 .OR.                                                &
                  (ITYPE == 1 .AND. (PKL >= PSFCK-DPBND .AND. PKL <= PSFCK)))THEN
                 IF (ITYPE == 1) THEN
-                  IF (capecin_2m) THEN
-                    IF (KB == LM) THEN 
-                        PKL = PSHLTR(I,J)
-                        TBTK = TSHLTR(I,J)
-                        QBTK = max(0.0, QSHLTR(I,J))
-                    ELSE 
-                        TBTK   = T(I,J,KB)
-                        QBTK   = max(0.0, Q(I,J,KB))
-                    ENDIF
-                  ELSE
-                    TBTK   = T(I,J,KB)
-                    QBTK   = max(0.0, Q(I,J,KB))
+                  IF (capecin_2m .AND. KB == LM) THEN
+                      PKL = PSHLTR(I,J)
+                      TBTK = TSHLTR(I,J)
+                      QBTK = max(0.0, QSHLTR(I,J))
+                  ELSE 
+                      TBTK   = T(I,J,KB)
+                      QBTK   = max(0.0, Q(I,J,KB))
                   ENDIF
                   APEBTK = (H10E5/PKL)**CAPA
                 ELSE

--- a/sorc/ncep_post.fd/WRFPOST.F
+++ b/sorc/ncep_post.fd/WRFPOST.F
@@ -40,7 +40,8 @@
 !> 2024-08-19 | Jaymes Kenyon             | Adding a call to INITPOST_MPAS
 !> 2024-10-29 | Wen Meng                  | Set iSF_SURFACE_PHYSICS: 1 for NOAH; 2 for NOAH MP; 3 for RUC
 !> 2025-07-25 | Jaymes Kenyon             | Add "earth_radius" namelist option
-!> @author Mike Bladwin NSSL/SPC @date 2002-06-18
+!> 2025-12-16 | Ben Blake                 | Add capecin_2m option to calculate CAPE and CIN with 2-m fields
+!> @author Mike Baldwin NSSL/SPC @date 2002-06-18
 !---------------------------------------------------------------------
 !> @return wrfpost
 !---------------------------------------------------------------------
@@ -133,7 +134,7 @@
               mdl2agl_tim, mdl2std_tim, mdl2thandpv_tim, calrad_wcloud_tim,nasa_on,gccpp_on,         &
               fixed_tim, time_output, imin, surfce2_tim, komax, ivegsrc, d3d_on, gocart_on,rdaod,    &
               readxml_tim, spval, fullmodelname, submodelname, hyb_sigp, filenameflat, aqf_on,numx,  &
-              run_ifi_tim, slrutah_on, d2d_chem, gtg_on, method_blsn
+              run_ifi_tim, slrutah_on, d2d_chem, gtg_on, method_blsn, capecin_2m
       use grib2_module,   only: gribit2,num_pset,nrecout,first_grbtbl,grib_info_finalize
       use upp_ifi_mod, only: write_ifi_debug_files
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
@@ -162,7 +163,7 @@
       integer      :: kpo,kth,kpv
       real,dimension(komax) :: po,th,pv
       namelist/nampgb/kpo,po,kth,th,kpv,pv,fileNameAER,d3d_on,gocart_on,gccpp_on, nasa_on,gtg_on,method_blsn,popascal &
-                     ,hyb_sigp,rdaod,d2d_chem, aqf_on,slrutah_on, vtimeunits,numx,write_ifi_debug_files
+                     ,hyb_sigp,rdaod,d2d_chem, aqf_on,slrutah_on, vtimeunits,numx,write_ifi_debug_files, capecin_2m
       integer      :: itag_ierr
       namelist/model_inputs/fileName,IOFORM,grib,DateStr,MODELNAME,SUBMODELNAME,earth_radius &
                      ,fileNameFlux,fileNameFlat
@@ -271,6 +272,7 @@
         slrutah_on  = .false.
         gtg_on   = .false.
         method_blsn = .true.
+        capecin_2m  = .false.
         popascal    = .false.
         fileNameAER = ''
         rdaod       = .false.


### PR DESCRIPTION
This PR partly addresses issue #1273 .  We want to target the release/3drtma_v1 branch for these initial updates to the CAPE/CINH routines.  
**Edit: The surface-based and mixed layer CAPE/CINH are updated in this PR, and a future PR will include updates to most unstable CAPE and the effective inflow layer (see details below).**

From @keltonhalbert : The last thing that needs to be figured out is how to include the shelter fields in the vertical loops for the effective inflow layer and best boundary layer CAPE.

Best Boundary Layer CAPE
https://github.com/keltonhalbert/UPP/blob/581d81acdbeac1e08b1fa1d33e85663476823944/sorc/ncep_post.fd/MISCLN.f#L2059-L2078

Effective Inflow Layer
https://github.com/keltonhalbert/UPP/blob/581d81acdbeac1e08b1fa1d33e85663476823944/sorc/ncep_post.fd/MISCLN.f#L3459-L3478

Both of these are loops over a vertical coordinate, with the best boundary layer being over NBND and the effective inflow layer being over LM. Neither of these pose easy ability to add the shelter fields to the loop indices, but there are probably a few options. I'm having a hard time deciphering the "best boundary layer CAPE", but I am assuming it is taking the maximum value... so there should be a way to compare the shelter field CAPE with the model levels and take the maximum. The effective inflow layer would be a bit more tricky, since it is also using the equilibrium level value based on the effective inflow criteria.

For further details/discussion, refer to PR #1275 