### PR TITLE
Correct solar zenith angle calculation for 3DRTMA

### DIFF
--- a/sorc/ncep_post.fd/CALRAD_WCLOUD_newcrtm.f
+++ b/sorc/ncep_post.fd/CALRAD_WCLOUD_newcrtm.f
@@ -22,6 +22,7 @@
 !> 2023-10-25 | Eric James     | Bug fix for invalid land category in CRTM
 !> 2025-03-10 | Hua Leighton   | Added channel 12 and 13 in ssmis-f17 
 !> 2025-09-05 | Gillian Petro  | Remove legacy satellite products: amsre (483-86), tim (488-91), and ssmi(s) TB (492-499)
+!> 2026-04-21 | Wen Meng       | Correct solar zenith angle calculation
 !>
 !> @author Chuang @date 2007-01-17
 !---------------------------------------------------------------------------
@@ -218,7 +219,6 @@
   type(crtm_channelinfo_type),allocatable,dimension(:) :: channelinfo
 !     
   integer ii,jj,n_clouds,n,nc
-  integer,external :: iw3jdn
   !
 
   !*****************************************************************************
@@ -362,8 +362,7 @@
      if (MODELNAME == 'NMM' .OR. MODELNAME == 'NCAR' .OR. MODELNAME == 'RAPR' &
       )o3=0.0
      ! Compute solar zenith angle for GFS, ARW now computes czen in INITPOST
-!     if (MODELNAME == 'GFS')then
-        jdn=iw3jdn(idat(3),idat(1),idat(2))
+        call w3fs13(idat(3),idat(1),idat(2),jdn)
 	do j=jsta,jend
 	   do i=ista,iend
 	      call zensun(jdn,float(idat(4)),gdlat(i,j),gdlon(i,j)       &
@@ -374,7 +373,6 @@
 	end do
         if(jj>=jsta .and. jj<=jend.and.debugprint)                   &
             print*,'sample GFS zenith angle=',acos(czen(ii,jj))*rtd   
-!     end if	       
      ! Initialize CRTM.  Load satellite sensor array.
      ! The optional arguments Process_ID and Output_Process_ID limit
      ! generation of runtime informative output to mpi task

--- a/sorc/ncep_post.fd/INITPOST.F
+++ b/sorc/ncep_post.fd/INITPOST.F
@@ -23,6 +23,7 @@
 !> 2025-11-13 | J Kenyon     | Reintroduce a previous algorithm to create a
 !>                           | "synthetic" cloud-fraction field, intended for
 !>                           | RTMA applications
+!> 2026-04-21 | Wen Meng     | Correct solar zenith angle calculation
 !>
 !> @author Russ Treadon W/NP2 @date 1993-11-10
       SUBROUTINE INITPOST
@@ -118,7 +119,6 @@
       real LAT
 
       integer jdn, numr, ic, jc, ierr
-      integer, external :: iw3jdn
       real sun_zenith,sun_azimuth, ptop_low, ptop_mid, ptop_high
       real delta_theta4gust
       real watericetotal, radius, totcount, cloudcount
@@ -2969,7 +2969,7 @@ endif  ! 1==2
        end do
       ELSE
 
-        jdn=iw3jdn(idat(3),idat(1),idat(2))
+        call w3fs13(idat(3),idat(1),idat(2),jdn)
         do j=jsta,jend
          do i=1,im
              call zensun(jdn,float(idat(4)),gdlat(i,j),gdlon(i,j)     &

--- a/sorc/ncep_post.fd/INITPOST_MPAS.F
+++ b/sorc/ncep_post.fd/INITPOST_MPAS.F
@@ -38,6 +38,7 @@
 !>                           | correct the initial assignment of ZINT;
 !>                           | simplify/refactor the re-assignment of ZINT using the hypsometric equation;
 !>                           | add numerous descriptive comments.
+!> 2026-02-24 | Eric James   | Correct calculation of day of year
 !>
 !> @author Jaymes Kenyon (GSL) @date 2024-08-14
 
@@ -133,7 +134,6 @@
       real LAT
 
       integer jdn, numr, ic, jc, ierr
-      integer, external :: iw3jdn
       real sun_zenith,sun_azimuth, ptop_low, ptop_mid, ptop_high
 
 !***********************************************************************
@@ -2652,7 +2652,7 @@ endif  ! 1==2
        end do
       ELSE
 
-        jdn=iw3jdn(idat(3),idat(1),idat(2))
+        call w3fs13(idat(3),idat(1),idat(2),jdn)
         do j=jsta,jend
          do i=1,im
              call zensun(jdn,float(idat(4)),gdlat(i,j),gdlon(i,j)     &

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -237,7 +237,6 @@
       integer isa, jsa, latghf, jtem, idvc, idsl, nvcoord, ip1, nn, npass
 
       integer jdn
-      integer, external :: iw3jdn
       real sun_zenith, sun_azimuth, temp
 
       integer, parameter    :: npass2=5, npass3=30


### PR DESCRIPTION
This PR resolves issue #1526 

The calculation of the solar zenith angle was recently fixed in the UPP develop branch with PR #1509 , and while this bug fix does not impact the current 3DRTMA products, we feel it would be beneficial to include in the 3DRTMA release branch.

My test results are located here on Cactus:

`/lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2-3drtma/3drtma_2025091010`