### PR TITLE
Labeling of cloud ceiling and cloud base parameters, relocate dxm calculation in MDL2P.f: 3DRTMA

### DIFF
--- a/parm/3drtma/3drtma_postcntrl.xml
+++ b/parm/3drtma/3drtma_postcntrl.xml
@@ -342,12 +342,13 @@
 
        <param>
            <shortname>HGT_ON_CLOUD_CEILING</shortname>
+           <fixed_sfc1_type>cloud_base</fixed_sfc1_type>
            <scale>-3.0</scale>
        </param>
 
        <param>
            <shortname>GSD_HGT_ON_CLOUD_CEILING</shortname>
-           <fixed_sfc1_type>cloud_base</fixed_sfc1_type>
+           <fixed_sfc1_type>cloud_ceilng</fixed_sfc1_type>
            <scale>-3.0</scale>
        </param>
 

--- a/parm/3drtma/postxconfig-NT-3drtma.txt
+++ b/parm/3drtma/postxconfig-NT-3drtma.txt
@@ -2420,7 +2420,7 @@ tmpl4_0
 HGT
 ?
 ?
-cloud_ceilng
+cloud_base
 0
 ?
 0
@@ -2462,7 +2462,7 @@ tmpl4_0
 HGT
 ?
 ?
-cloud_base
+cloud_ceilng
 0
 ?
 0

--- a/sorc/ncep_post.fd/MDL2P.f
+++ b/sorc/ncep_post.fd/MDL2P.f
@@ -42,6 +42,7 @@
 !> 2024-09-23 | K Asmar		| Add velocity potential and streamfunction from wind vectors
 !> 2024-12-12 | J Meng          | Adding UUtah 2024 SLR algorithm
 !> 2025-01-17 | J Kenyon        | Add graupel number concentration (QQNG)
+!> 2025-12-04 | B Blake         | Relocate dxm calculation
 !>
 !> @author T Black W/NP2 @date 1999-09-23
 !--------------------------------------------------------------------------------------
@@ -151,6 +152,19 @@
        else
         zero = h1m12
        endif
+
+! Calculate dxm which will be used in smoothing
+      if(MAPTYPE == 6) then
+        if(grib=='grib2') then
+          dxm = (DXVAL / 360.)*(ERAD*2.*pi)/1.d6  ! [mm]
+        endif
+      else
+        dxm = dxval
+      endif
+      if(grib == 'grib2')then
+        dxm=dxm/1000.0
+      endif
+
       if (d3d_on) then
         if (.not. allocated(d3dsl)) allocate(d3dsl(im,jm,27))
 !$omp parallel do private(i,j,l)
@@ -1295,16 +1309,16 @@
 
                   IF (SMFLAG) THEN
 !tgs - smoothing of geopotential heights
-                    if(MAPTYPE == 6) then
-                      if(grib=='grib2') then
-                        dxm = (DXVAL / 360.)*(ERAD*2.*pi)/1.d6  ! [mm]
-                      endif
-                    else
-                      dxm = dxval
-                    endif
-                    if(grib == 'grib2')then
-                      dxm=dxm/1000.0
-                    endif
+!                    if(MAPTYPE == 6) then
+!                      if(grib=='grib2') then
+!                        dxm = (DXVAL / 360.)*(ERAD*2.*pi)/1.d6  ! [mm]
+!                      endif
+!                    else
+!                      dxm = dxval
+!                    endif
+!                    if(grib == 'grib2')then
+!                      dxm=dxm/1000.0
+!                    endif
 !                    print *,'dxm=',dxm
                     NSMOOTH = nint(5.*(13500./dxm))
                     call AllGETHERV(GRID1)


### PR DESCRIPTION
This PR resolves issue #1379 

A bug fix was recently added to the UPP develop branch by @WenMeng-NOAA to relocate the dxm calculation within MDL2P.f (part of PR https://github.com/NOAA-EMC/UPP/pull/1361 ).  This bug fix should also be added to the release/3drtma_v1 branch.

I ran the 3DRTMA test and there were no baseline changes when compared with the output from the develop branch.  Without this bug fix, there are baseline changes to UGRD/VGRD at 250 mb and 300 mb.