### PR TITLE
IFI test app updates

### DIFF
--- a/ci/jobs-dev/run_ifi_standalone_hrrr_URSA.sh
+++ b/ci/jobs-dev/run_ifi_standalone_hrrr_URSA.sh
@@ -39,7 +39,7 @@ msg="Starting ifi_standalone_hrrr test"
 postmsg "$logfile" "$msg"
 
 
-FIPEXEC=${svndir}/exec/fip2-lookalike.x
+FIPEXEC=${svndir}/exec/fip_runner
 
 # use the UPP run directory so we get the input files in the expected format
 export startdate=2025063004
@@ -47,7 +47,7 @@ export DATA=$rundir/hrrr_ifi_${startdate}
 cd $DATA
 
 upp_output=cat_vars_0.nc
-ifi_standalone_output=icing-category-output.nc
+ifi_standalone_output=20250630/fip_icing_category.20250630_g_040000_f_00036000.nc
 diff_file=cat_vars_0.nc.diff
 
 $APRUN --cpus-per-task=$OMP_NUM_THREADS --nodes=1 --ntasks=1 --exclusive \

--- a/ci/jobs-dev/run_ifi_standalone_hrrr_URSA.sh
+++ b/ci/jobs-dev/run_ifi_standalone_hrrr_URSA.sh
@@ -47,7 +47,7 @@ export DATA=$rundir/hrrr_ifi_${startdate}
 cd $DATA
 
 upp_output=cat_vars_0.nc
-ifi_standalone_output=icing-category-output.nc
+ifi_standalone_output=20250630/fip_icing_category.20250630_g_040000_f_00036000.nc
 diff_file=cat_vars_0.nc.diff
 
 $APRUN --cpus-per-task=$OMP_NUM_THREADS --nodes=1 --ntasks=1 --exclusive \

--- a/ci/jobs-dev/run_ifi_standalone_hrrr_URSA.sh
+++ b/ci/jobs-dev/run_ifi_standalone_hrrr_URSA.sh
@@ -47,7 +47,7 @@ export DATA=$rundir/hrrr_ifi_${startdate}
 cd $DATA
 
 upp_output=cat_vars_0.nc
-ifi_standalone_output=20250630/fip_icing_category.20250630_g_040000_f_00036000.nc
+ifi_standalone_output=icing-category-output.nc
 diff_file=cat_vars_0.nc.diff
 
 $APRUN --cpus-per-task=$OMP_NUM_THREADS --nodes=1 --ntasks=1 --exclusive \

--- a/ci/jobs-dev/run_ifi_standalone_rrfs_URSA.sh
+++ b/ci/jobs-dev/run_ifi_standalone_rrfs_URSA.sh
@@ -40,7 +40,7 @@ msg="Starting ifi_standalone_rrfs test"
 postmsg "$logfile" "$msg"
 
 
-FIPEXEC=${svndir}/exec/fip2-lookalike.x
+FIPEXEC=${svndir}/exec/fip_runner
 
 # use the UPP run directory so we get the input files in the expected format
 export startdate=2025040112
@@ -48,7 +48,7 @@ export DATA=$rundir/rrfs_ifi_${startdate}
 cd $DATA
 
 upp_output=cat_vars_0.nc
-ifi_standalone_output=icing-category-output.nc
+ifi_standalone_output=20250401/fip_icing_category.20250401_g_120000_f_00064800.nc
 diff_file=cat_vars_0.nc.diff
 
 $APRUN --cpus-per-task=$OMP_NUM_THREADS --nodes=1 --ntasks=1 --exclusive \

--- a/ci/jobs-dev/run_ifi_standalone_rrfs_URSA.sh
+++ b/ci/jobs-dev/run_ifi_standalone_rrfs_URSA.sh
@@ -48,7 +48,7 @@ export DATA=$rundir/rrfs_ifi_${startdate}
 cd $DATA
 
 upp_output=cat_vars_0.nc
-ifi_standalone_output=20250401/fip_icing_category.20250401_g_120000_f_00064800.nc
+ifi_standalone_output=icing-category-output.nc
 diff_file=cat_vars_0.nc.diff
 
 $APRUN --cpus-per-task=$OMP_NUM_THREADS --nodes=1 --ntasks=1 --exclusive \

--- a/ci/jobs-dev/run_ifi_standalone_rrfs_URSA.sh
+++ b/ci/jobs-dev/run_ifi_standalone_rrfs_URSA.sh
@@ -48,7 +48,7 @@ export DATA=$rundir/rrfs_ifi_${startdate}
 cd $DATA
 
 upp_output=cat_vars_0.nc
-ifi_standalone_output=icing-category-output.nc
+ifi_standalone_output=20250401/fip_icing_category.20250401_g_120000_f_00064800.nc
 diff_file=cat_vars_0.nc.diff
 
 $APRUN --cpus-per-task=$OMP_NUM_THREADS --nodes=1 --ntasks=1 --exclusive \

--- a/sorc/ncep_post.fd/IFI.F
+++ b/sorc/ncep_post.fd/IFI.F
@@ -1043,7 +1043,7 @@ contains !==============================================================
     use ifi_mod
     use iso_c_binding
     use netcdf
-    use ctlblk_mod, only: me
+    use ctlblk_mod, only: me, DateStr
     implicit none
     integer, parameter :: maxname=80
     integer, parameter :: maxvars=999
@@ -1129,6 +1129,9 @@ contains !==============================================================
 
         call nc_check(nf90_put_att(ncid,NF90_GLOBAL,"fcst_lead_sec",fcst_lead_sec),&
              output_file,"nf90_put_att fcst_lead_sec")
+
+        call nc_check(nf90_put_att(ncid,NF90_GLOBAL,"valid_string",trim(DateStr)),&
+             output_file,"nf90_put_att valid_string")
         
         call nc_check(nf90_def_dim(ncid,"x0",nx0,dimids(1)),output_file,"nf90_def_dim x0")
         call nc_check(nf90_def_dim(ncid,"y0",ny0,dimids(2)),output_file,"nf90_def_dim y0")

--- a/tests/compile_upp.sh
+++ b/tests/compile_upp.sh
@@ -175,5 +175,5 @@ fi
 test -d $PATHTR/exec || mkdir -p $PATHTR/exec
 cp $prefix/bin/upp.x $PATHTR/exec/$upp_name
 if [[ "$build_ifi_executables" == YES ]] ; then
-    cp $prefix/bin/fip2-lookalike.x $PATHTR/exec/.
+    cp $prefix/bin/fip_runner $PATHTR/exec/.
 fi

--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,64 +1,64 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-f98be00cdae0c32ed167c3c67cb193882b7fb538
+4e96912052331a72e626490bc4f29ec6c5ee6b1a
 
 Submodule hashes:
--5afd607642ae0fd6a53b137230336386beb47ce6 sorc/libIFI.fd
+-68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1466_hercules_intel/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1467_hercules_intel/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:11m:53s
-Test Date: 20260312 18:35:08
+Total runtime: 00h:12m:31s
+Test Date: 20260320 03:55:56
 Summary Results:
 
-03/12 23:25:29Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-03/12 23:25:32Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-03/12 23:25:40Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-03/12 23:25:55Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-03/12 23:26:06Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-03/12 23:26:19Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-03/12 23:26:20Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-03/12 23:26:35Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-03/12 23:26:36Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-03/12 23:26:37Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-03/12 23:26:50Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-03/12 23:26:51Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-03/12 23:26:51Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-03/12 23:27:04Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-03/12 23:27:04Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-03/12 23:27:05Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-03/12 23:27:19Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-03/12 23:27:20Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-03/12 23:27:20Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-03/12 23:27:21Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-03/12 23:27:21Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-03/12 23:27:22Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-03/12 23:27:46Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-03/12 23:28:46Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-03/12 23:28:47Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-03/12 23:33:16Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-03/12 23:33:18Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-03/12 23:33:18Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-03/12 23:34:38Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-03/12 23:34:58Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-03/12 23:35:00Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
-03/12 23:25:52Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-03/12 23:25:52Z -Runtime: aqm_test 00:00:09 -- baseline 00:00:30
-03/12 23:25:52Z -Runtime: gefsv12_test 00:00:17 -- baseline 00:01:00
-03/12 23:26:07Z -Runtime: gefsv13_test 00:00:43 -- baseline 00:02:00
-03/12 23:26:52Z -Runtime: nmmb_test 00:01:28 -- baseline 00:03:00
-03/12 23:26:52Z -Runtime: rap_test 00:00:57 -- baseline 00:02:00
-03/12 23:27:22Z -Runtime: hrrr_test 00:01:58 -- baseline 00:06:00
-03/12 23:27:22Z -Runtime: hafs_test 00:00:32 -- baseline 00:01:00
-03/12 23:27:22Z -Runtime: 3drtma_test 00:01:42 -- baseline 00:03:00
-03/12 23:27:22Z -Runtime: mpas_test 00:01:14 -- baseline 00:02:30
-03/12 23:27:22Z -Runtime: mpas_hfip_test 00:02:00 -- baseline 00:05:00
-03/12 23:28:52Z -Runtime: gcafs_test 00:03:24 -- baseline 00:02:30
-03/12 23:35:08Z -Runtime: rrfs_test 00:09:37 -- baseline 00:12:00
-03/12 23:35:08Z -Runtime: rrfs_ifi_missing 00:02:23 -- baseline 00:04:00
-03/12 23:35:08Z -Runtime: gfs_test 00:07:55 -- baseline 00:25:00
+03/20 08:45:59Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+03/20 08:46:02Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+03/20 08:46:09Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+03/20 08:46:22Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+03/20 08:46:36Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+03/20 08:46:51Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+03/20 08:46:51Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+03/20 08:46:56Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+03/20 08:46:57Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+03/20 08:46:57Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+03/20 08:47:04Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+03/20 08:47:04Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+03/20 08:47:04Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+03/20 08:47:42Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+03/20 08:47:42Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+03/20 08:47:43Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+03/20 08:47:46Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+03/20 08:47:47Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+03/20 08:47:47Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+03/20 08:47:48Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+03/20 08:47:49Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+03/20 08:47:49Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+03/20 08:48:10Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+03/20 08:48:27Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+03/20 08:48:28Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+03/20 08:53:26Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+03/20 08:53:29Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+03/20 08:53:29Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+03/20 08:55:21Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+03/20 08:55:42Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+03/20 08:55:44Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
+03/20 08:46:23Z -Runtime: sfs_test 00:00:05 -- baseline 00:01:20
+03/20 08:46:23Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
+03/20 08:46:23Z -Runtime: gefsv12_test 00:00:15 -- baseline 00:01:00
+03/20 08:46:39Z -Runtime: gefsv13_test 00:00:42 -- baseline 00:02:00
+03/20 08:47:09Z -Runtime: nmmb_test 00:01:03 -- baseline 00:03:00
+03/20 08:47:09Z -Runtime: rap_test 00:00:57 -- baseline 00:02:00
+03/20 08:47:54Z -Runtime: hrrr_test 00:01:54 -- baseline 00:06:00
+03/20 08:47:54Z -Runtime: hafs_test 00:00:28 -- baseline 00:01:00
+03/20 08:47:54Z -Runtime: 3drtma_test 00:01:49 -- baseline 00:03:00
+03/20 08:47:54Z -Runtime: mpas_test 00:01:10 -- baseline 00:02:30
+03/20 08:47:54Z -Runtime: mpas_hfip_test 00:01:56 -- baseline 00:05:00
+03/20 08:48:39Z -Runtime: gcafs_test 00:02:34 -- baseline 00:02:30
+03/20 08:55:56Z -Runtime: rrfs_test 00:09:50 -- baseline 00:12:00
+03/20 08:55:56Z -Runtime: rrfs_ifi_missing 00:02:16 -- baseline 00:04:00
+03/20 08:55:56Z -Runtime: gfs_test 00:07:35 -- baseline 00:25:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'rrfs_ifi_missing', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,64 +1,64 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-f98be00cdae0c32ed167c3c67cb193882b7fb538
+4e96912052331a72e626490bc4f29ec6c5ee6b1a
 
 Submodule hashes:
--5afd607642ae0fd6a53b137230336386beb47ce6 sorc/libIFI.fd
+-68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1466_orion_intel/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1467_orion_intel/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 00h:20m:19s
-Test Date: 20260312 18:43:35
+Total runtime: 00h:20m:05s
+Test Date: 20260320 04:03:29
 Summary Results:
 
-03/12 23:26:41Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-03/12 23:26:45Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-03/12 23:26:53Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-03/12 23:27:10Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-03/12 23:27:38Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-03/12 23:28:20Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-03/12 23:28:20Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-03/12 23:28:22Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-03/12 23:28:23Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-03/12 23:28:23Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-03/12 23:28:27Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-03/12 23:28:28Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-03/12 23:28:28Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-03/12 23:29:06Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-03/12 23:29:25Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-03/12 23:29:25Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-03/12 23:29:26Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-03/12 23:30:02Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-03/12 23:30:04Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-03/12 23:30:05Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-03/12 23:30:23Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-03/12 23:30:24Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-03/12 23:30:24Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-03/12 23:30:25Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-03/12 23:30:25Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-03/12 23:38:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-03/12 23:38:13Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-03/12 23:38:13Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-03/12 23:43:00Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-03/12 23:43:25Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-03/12 23:43:28Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
-03/12 23:27:02Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
-03/12 23:27:02Z -Runtime: aqm_test 00:00:12 -- baseline 00:00:30
-03/12 23:27:02Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:01:00
-03/12 23:27:47Z -Runtime: gefsv13_test 00:01:05 -- baseline 00:02:00
-03/12 23:28:32Z -Runtime: nmmb_test 00:01:50 -- baseline 00:03:00
-03/12 23:28:32Z -Runtime: rap_test 00:01:47 -- baseline 00:02:00
-03/12 23:30:33Z -Runtime: hrrr_test 00:03:52 -- baseline 00:08:00
-03/12 23:30:33Z -Runtime: hafs_test 00:00:37 -- baseline 00:01:00
-03/12 23:30:33Z -Runtime: 3drtma_test 00:02:53 -- baseline 00:03:00
-03/12 23:30:33Z -Runtime: mpas_test 00:01:55 -- baseline 00:02:30
-03/12 23:30:33Z -Runtime: mpas_hfip_test 00:03:33 -- baseline 00:05:00
-03/12 23:30:33Z -Runtime: gcafs_test 00:03:52 -- baseline 00:03:15
-03/12 23:43:34Z -Runtime: rrfs_test 00:16:55 -- baseline 00:12:00
-03/12 23:43:34Z -Runtime: rrfs_ifi_missing 00:02:33 -- baseline 00:04:00
-03/12 23:43:34Z -Runtime: gfs_test 00:11:40 -- baseline 00:26:00
+03/20 08:46:52Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+03/20 08:46:54Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+03/20 08:47:03Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+03/20 08:47:17Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+03/20 08:47:39Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+03/20 08:48:06Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+03/20 08:48:07Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+03/20 08:48:07Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+03/20 08:48:25Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+03/20 08:48:26Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+03/20 08:48:37Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+03/20 08:48:38Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+03/20 08:48:38Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+03/20 08:49:17Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+03/20 08:49:35Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+03/20 08:49:35Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+03/20 08:49:36Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+03/20 08:49:37Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+03/20 08:49:37Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+03/20 08:50:14Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+03/20 08:50:17Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+03/20 08:50:18Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+03/20 08:50:21Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+03/20 08:50:21Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+03/20 08:50:23Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+03/20 08:58:15Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+03/20 08:58:16Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+03/20 08:58:16Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+03/20 09:02:57Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+03/20 09:03:20Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+03/20 09:03:24Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
+03/20 08:47:11Z -Runtime: sfs_test 00:00:10 -- baseline 00:01:20
+03/20 08:47:11Z -Runtime: aqm_test 00:00:12 -- baseline 00:00:30
+03/20 08:47:11Z -Runtime: gefsv12_test 00:00:21 -- baseline 00:01:00
+03/20 08:47:41Z -Runtime: gefsv13_test 00:00:57 -- baseline 00:02:00
+03/20 08:48:12Z -Runtime: nmmb_test 00:01:25 -- baseline 00:03:00
+03/20 08:48:27Z -Runtime: rap_test 00:01:44 -- baseline 00:02:00
+03/20 08:50:27Z -Runtime: hrrr_test 00:03:41 -- baseline 00:08:00
+03/20 08:50:27Z -Runtime: hafs_test 00:00:35 -- baseline 00:01:00
+03/20 08:50:27Z -Runtime: 3drtma_test 00:02:54 -- baseline 00:03:00
+03/20 08:50:27Z -Runtime: mpas_test 00:01:56 -- baseline 00:02:30
+03/20 08:50:27Z -Runtime: mpas_hfip_test 00:03:37 -- baseline 00:05:00
+03/20 08:50:27Z -Runtime: gcafs_test 00:02:55 -- baseline 00:03:15
+03/20 09:03:29Z -Runtime: rrfs_test 00:16:42 -- baseline 00:12:00
+03/20 09:03:29Z -Runtime: rrfs_ifi_missing 00:02:35 -- baseline 00:04:00
+03/20 09:03:29Z -Runtime: gfs_test 00:11:34 -- baseline 00:26:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'rrfs_ifi_missing', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,64 +1,64 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-f98be00cdae0c32ed167c3c67cb193882b7fb538
+4e96912052331a72e626490bc4f29ec6c5ee6b1a
 
 Submodule hashes:
--5afd607642ae0fd6a53b137230336386beb47ce6 sorc/libIFI.fd
+-68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1466_ursa_intel/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1467_ursa_intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:13m:00s
-Test Date: 20260312 23:36:13
+Total runtime: 00h:13m:30s
+Test Date: 20260320 08:56:52
 Summary Results:
 
-03/12 23:25:42Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-03/12 23:26:09Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-03/12 23:26:10Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-03/12 23:26:10Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-03/12 23:26:21Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-03/12 23:26:27Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-03/12 23:26:28Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-03/12 23:26:36Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-03/12 23:26:36Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-03/12 23:26:37Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-03/12 23:31:02Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-03/12 23:32:24Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-03/12 23:32:25Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-03/12 23:32:26Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-03/12 23:32:27Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-03/12 23:33:32Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-03/12 23:33:40Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-03/12 23:33:41Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-03/12 23:33:42Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-03/12 23:33:51Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-03/12 23:34:01Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-03/12 23:34:02Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-03/12 23:34:28Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-03/12 23:34:29Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-03/12 23:34:29Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-03/12 23:34:47Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-03/12 23:34:48Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-03/12 23:34:49Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-03/12 23:35:50Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-03/12 23:35:55Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-03/12 23:36:00Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
-03/12 23:32:27Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-03/12 23:32:27Z -Runtime: aqm_test 00:00:06 -- baseline 00:00:30
-03/12 23:33:42Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
-03/12 23:33:57Z -Runtime: gefsv13_test 00:00:32 -- baseline 00:02:00
-03/12 23:33:57Z -Runtime: nmmb_test 00:00:23 -- baseline 00:02:00
-03/12 23:34:12Z -Runtime: rap_test 00:00:43 -- baseline 00:02:00
-03/12 23:34:57Z -Runtime: hrrr_test 00:01:30 -- baseline 00:03:00
-03/12 23:34:57Z -Runtime: hafs_test 00:00:27 -- baseline 00:01:30
-03/12 23:34:58Z -Runtime: 3drtma_test 00:01:22 -- baseline 00:01:30
-03/12 23:34:58Z -Runtime: mpas_test 00:00:55 -- baseline 00:02:30
-03/12 23:34:58Z -Runtime: mpas_hfip_test 00:03:10 -- baseline 00:05:00
-03/12 23:34:58Z -Runtime: gcafs_test 00:01:13 -- baseline 00:02:00
-03/12 23:36:13Z -Runtime: rrfs_test 00:06:43 -- baseline 00:07:00
-03/12 23:36:13Z -Runtime: rrfs_ifi_missing 00:01:45 -- baseline 00:03:00
-03/12 23:36:13Z -Runtime: gfs_test 00:05:12 -- baseline 00:15:00
+03/20 08:46:20Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+03/20 08:47:04Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+03/20 08:47:05Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+03/20 08:47:06Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+03/20 08:47:23Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+03/20 08:47:24Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+03/20 08:47:24Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+03/20 08:49:57Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+03/20 08:49:58Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+03/20 08:50:04Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+03/20 08:50:14Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+03/20 08:50:15Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+03/20 08:50:20Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+03/20 08:50:21Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+03/20 08:50:22Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+03/20 08:50:24Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+03/20 08:50:32Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+03/20 08:50:33Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+03/20 08:51:16Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+03/20 08:51:17Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+03/20 08:51:18Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+03/20 08:51:38Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+03/20 08:54:59Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+03/20 08:55:00Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+03/20 08:55:00Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+03/20 08:55:16Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+03/20 08:55:17Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+03/20 08:55:17Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+03/20 08:56:29Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+03/20 08:56:33Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+03/20 08:56:38Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
+03/20 08:50:06Z -Runtime: sfs_test 00:00:05 -- baseline 00:01:20
+03/20 08:50:06Z -Runtime: aqm_test 00:00:06 -- baseline 00:00:30
+03/20 08:50:06Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
+03/20 08:50:36Z -Runtime: gefsv13_test 00:00:32 -- baseline 00:02:00
+03/20 08:55:21Z -Runtime: nmmb_test 00:00:24 -- baseline 00:02:00
+03/20 08:55:21Z -Runtime: rap_test 00:00:41 -- baseline 00:02:00
+03/20 08:55:21Z -Runtime: hrrr_test 00:01:26 -- baseline 00:03:00
+03/20 08:55:21Z -Runtime: hafs_test 00:00:29 -- baseline 00:01:30
+03/20 08:55:21Z -Runtime: 3drtma_test 00:01:33 -- baseline 00:01:30
+03/20 08:55:22Z -Runtime: mpas_test 00:01:15 -- baseline 00:02:30
+03/20 08:55:22Z -Runtime: mpas_hfip_test 00:03:30 -- baseline 00:05:00
+03/20 08:55:22Z -Runtime: gcafs_test 00:01:23 -- baseline 00:02:00
+03/20 08:56:52Z -Runtime: rrfs_test 00:06:46 -- baseline 00:07:00
+03/20 08:56:52Z -Runtime: rrfs_ifi_missing 00:01:46 -- baseline 00:03:00
+03/20 08:56:52Z -Runtime: gfs_test 00:05:08 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'rrfs_ifi_missing', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,64 +1,64 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-f98be00cdae0c32ed167c3c67cb193882b7fb538
+4e96912052331a72e626490bc4f29ec6c5ee6b1a
 
 Submodule hashes:
--5afd607642ae0fd6a53b137230336386beb47ce6 sorc/libIFI.fd
+-68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1466_ursa_intelllvm/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1467_ursa_intelllvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:11m:25s
-Test Date: 20260312 23:34:39
+Total runtime: 00h:10m:55s
+Test Date: 20260320 08:54:18
 Summary Results:
 
-03/12 23:24:43Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-03/12 23:24:49Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-03/12 23:24:49Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-03/12 23:25:08Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-03/12 23:25:10Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-03/12 23:25:10Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-03/12 23:25:24Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-03/12 23:25:25Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-03/12 23:25:32Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-03/12 23:25:32Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-03/12 23:25:33Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-03/12 23:26:21Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-03/12 23:26:21Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-03/12 23:27:22Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-03/12 23:27:23Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-03/12 23:27:24Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-03/12 23:28:28Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-03/12 23:28:36Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-03/12 23:28:36Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-03/12 23:28:37Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-03/12 23:28:48Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-03/12 23:30:01Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-03/12 23:31:22Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-03/12 23:31:24Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-03/12 23:31:25Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-03/12 23:33:01Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-03/12 23:33:02Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-03/12 23:33:02Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-03/12 23:34:20Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-03/12 23:34:24Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-03/12 23:34:29Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
-03/12 23:26:23Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-03/12 23:26:23Z -Runtime: aqm_test 00:00:06 -- baseline 00:00:30
-03/12 23:28:38Z -Runtime: gefsv12_test 00:00:11 -- baseline 00:02:00
-03/12 23:28:53Z -Runtime: gefsv13_test 00:00:31 -- baseline 00:02:00
-03/12 23:28:53Z -Runtime: nmmb_test 00:00:20 -- baseline 00:01:30
-03/12 23:28:53Z -Runtime: rap_test 00:00:35 -- baseline 00:02:00
-03/12 23:28:53Z -Runtime: hrrr_test 00:01:09 -- baseline 00:02:30
-03/12 23:28:53Z -Runtime: hafs_test 00:00:29 -- baseline 00:01:30
-03/12 23:28:53Z -Runtime: 3drtma_test 00:01:19 -- baseline 00:01:30
-03/12 23:28:53Z -Runtime: mpas_test 00:00:56 -- baseline 00:02:30
-03/12 23:31:39Z -Runtime: mpas_hfip_test 00:03:08 -- baseline 00:05:00
-03/12 23:31:39Z -Runtime: gcafs_test 00:01:11 -- baseline 00:02:30
-03/12 23:34:39Z -Runtime: rrfs_test 00:06:12 -- baseline 00:06:00
-03/12 23:34:39Z -Runtime: rrfs_ifi_missing 00:01:44 -- baseline 00:03:00
-03/12 23:34:39Z -Runtime: gfs_test 00:04:45 -- baseline 00:15:00
+03/20 08:44:56Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+03/20 08:45:27Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+03/20 08:45:56Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+03/20 08:45:57Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+03/20 08:45:57Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+03/20 08:45:57Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+03/20 08:46:16Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+03/20 08:46:17Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+03/20 08:46:17Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+03/20 08:48:04Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+03/20 08:48:24Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+03/20 08:49:31Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+03/20 08:49:32Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+03/20 08:49:38Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+03/20 08:49:59Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+03/20 08:50:00Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+03/20 08:50:00Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+03/20 08:50:00Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+03/20 08:50:01Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+03/20 08:50:02Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+03/20 08:50:12Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+03/20 08:50:13Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+03/20 08:50:18Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+03/20 08:50:20Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+03/20 08:50:21Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+03/20 08:52:09Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+03/20 08:52:10Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+03/20 08:52:10Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+03/20 08:54:00Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+03/20 08:54:04Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+03/20 08:54:09Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
+03/20 08:45:02Z -Runtime: sfs_test 00:00:05 -- baseline 00:01:20
+03/20 08:46:02Z -Runtime: aqm_test 00:00:06 -- baseline 00:00:30
+03/20 08:48:17Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
+03/20 08:48:32Z -Runtime: gefsv13_test 00:00:32 -- baseline 00:02:00
+03/20 08:50:03Z -Runtime: nmmb_test 00:01:08 -- baseline 00:01:30
+03/20 08:50:03Z -Runtime: rap_test 00:00:40 -- baseline 00:02:00
+03/20 08:50:03Z -Runtime: hrrr_test 00:01:10 -- baseline 00:02:30
+03/20 08:50:03Z -Runtime: hafs_test 00:00:36 -- baseline 00:01:30
+03/20 08:50:03Z -Runtime: 3drtma_test 00:01:27 -- baseline 00:01:30
+03/20 08:50:03Z -Runtime: mpas_test 00:01:06 -- baseline 00:02:30
+03/20 08:50:33Z -Runtime: mpas_hfip_test 00:03:29 -- baseline 00:05:00
+03/20 08:50:33Z -Runtime: gcafs_test 00:02:21 -- baseline 00:02:30
+03/20 08:54:18Z -Runtime: rrfs_test 00:06:17 -- baseline 00:06:00
+03/20 08:54:18Z -Runtime: rrfs_ifi_missing 00:01:46 -- baseline 00:03:00
+03/20 08:54:18Z -Runtime: gfs_test 00:05:18 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'rrfs_ifi_missing', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,65 +1,72 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-31d177b91889a139527438631adfc5965e5e8a00
+2f4f9bf76e9bbcd954d8ba70dbcd798f6ffa51b1
 
 Submodule hashes:
--5afd607642ae0fd6a53b137230336386beb47ce6 sorc/libIFI.fd
--3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
+ 68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd (fip_v2.0.0-39-g68953f5)
+ 3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd (ncep_post_gtg.v1.0.6-64-g3d35332)
 
-Run directory: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2
+Run directory: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:16m:46s
-Test Date: 20260312 17:45:53
+Total runtime: 00h:21m:49s
+Test Date: 20260319 11:15:44
 Summary Results:
 
-03/12 17:32:40Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-03/12 17:32:43Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-03/12 17:32:56Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-03/12 17:33:26Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-03/12 17:33:43Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-03/12 17:33:45Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-03/12 17:33:48Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-03/12 17:34:10Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
-03/12 17:34:14Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
-03/12 17:34:15Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-03/12 17:34:16Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
-03/12 17:34:17Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-03/12 17:34:17Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-03/12 17:34:38Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-03/12 17:34:39Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-03/12 17:34:41Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-03/12 17:35:12Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-03/12 17:35:13Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-03/12 17:35:15Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-03/12 17:36:12Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-03/12 17:36:15Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-03/12 17:37:10Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-03/12 17:37:18Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-03/12 17:37:20Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-03/12 17:38:09Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
-03/12 17:43:21Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-03/12 17:43:22Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-03/12 17:43:23Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-03/12 17:44:48Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
-03/12 17:45:08Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
-03/12 17:45:16Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
-03/12 17:32:53Z -Runtime: sfs_test 00:00:45 -- baseline 00:00:50
-03/12 17:32:57Z -Runtime: aqm_test 00:00:52 -- baseline 00:01:00
-03/12 17:33:18Z -Runtime: gefsv12_test 00:01:06 -- baseline 00:01:20
-03/12 17:34:10Z -Runtime: gefsv13_test 00:01:56 -- baseline 00:02:00
-03/12 17:34:47Z -Runtime: nmmb_test 00:02:25 -- baseline 00:02:20
-03/12 17:34:51Z -Runtime: rap_test 00:01:53 -- baseline 00:02:00
-03/12 17:35:46Z -Runtime: hrrr_test 00:03:27 -- baseline 00:03:40
-03/12 17:35:50Z -Runtime: hafs_test 00:01:34 -- baseline 00:02:00
-03/12 17:35:55Z -Runtime: 3drtma_test 00:02:46 -- baseline 00:03:00
-03/12 17:35:59Z -Runtime: mpas_test 00:02:25 -- baseline 00:02:40
-03/12 17:37:40Z -Runtime: mpas_hfip.test 00:05:30 -- baseline 00:05:00
-03/12 17:37:44Z -Runtime: gcafs_test 00:04:26 -- baseline 00:05:30
-03/12 17:45:44Z -Runtime: rrfs_test 00:13:31 -- baseline 00:10:00
-03/12 17:45:48Z -Runtime: rrfs_ifi_mis 00:06:18 -- baseline 00:08:00
-03/12 17:45:52Z -Runtime: gfs_test 00:11:34 -- baseline 00:15:00
+03/19 11:00:53Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+03/19 11:01:09Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+03/19 11:01:29Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+03/19 11:02:05Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+03/19 11:02:09Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+03/19 11:02:10Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+03/19 11:02:11Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+03/19 11:02:12Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
+03/19 11:02:28Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
+03/19 11:02:29Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
+03/19 11:02:42Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+03/19 11:02:44Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+03/19 11:02:45Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+03/19 11:02:45Z -mpas test: your new post executable generates bit-identical POSTNAT18.tm00 as the develop branch
+03/19 11:02:51Z -mpas test: your new post executable generates bit-identical POSTPRS18.tm00 as the develop branch
+03/19 11:02:54Z -mpas test: your new post executable generates bit-identical POSTTWO18.tm00 as the develop branch
+03/19 11:03:11Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+03/19 11:03:12Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+03/19 11:03:14Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+03/19 11:03:35Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+03/19 11:03:37Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+03/19 11:03:39Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+03/19 11:04:59Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+03/19 11:05:03Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+03/19 11:05:29Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+03/19 11:05:37Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+03/19 11:05:39Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+03/19 11:07:48Z -rrfs_ifi test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+03/19 11:08:06Z -rrfs_ifi_missing test: your new post executable generates bit-identical IFIFIP18.tm00 as the develop branch
+03/19 11:11:58Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+03/19 11:11:59Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+03/19 11:11:59Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+03/19 11:14:06Z -rrfs test: your new post executable generates bit-identical PRSLEV18.tm00 as the develop branch
+03/19 11:14:24Z -rrfs test: your new post executable generates bit-identical NATLEV18.tm00 as the develop branch
+03/19 11:14:31Z -rrfs test: your new post executable generates bit-identical 2DFLD18.tm00 as the develop branch
+03/19 11:01:04Z -Runtime: sfs_test 00:00:45 -- baseline 00:00:50
+03/19 11:01:24Z -Runtime: aqm_test 00:01:03 -- baseline 00:01:00
+03/19 11:01:45Z -Runtime: gefsv12_test 00:01:16 -- baseline 00:01:20
+03/19 11:02:37Z -Runtime: gefsv13_test 00:01:55 -- baseline 00:02:00
+03/19 11:03:14Z -Runtime: nmmb_test 00:02:32 -- baseline 00:02:20
+03/19 11:03:18Z -Runtime: rap_test 00:01:56 -- baseline 00:02:00
+03/19 11:04:10Z -Runtime: hrrr_test 00:03:27 -- baseline 00:03:40
+03/19 11:04:15Z -Runtime: hafs_test 00:01:46 -- baseline 00:02:00
+03/19 11:04:19Z -Runtime: 3drtma_test 00:02:55 -- baseline 00:03:00
+03/19 11:04:24Z -Runtime: mpas_test 00:02:36 -- baseline 00:02:40
+03/19 11:06:04Z -Runtime: mpas_hfip.test 00:05:17 -- baseline 00:05:00
+03/19 11:06:09Z -Runtime: gcafs_test 00:04:40 -- baseline 00:05:30
+03/19 11:15:04Z -Runtime: rrfs_test 00:13:22 -- baseline 00:10:00
+03/19 11:15:08Z -Runtime: rrfs_ifi_mis 00:07:39 -- baseline 00:08:00
+03/19 11:15:13Z -Runtime: gfs_test 00:11:28 -- baseline 00:15:00
+03/19 11:15:17Z -Runtime: hrrr_ifi_test 00:01:42 -- baseline 00:02:00
+03/19 11:15:38Z -Runtime: rrfs_ifi_test 00:07:12 -- baseline 00:08:10
+03/19 11:15:42Z -Runtime: dafs_test 00:01:55 -- baseline 00:02:00
 Check tests:
-['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'rrfs_ifi_missing', 'gfs']
+['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'rrfs_ifi_missing', 'gfs', 'hrrr_ifi', 'rrfs_ifi', 'dafs']
 No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
Closes #1468

This PR is meant to test that the changes to the app that runs the IFI FIP tests do not break anything. The changes to the app do not include any science changes. They are changes to allow the IFI team to more easily run libifi internally to test future changes, e.g. including grid and timing metadata to the output files.