### PR TITLE
Correct solar zenith angle calculation in CALRAD_WCLOUD_newcrtm.f

### DIFF
--- a/sorc/ncep_post.fd/CALRAD_WCLOUD_newcrtm.f
+++ b/sorc/ncep_post.fd/CALRAD_WCLOUD_newcrtm.f
@@ -22,6 +22,7 @@
 !> 2023-10-25 | Eric James     | Bug fix for invalid land category in CRTM
 !> 2025-03-10 | Hua Leighton   | Added channel 12 and 13 in ssmis-f17 
 !> 2025-09-05 | Gillian Petro  | Remove legacy satellite products: amsre (483-86), tim (488-91), and ssmi(s) TB (492-499)
+!> 2026-04-21 | Wen Meng       | Correct solar zenith angle calculation
 !>
 !> @author Chuang @date 2007-01-17
 !---------------------------------------------------------------------------
@@ -218,7 +219,6 @@
   type(crtm_channelinfo_type),allocatable,dimension(:) :: channelinfo
 !     
   integer ii,jj,n_clouds,n,nc
-  integer,external :: iw3jdn
   !
 
   !*****************************************************************************
@@ -362,8 +362,7 @@
      if (MODELNAME == 'NMM' .OR. MODELNAME == 'NCAR' .OR. MODELNAME == 'RAPR' &
       )o3=0.0
      ! Compute solar zenith angle for GFS, ARW now computes czen in INITPOST
-!     if (MODELNAME == 'GFS')then
-        jdn=iw3jdn(idat(3),idat(1),idat(2))
+        call w3fs13(idat(3),idat(1),idat(2),jdn)
 	do j=jsta,jend
 	   do i=ista,iend
 	      call zensun(jdn,float(idat(4)),gdlat(i,j),gdlon(i,j)       &
@@ -374,7 +373,6 @@
 	end do
         if(jj>=jsta .and. jj<=jend.and.debugprint)                   &
             print*,'sample GFS zenith angle=',acos(czen(ii,jj))*rtd   
-!     end if	       
      ! Initialize CRTM.  Load satellite sensor array.
      ! The optional arguments Process_ID and Output_Process_ID limit
      ! generation of runtime informative output to mpi task

--- a/sorc/ncep_post.fd/INITPOST.F
+++ b/sorc/ncep_post.fd/INITPOST.F
@@ -23,6 +23,7 @@
 !> 2025-11-13 | J Kenyon     | Reintroduce a previous algorithm to create a
 !>                           | "synthetic" cloud-fraction field, intended for
 !>                           | RTMA applications
+!> 2026-04-21 | Wen Meng     | Correct solar zenith angle calculation
 !>
 !> @author Russ Treadon W/NP2 @date 1993-11-10
       SUBROUTINE INITPOST
@@ -121,7 +122,6 @@
       real LAT
 
       integer jdn, numr, ic, jc, ierr
-      integer, external :: iw3jdn
       real sun_zenith,sun_azimuth, ptop_low, ptop_mid, ptop_high
       real delta_theta4gust
       real watericetotal, radius, totcount, cloudcount
@@ -2972,7 +2972,7 @@ endif  ! 1==2
        end do
       ELSE
 
-        jdn=iw3jdn(idat(3),idat(1),idat(2))
+        call w3fs13(idat(3),idat(1),idat(2),jdn)
         do j=jsta,jend
          do i=1,im
              call zensun(jdn,float(idat(4)),gdlat(i,j),gdlon(i,j)     &

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -242,7 +242,6 @@
       integer isa, jsa, latghf, jtem, idvc, idsl, nvcoord, ip1, nn, npass
 
       integer jdn
-      integer, external :: iw3jdn
       real sun_zenith, sun_azimuth, temp
 
       integer, parameter    :: npass2=5, npass3=30

--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,62 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-47ea865faea7452394730576571edfe896aece34
+afd76486fd75d85270e9d3f51a1d8b2ac40ff362
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1496_hercules_intel/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1509_hercules_intel/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:11m:37s
-Test Date: 20260423 12:10:09
+Total runtime: 00h:11m:56s
+Test Date: 20260428 00:26:23
 Summary Results:
 
-04/23 17:00:43Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-04/23 17:00:47Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-04/23 17:00:54Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-04/23 17:01:07Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-04/23 17:01:20Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-04/23 17:01:37Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-04/23 17:01:37Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-04/23 17:01:45Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-04/23 17:01:45Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-04/23 17:01:45Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-04/23 17:01:49Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-04/23 17:01:49Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-04/23 17:01:50Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-04/23 17:01:54Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-04/23 17:01:54Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-04/23 17:01:55Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-04/23 17:02:27Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-04/23 17:02:27Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-04/23 17:02:28Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-04/23 17:02:29Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-04/23 17:02:30Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-04/23 17:02:31Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-04/23 17:03:10Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-04/23 17:03:11Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-04/23 17:08:17Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-04/23 17:08:19Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-04/23 17:08:19Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-04/23 17:09:33Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-04/23 17:10:00Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-04/23 17:10:03Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-04/23 17:01:07Z -Runtime: sfs_test 00:00:05 -- baseline 00:01:20
-04/23 17:01:07Z -Runtime: aqm_test 00:00:09 -- baseline 00:00:30
-04/23 17:01:07Z -Runtime: gefsv12_test 00:00:16 -- baseline 00:01:00
-04/23 17:01:23Z -Runtime: gefsv13_test 00:00:42 -- baseline 00:02:00
-04/23 17:01:53Z -Runtime: nmmb_test 00:01:07 -- baseline 00:03:00
-04/23 17:01:53Z -Runtime: rap_test 00:00:59 -- baseline 00:02:00
-04/23 17:02:38Z -Runtime: hrrr_test 00:01:50 -- baseline 00:06:00
-04/23 17:02:38Z -Runtime: hafs_test 00:00:29 -- baseline 00:01:00
-04/23 17:02:38Z -Runtime: 3drtma_test 00:01:17 -- baseline 00:03:00
-04/23 17:02:38Z -Runtime: mpas_test 00:01:12 -- baseline 00:02:30
-04/23 17:02:38Z -Runtime: mpas_hfip_test 00:01:54 -- baseline 00:05:00
-04/23 17:03:23Z -Runtime: gcafs_test 00:02:33 -- baseline 00:02:30
-04/23 17:10:08Z -Runtime: rrfs_test 00:09:25 -- baseline 00:12:00
-04/23 17:10:08Z -Runtime: gfs_test 00:07:41 -- baseline 00:25:00
+04/28 05:16:44Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+04/28 05:16:47Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+04/28 05:16:54Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+04/28 05:17:12Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+04/28 05:17:24Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+04/28 05:17:38Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+04/28 05:17:39Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+04/28 05:17:54Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+04/28 05:17:54Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+04/28 05:17:55Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+04/28 05:17:55Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+04/28 05:17:55Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+04/28 05:17:56Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+04/28 05:18:16Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+04/28 05:18:17Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+04/28 05:18:17Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+04/28 05:18:30Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+04/28 05:18:31Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+04/28 05:18:32Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+04/28 05:18:37Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+04/28 05:18:39Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+04/28 05:18:39Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+04/28 05:19:51Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+04/28 05:19:52Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+04/28 05:24:19Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+04/28 05:24:21Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+04/28 05:24:21Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+04/28 05:25:42Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+04/28 05:26:12Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+04/28 05:26:16Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+04/28 05:17:07Z -Runtime: sfs_test 00:00:05 -- baseline 00:01:20
+04/28 05:17:07Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
+04/28 05:17:07Z -Runtime: gefsv12_test 00:00:15 -- baseline 00:01:00
+04/28 05:17:37Z -Runtime: gefsv13_test 00:00:45 -- baseline 00:02:00
+04/28 05:18:22Z -Runtime: nmmb_test 00:01:38 -- baseline 00:03:00
+04/28 05:18:22Z -Runtime: rap_test 00:01:00 -- baseline 00:02:00
+04/28 05:18:37Z -Runtime: hrrr_test 00:01:53 -- baseline 00:06:00
+04/28 05:18:37Z -Runtime: hafs_test 00:00:33 -- baseline 00:01:00
+04/28 05:18:37Z -Runtime: 3drtma_test 00:01:17 -- baseline 00:03:00
+04/28 05:18:37Z -Runtime: mpas_test 00:01:16 -- baseline 00:02:30
+04/28 05:18:52Z -Runtime: mpas_hfip_test 00:02:00 -- baseline 00:05:00
+04/28 05:19:52Z -Runtime: gcafs_test 00:03:13 -- baseline 00:02:30
+04/28 05:26:23Z -Runtime: rrfs_test 00:09:37 -- baseline 00:12:00
+04/28 05:26:23Z -Runtime: gfs_test 00:07:42 -- baseline 00:25:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,62 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-47ea865faea7452394730576571edfe896aece34
+afd76486fd75d85270e9d3f51a1d8b2ac40ff362
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1496_orion_intel/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1509_orion_intel/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 00h:20m:03s
-Test Date: 20260423 12:18:34
+Total runtime: 00h:20m:06s
+Test Date: 20260428 00:34:32
 Summary Results:
 
-04/23 17:01:55Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-04/23 17:01:59Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-04/23 17:02:06Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-04/23 17:02:23Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-04/23 17:02:42Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-04/23 17:03:15Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-04/23 17:03:16Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-04/23 17:03:16Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-04/23 17:03:29Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-04/23 17:03:30Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-04/23 17:03:34Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-04/23 17:03:34Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-04/23 17:03:35Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-04/23 17:03:35Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-04/23 17:03:36Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-04/23 17:03:36Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-04/23 17:04:43Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-04/23 17:04:44Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-04/23 17:05:22Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-04/23 17:05:23Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-04/23 17:05:24Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-04/23 17:05:58Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-04/23 17:06:00Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-04/23 17:06:01Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-04/23 17:13:18Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-04/23 17:13:20Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-04/23 17:13:20Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-04/23 17:17:53Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-04/23 17:18:25Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-04/23 17:18:28Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-04/23 17:02:16Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
-04/23 17:02:16Z -Runtime: aqm_test 00:00:12 -- baseline 00:00:30
-04/23 17:02:17Z -Runtime: gefsv12_test 00:00:19 -- baseline 00:01:00
-04/23 17:02:47Z -Runtime: gefsv13_test 00:00:55 -- baseline 00:02:00
-04/23 17:03:17Z -Runtime: nmmb_test 00:01:29 -- baseline 00:03:00
-04/23 17:03:32Z -Runtime: rap_test 00:01:43 -- baseline 00:02:00
-04/23 17:05:32Z -Runtime: hrrr_test 00:03:37 -- baseline 00:08:00
-04/23 17:05:32Z -Runtime: hafs_test 00:00:36 -- baseline 00:01:00
-04/23 17:05:32Z -Runtime: 3drtma_test 00:01:49 -- baseline 00:03:00
-04/23 17:05:32Z -Runtime: mpas_test 00:01:49 -- baseline 00:02:30
-04/23 17:06:02Z -Runtime: mpas_hfip_test 00:04:15 -- baseline 00:05:00
-04/23 17:06:02Z -Runtime: gcafs_test 00:02:57 -- baseline 00:03:15
-04/23 17:18:34Z -Runtime: rrfs_test 00:16:41 -- baseline 00:17:00
-04/23 17:18:34Z -Runtime: gfs_test 00:11:33 -- baseline 00:26:00
+04/28 05:17:52Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+04/28 05:17:56Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+04/28 05:18:04Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+04/28 05:18:26Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+04/28 05:18:41Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+04/28 05:19:27Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+04/28 05:19:28Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+04/28 05:19:34Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+04/28 05:19:35Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+04/28 05:19:35Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+04/28 05:19:40Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+04/28 05:19:41Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+04/28 05:19:42Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+04/28 05:19:45Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+04/28 05:19:46Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+04/28 05:19:46Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+04/28 05:21:17Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+04/28 05:21:19Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+04/28 05:21:20Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+04/28 05:21:21Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+04/28 05:21:22Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+04/28 05:21:31Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+04/28 05:21:32Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+04/28 05:21:33Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+04/28 05:29:25Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+04/28 05:29:27Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+04/28 05:29:27Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+04/28 05:33:49Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+04/28 05:34:16Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+04/28 05:34:19Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+04/28 05:18:14Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
+04/28 05:18:14Z -Runtime: aqm_test 00:00:12 -- baseline 00:00:30
+04/28 05:18:14Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:01:00
+04/28 05:18:44Z -Runtime: gefsv13_test 00:00:57 -- baseline 00:02:00
+04/28 05:19:44Z -Runtime: nmmb_test 00:01:51 -- baseline 00:03:00
+04/28 05:19:44Z -Runtime: rap_test 00:01:45 -- baseline 00:02:00
+04/28 05:21:45Z -Runtime: hrrr_test 00:03:45 -- baseline 00:08:00
+04/28 05:21:45Z -Runtime: hafs_test 00:00:38 -- baseline 00:01:00
+04/28 05:21:45Z -Runtime: 3drtma_test 00:01:54 -- baseline 00:03:00
+04/28 05:21:45Z -Runtime: mpas_test 00:01:58 -- baseline 00:02:30
+04/28 05:21:45Z -Runtime: mpas_hfip_test 00:03:32 -- baseline 00:05:00
+04/28 05:21:45Z -Runtime: gcafs_test 00:03:34 -- baseline 00:03:15
+04/28 05:34:32Z -Runtime: rrfs_test 00:16:31 -- baseline 00:17:00
+04/28 05:34:32Z -Runtime: gfs_test 00:11:39 -- baseline 00:26:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,62 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-47ea865faea7452394730576571edfe896aece34
+afd76486fd75d85270e9d3f51a1d8b2ac40ff362
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1496_ursa_intel/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1509_ursa_intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:09m:10s
-Test Date: 20260423 17:07:39
+Total runtime: 00h:09m:05s
+Test Date: 20260428 05:23:30
 Summary Results:
 
-04/23 17:00:43Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-04/23 17:00:51Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-04/23 17:01:06Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-04/23 17:01:12Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-04/23 17:01:35Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-04/23 17:01:36Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-04/23 17:01:37Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-04/23 17:01:38Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-04/23 17:02:03Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-04/23 17:02:04Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-04/23 17:02:05Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-04/23 17:02:19Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-04/23 17:02:20Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-04/23 17:02:27Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-04/23 17:02:28Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-04/23 17:02:31Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-04/23 17:02:32Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-04/23 17:02:33Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-04/23 17:03:03Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-04/23 17:03:04Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-04/23 17:03:04Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-04/23 17:03:58Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-04/23 17:04:00Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-04/23 17:04:00Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-04/23 17:06:04Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-04/23 17:06:05Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-04/23 17:06:05Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-04/23 17:07:13Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-04/23 17:07:24Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-04/23 17:07:28Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-04/23 17:00:53Z -Runtime: sfs_test 00:00:04 -- baseline 00:01:20
-04/23 17:00:53Z -Runtime: aqm_test 00:00:05 -- baseline 00:00:30
-04/23 17:01:08Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
-04/23 17:01:38Z -Runtime: gefsv13_test 00:00:32 -- baseline 00:02:00
-04/23 17:03:08Z -Runtime: nmmb_test 00:00:22 -- baseline 00:02:00
-04/23 17:03:08Z -Runtime: rap_test 00:00:41 -- baseline 00:02:00
-04/23 17:03:08Z -Runtime: hrrr_test 00:01:25 -- baseline 00:03:00
-04/23 17:03:08Z -Runtime: hafs_test 00:00:28 -- baseline 00:01:30
-04/23 17:03:08Z -Runtime: 3drtma_test 00:01:10 -- baseline 00:01:30
-04/23 17:03:08Z -Runtime: mpas_test 00:01:18 -- baseline 00:02:30
-04/23 17:04:08Z -Runtime: mpas_hfip_test 00:03:13 -- baseline 00:05:00
-04/23 17:04:08Z -Runtime: gcafs_test 00:01:17 -- baseline 00:02:00
-04/23 17:07:39Z -Runtime: rrfs_test 00:06:41 -- baseline 00:07:00
-04/23 17:07:39Z -Runtime: gfs_test 00:05:18 -- baseline 00:15:00
+04/28 05:16:25Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+04/28 05:16:39Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+04/28 05:16:43Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+04/28 05:16:52Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+04/28 05:17:24Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+04/28 05:17:31Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+04/28 05:17:32Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+04/28 05:17:32Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+04/28 05:17:33Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+04/28 05:17:33Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+04/28 05:17:33Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+04/28 05:18:20Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+04/28 05:18:21Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+04/28 05:18:22Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+04/28 05:18:48Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+04/28 05:18:49Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+04/28 05:18:59Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+04/28 05:18:59Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+04/28 05:19:21Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+04/28 05:19:22Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+04/28 05:19:22Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+04/28 05:19:52Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+04/28 05:19:54Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+04/28 05:19:55Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+04/28 05:21:52Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+04/28 05:21:52Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+04/28 05:21:52Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+04/28 05:23:16Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+04/28 05:23:21Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+04/28 05:23:25Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+04/28 05:16:44Z -Runtime: sfs_test 00:00:04 -- baseline 00:01:20
+04/28 05:16:44Z -Runtime: aqm_test 00:00:05 -- baseline 00:00:30
+04/28 05:16:59Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
+04/28 05:17:29Z -Runtime: gefsv13_test 00:00:31 -- baseline 00:02:00
+04/28 05:19:29Z -Runtime: nmmb_test 00:00:22 -- baseline 00:02:00
+04/28 05:19:29Z -Runtime: rap_test 00:00:47 -- baseline 00:02:00
+04/28 05:19:29Z -Runtime: hrrr_test 00:01:27 -- baseline 00:03:00
+04/28 05:19:29Z -Runtime: hafs_test 00:00:27 -- baseline 00:01:30
+04/28 05:19:29Z -Runtime: 3drtma_test 00:01:17 -- baseline 00:01:30
+04/28 05:19:29Z -Runtime: mpas_test 00:01:17 -- baseline 00:02:30
+04/28 05:19:59Z -Runtime: mpas_hfip_test 00:03:32 -- baseline 00:05:00
+04/28 05:19:59Z -Runtime: gcafs_test 00:01:13 -- baseline 00:02:00
+04/28 05:23:30Z -Runtime: rrfs_test 00:06:52 -- baseline 00:07:00
+04/28 05:23:30Z -Runtime: gfs_test 00:05:19 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,62 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-47ea865faea7452394730576571edfe896aece34
+afd76486fd75d85270e9d3f51a1d8b2ac40ff362
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1496_ursa_intelllvm/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1509_ursa_intelllvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:07m:26s
-Test Date: 20260423 17:05:56
+Total runtime: 00h:08m:28s
+Test Date: 20260428 05:22:54
 Summary Results:
 
-04/23 16:59:39Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-04/23 16:59:46Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-04/23 16:59:57Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-04/23 16:59:58Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-04/23 17:00:23Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-04/23 17:00:40Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-04/23 17:00:41Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-04/23 17:00:41Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-04/23 17:00:42Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-04/23 17:00:42Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-04/23 17:00:46Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-04/23 17:00:47Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-04/23 17:00:47Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-04/23 17:00:59Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-04/23 17:01:00Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-04/23 17:01:01Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-04/23 17:01:50Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-04/23 17:01:51Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-04/23 17:02:38Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-04/23 17:02:40Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-04/23 17:02:41Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-04/23 17:02:54Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-04/23 17:02:55Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-04/23 17:02:55Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-04/23 17:04:53Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-04/23 17:04:54Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-04/23 17:04:54Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-04/23 17:05:41Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-04/23 17:05:51Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-04/23 17:05:56Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-04/23 16:59:55Z -Runtime: sfs_test 00:00:06 -- baseline 00:01:20
-04/23 16:59:55Z -Runtime: aqm_test 00:00:09 -- baseline 00:00:30
-04/23 17:00:10Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
-04/23 17:00:25Z -Runtime: gefsv13_test 00:00:34 -- baseline 00:02:00
-04/23 17:02:55Z -Runtime: nmmb_test 00:00:20 -- baseline 00:01:30
-04/23 17:02:56Z -Runtime: rap_test 00:00:40 -- baseline 00:02:00
-04/23 17:02:56Z -Runtime: hrrr_test 00:01:12 -- baseline 00:02:30
-04/23 17:02:56Z -Runtime: hafs_test 00:00:30 -- baseline 00:01:30
-04/23 17:02:56Z -Runtime: 3drtma_test 00:01:15 -- baseline 00:01:30
-04/23 17:02:56Z -Runtime: mpas_test 00:01:20 -- baseline 00:02:30
-04/23 17:02:56Z -Runtime: mpas_hfip_test 00:03:14 -- baseline 00:05:00
-04/23 17:02:56Z -Runtime: gcafs_test 00:02:02 -- baseline 00:02:30
-04/23 17:05:56Z -Runtime: rrfs_test 00:06:29 -- baseline 00:06:00
-04/23 17:05:56Z -Runtime: gfs_test 00:05:05 -- baseline 00:15:00
+04/28 05:15:41Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+04/28 05:15:42Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+04/28 05:15:47Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+04/28 05:16:04Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+04/28 05:16:33Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+04/28 05:16:37Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+04/28 05:16:38Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+04/28 05:16:39Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+04/28 05:16:42Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+04/28 05:16:43Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+04/28 05:16:44Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+04/28 05:17:07Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+04/28 05:17:07Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+04/28 05:17:08Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+04/28 05:18:43Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+04/28 05:18:44Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+04/28 05:18:50Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+04/28 05:18:51Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+04/28 05:19:09Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+04/28 05:19:11Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+04/28 05:19:11Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+04/28 05:19:12Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+04/28 05:19:12Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+04/28 05:19:12Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+04/28 05:20:37Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+04/28 05:20:38Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+04/28 05:20:38Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+04/28 05:22:33Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+04/28 05:22:39Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+04/28 05:22:44Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+04/28 05:15:52Z -Runtime: sfs_test 00:00:04 -- baseline 00:01:20
+04/28 05:15:53Z -Runtime: aqm_test 00:00:09 -- baseline 00:00:30
+04/28 05:16:08Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
+04/28 05:16:38Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
+04/28 05:19:23Z -Runtime: nmmb_test 00:00:21 -- baseline 00:01:30
+04/28 05:19:23Z -Runtime: rap_test 00:00:39 -- baseline 00:02:00
+04/28 05:19:23Z -Runtime: hrrr_test 00:01:07 -- baseline 00:02:30
+04/28 05:19:23Z -Runtime: hafs_test 00:00:24 -- baseline 00:01:30
+04/28 05:19:23Z -Runtime: 3drtma_test 00:01:16 -- baseline 00:01:30
+04/28 05:19:23Z -Runtime: mpas_test 00:01:21 -- baseline 00:02:30
+04/28 05:19:23Z -Runtime: mpas_hfip_test 00:03:17 -- baseline 00:05:00
+04/28 05:19:23Z -Runtime: gcafs_test 00:01:11 -- baseline 00:02:30
+04/28 05:22:53Z -Runtime: rrfs_test 00:06:18 -- baseline 00:06:00
+04/28 05:22:54Z -Runtime: gfs_test 00:04:54 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,6 +1,6 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-16f0159a51ff58edab3c3d742ccac666a5187adb
+4cfdee49cf11824d1a33753ca679d605d657a359
 
 Submodule hashes:
  68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd (fip_v2.0.0-39-g68953f5)
@@ -9,60 +9,68 @@ Submodule hashes:
 Run directory: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:19m:34s
-Test Date: 20260417 13:46:35
+Total runtime: 00h:42m:17s
+Test Date: 20260427 14:16:22
 Summary Results:
 
-04/17 13:33:49Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
-04/17 13:34:10Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-04/17 13:34:18Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-04/17 13:34:41Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
-04/17 13:34:43Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-04/17 13:35:01Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-04/17 13:35:03Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
-04/17 13:35:03Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-04/17 13:35:04Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
-04/17 13:35:07Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-04/17 13:35:25Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-04/17 13:35:29Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-04/17 13:35:32Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-04/17 13:35:37Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-04/17 13:35:39Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-04/17 13:35:39Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-04/17 13:35:40Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-04/17 13:35:41Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-04/17 13:35:44Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-04/17 13:36:32Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-04/17 13:36:35Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-04/17 13:36:37Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-04/17 13:37:46Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-04/17 13:37:47Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-04/17 13:37:49Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-04/17 13:37:53Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-04/17 13:37:55Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-04/17 13:44:37Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-04/17 13:44:39Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-04/17 13:44:40Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-04/17 13:45:18Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-04/17 13:45:36Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-04/17 13:45:43Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-04/17 13:34:06Z -Runtime: sfs_test 00:00:38 -- baseline 00:00:50
-04/17 13:34:27Z -Runtime: aqm_test 00:01:03 -- baseline 00:01:00
-04/17 13:34:50Z -Runtime: gefsv12_test 00:01:13 -- baseline 00:01:20
-04/17 13:35:42Z -Runtime: gefsv13_test 00:02:01 -- baseline 00:02:00
-04/17 13:36:10Z -Runtime: nmmb_test 00:02:37 -- baseline 00:02:20
-04/17 13:36:15Z -Runtime: rap_test 00:01:58 -- baseline 00:02:00
-04/17 13:37:08Z -Runtime: hrrr_test 00:03:34 -- baseline 00:03:40
-04/17 13:37:13Z -Runtime: hafs_test 00:01:38 -- baseline 00:02:00
-04/17 13:37:18Z -Runtime: 3drtma_test 00:02:44 -- baseline 00:03:00
-04/17 13:37:23Z -Runtime: mpas_test 00:02:34 -- baseline 00:02:40
-04/17 13:38:15Z -Runtime: mpas_hfip.test 00:04:50 -- baseline 00:05:00
-04/17 13:38:20Z -Runtime: gcafs_test 00:04:45 -- baseline 00:05:30
-04/17 13:46:19Z -Runtime: rrfs_test 00:12:48 -- baseline 00:10:00
-04/17 13:46:25Z -Runtime: gfs_test 00:11:39 -- baseline 00:15:00
-04/17 13:46:29Z -Runtime: hrrr_ifi_test 00:01:36 -- baseline 00:02:00
-04/17 13:46:34Z -Runtime: dafs_test 00:01:58 -- baseline 00:02:00
+04/27 13:41:37Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f048 as the develop branch
+04/27 13:41:54Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+04/27 13:42:08Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+04/27 13:42:31Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
+04/27 13:42:33Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
+04/27 13:42:33Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+04/27 13:42:34Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+04/27 13:42:35Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+04/27 13:42:37Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
+04/27 13:42:37Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
+04/27 13:42:51Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+04/27 13:42:57Z -rap test: your new post executable did not generate bit-identical WRFPRS.GrbF06 as the develop branch
+04/27 13:43:11Z -rap test: your new post executable did not generate bit-identical WRFNAT.GrbF06 as the develop branch
+04/27 13:43:15Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+04/27 13:43:17Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+04/27 13:43:17Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+04/27 13:43:34Z -mpas test: your new post executable did not generate bit-identical POSTTWO12.tm00 as the develop branch
+04/27 13:43:35Z -3drtma test: your new post executable did not generate bit-identical WRFTWO.GrbF00 as the develop branch
+04/27 13:43:36Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+04/27 13:44:29Z -hrrr test: your new post executable did not generate bit-identical WRFTWO.GrbF10 as the develop branch
+04/27 13:44:30Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+04/27 13:44:31Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+04/27 13:44:46Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+04/27 13:44:48Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+04/27 13:45:05Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+04/27 13:45:07Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+04/27 13:45:09Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+04/27 13:52:14Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+04/27 13:52:15Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+04/27 13:52:16Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.special.grb2f006 as the develop branch
+04/27 13:53:25Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+04/27 14:12:10Z -rrfs test: your new post executable did not generate bit-identical NATLEV36.tm00 as the develop branch
+04/27 14:15:36Z -rrfs test: your new post executable did not generate bit-identical 2DFLD36.tm00 as the develop branch
+04/27 13:41:54Z -Runtime: sfs_test 00:00:41 -- baseline 00:00:50
+04/27 13:42:15Z -Runtime: aqm_test 00:01:03 -- baseline 00:01:00
+04/27 13:42:36Z -Runtime: gefsv12_test 00:01:17 -- baseline 00:01:20
+04/27 13:43:12Z -Runtime: gefsv13_test 00:01:56 -- baseline 00:02:00
+04/27 13:43:16Z -Runtime: nmmb_test 00:01:40 -- baseline 00:02:20
+04/27 13:43:37Z -Runtime: rap_test 00:02:17 -- baseline 00:02:00
+04/27 13:45:01Z -Runtime: hrrr_test 00:03:39 -- baseline 00:03:40
+04/27 13:45:06Z -Runtime: hafs_test 00:01:37 -- baseline 00:02:00
+04/27 13:45:10Z -Runtime: 3drtma_test 00:02:44 -- baseline 00:03:00
+04/27 13:45:14Z -Runtime: mpas_test 00:02:42 -- baseline 00:02:40
+04/27 13:45:37Z -Runtime: mpas_hfip.test 00:04:20 -- baseline 00:05:00
+04/27 13:45:42Z -Runtime: gcafs_test 00:03:55 -- baseline 00:05:30
+04/27 14:16:02Z -Runtime: rrfs_test 00:34:49 -- baseline 00:10:00
+04/27 14:16:10Z -Runtime: gfs_test 00:11:27 -- baseline 00:15:00
+04/27 14:16:16Z -Runtime: hrrr_ifi_test 00:01:37 -- baseline 00:02:00
+04/27 14:16:21Z -Runtime: dafs_test 00:01:43 -- baseline 00:02:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs', 'hrrr_ifi', 'dafs']
-No changes in test results detected.
+There are changes in results for case 3drtma in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/3drtma_2025091010/WRFTWO.GrbF00
+There are changes in results for case hrrr in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/hrrr_2025063004/WRFTWO.GrbF10
+There are changes in results for case mpas in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/mpas_2026032009/POSTTWO12.tm00
+There are changes in results for case rrfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/rrfs_2026032512/2DFLD36.tm00
+There are changes in results for case rrfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/rrfs_2026032512/NATLEV36.tm00
+There are changes in results for case rap in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/rap_2025070115/WRFPRS.GrbF06
+There are changes in results for case rap in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/rap_2025070115/WRFNAT.GrbF06
+There are changes in results for case gfs in /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2/gfs_2025012600/gfs.t00z.special.grb2f006
+Refer to .diff files in rundir: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2 for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
Resolves issue #1508 

It was found the solar zenith angle calculation in CALRAD_WCLOUD_newcrtm.f is incorrect. PRs #1503  and #1505  fixed this issue in the release/rrfs_v1 and release/gfs_v17 branches for the RRFSv1 and GFSv17 implementations. This fix will also be added to the UPP develop branch.

Similar fixes were previously added to the INITPOST routines in PR #1281  and PR #1444 

@WenMeng-NOAA there are baseline changes to GFS, RRFS, RAP, HRRR, and MPAS.  My test results are located here on Cactus:
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/upp-pr-1509