### PR TITLE
Iss1055 Testing alternative tropopause calculation

### DIFF
--- a/sorc/ncep_post.fd/CMakeLists.txt
+++ b/sorc/ncep_post.fd/CMakeLists.txt
@@ -116,6 +116,7 @@ list(APPEND LIB_SRC
     svptbl.f
     TABLE.f
     TABLEQ.f
+    TRPAUS2.f
     TRPAUS.f
     TTBLEX.f
     UPP_MATH.f

--- a/sorc/ncep_post.fd/MISCLN.f
+++ b/sorc/ncep_post.fd/MISCLN.f
@@ -55,6 +55,8 @@
 !!   2026-03-04 | G Zhao  | Fixed a bug: for ID(585), MU-CIN should be saved in MUCIN array, not in MUCAPE;
 !!                          Comment off "MUQ1D(I,J) = Q1D(I,J)" since Q1D is NOT the moisture of the Most
 !!                          Unstable (MU) parcel, MUQ1D is calculated later with CALTHTE to find MU parcel.
+!!   2026-05-20 | C Hill  | Alternative tropopause level subroutine TRPAUS2 replaces TPAUSE.
+!!
 !> 
 !> @author RUSS TREADON 
 !> @date 1992-12-20
@@ -419,39 +421,18 @@
 !     
 !
 !     ***BLOCK 1:  TROPOPAUSE P, Z, T, U, V, AND WIND SHEAR.
+!     Alternative, ECMWF-employed algorithm
 !    
       IF ((IGET(054)>0).OR.(IGET(055)>0).OR.       &
           (IGET(056)>0).OR.(IGET(057)>0).OR.       &
           (IGET(177)>0).OR.                           &
           (IGET(058)>0).OR.(IGET(108)>0) ) THEN
-! Chuang: Use GFS algorithm per Iredell's and DiMego's decision on unification
-!$omp parallel do private(i,j)
-          DO J=JSTA,JEND
-            DO I=ISTA,IEND
-
-              if(PMID(I,J,1)<spval) then
-! INPUT
-              CALL TPAUSE(LM,PMID(I,J,1:LM),UH(I,J,1:LM)             & 
-! INPUT
-                         ,VH(I,J,1:LM),T(I,J,1:LM),ZMID(I,J,1:LM)    &
-! OUTPUT
-                         ,P1D(I,J),U1D(I,J),V1D(I,J),T1D(I,J)        &
-! OUTPUT
-                         ,Z1D(I,J),SHR1D(I,J))                       ! OUTPUT
-              else
-                P1D(I,J) = spval
-                U1D(I,J) = spval
-                V1D(I,J) = spval
-                T1D(I,J) = spval
-                Z1D(I,J) = spval
-                SHR1D(I,J) = spval
-              endif
-
-            END DO
-          END DO
+         CALL TRPAUS2(P1D(1:IM,1:JM),T1D(1:IM,1:JM),Z1D(1:IM,1:JM),&
+     &                U1D(1:IM,1:JM),V1D(1:IM,1:JM),SHR1D(1:IM,1:JM))
 !
 !        TROPOPAUSE PRESSURE.
          IF (IGET(054) > 0) THEN
+             GRID1=spval
 !$omp parallel do private(i,j)
              DO J=JSTA,JEND
                DO I=ISTA,IEND

--- a/sorc/ncep_post.fd/TRPAUS2.f
+++ b/sorc/ncep_post.fd/TRPAUS2.f
@@ -1,0 +1,130 @@
+!> @file
+!> @brief trpaus2() computes tropopause level fields.
+!> 
+!> This routine computes tropopause data.
+!> Code is adapted from original routine trpaus().
+!> 
+!> At each mass point a downward search is made for the 
+!> first occurrence of a local stability parameter
+!> (based on the square of the Brunt-Vaisalla frequency)
+!> exceeding the value of Rd / Cp - as used by ECMWF.
+!> A maximum tropopause pressure of ~500mb is enforced.
+!> Once the tropopause is located in a column, pressure,
+!> temperature, u and v winds, and vertical wind shear
+!> are computed.
+!>
+!> ### Program history log:
+!> Date | Programmer | Comments
+!> -----|------------|---------
+!> 1992-12-22 | Russ Treadon  | Initial
+!> 1997-03-06 | Geoff Manikin | Changed criteria for determining the tropopause and added height
+!> 1998-06-15 | T Black       | Conversion from 1-D TO 2-D
+!> 2000-01-04 | Jim Tuccillo  | MPI Version
+!> 2002-04-23 | Mike Baldwin  | WRF Version
+!> 2019-10-30 | Bo Cui        | ReMOVE "GOTO" STATEMENT
+!> 2021-09-13 | JESSE MENG    | 2D DECOMPOSITION
+!> 2026-05-20 | C Hill        | Alternative, ECMWF-employed algorithm 
+!>
+!> @author Russ Treadon W/NP2 @date 1992-12-22
+!------------------------------------------------------------------------------
+!> @brief Computes tropopause data.
+!> 
+!> @param[out] PTROP Tropopause pressure.
+!> @param[out] TTROP Tropopause temperature.
+!> @param[out] ZTROP Tropopause height.
+!> @param[out] UTROP Tropopause u wind component.
+!> @param[out] VTROP Tropopause v wind component.
+!> @param[out] SHTROP Vertical wind shear at tropopause.
+!>
+      SUBROUTINE TRPAUS2(PTROP,TTROP,ZTROP,UTROP,VTROP,SHTROP)
+
+!     
+!     
+!     INCLUDE ETA GRID DIMENSIONS.  SET/DERIVE PARAMETERS.
+!
+       use vrbls3d,    only: pint, t, zint, pmid, zmid, uh, vh
+       use masks,      only: lmh
+       use physcons_post, only: CON_G, CON_RD, CON_ROCP
+       use ctlblk_mod, only: jsta, jend, spval, im, jm, lm, ista, iend
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+       implicit none
+!
+!     PARAMETER TRPPRM SPECIFIES A LOCAL STABILITY VALUE
+!     (IN ---) FOR IDENTIFYING THE TROPOPAUSE.  WE START 
+!     LOOKING FOR THE TROPOPAUSE BEGINNING AT PRESSURE LEVEL
+!     'PSTART' (IN PASCALS) AND DOWNWARD TO 'PEND'.
+      real,PARAMETER :: PSTART=7.0E3, PEND=5.0E4
+      real,PARAMETER :: N02=2.5E-4
+!     
+!     DECLARE VARIABLES.
+!     
+      REAL,dimension(IM,JM) :: PTROP,TTROP,ZTROP,UTROP,VTROP,SHTROP
+      REAL TRPPRM(LM)
+!
+      integer I,J,LLMH,L
+      real PM,DELT,DZ,DP,RSQDIF
+!     
+!*****************************************************************************
+!     START TRPAUS HERE.
+!     
+!     LOOP OVER THE HORIZONTAL GRID.
+!    
+      DO J=JSTA,JEND
+      DO I=ISTA,IEND
+         PTROP(I,J)  = SPVAL
+         TTROP(I,J)  = SPVAL
+         ZTROP(I,J)  = SPVAL
+         UTROP(I,J)  = SPVAL
+         VTROP(I,J)  = SPVAL
+         SHTROP(I,J) = SPVAL
+      ENDDO
+      ENDDO
+!
+!!!$omp parallel do private(i,j,delt,dz,dp,l,llmh,pm,pmd,rsqdif,trpprm)
+
+       DO J=JSTA,JEND
+        DO I=ISTA,IEND
+!     
+!        COMPUTE A STABILITY PARAMETER AT EACH ETA LAYER DESCENDING
+!        FROM THE TOP LEVEL. THE FIRST ETA LAYER BELOW PRESSURE
+!        LEVEL "PSTART" WHERE THE {PARAMETER > Rd / Cp} IS
+!        LABELED THE TROPOPAUSE.
+!
+        LLMH=NINT(LMH(I,J))
+!
+        TRPLVL = .FALSE.
+        loopL: DO L = 2,LLMH-1
+        PM     = PINT(I,J,L)
+        DELT   = T(I,J,L-1)-T(I,J,L)
+        DP     = PMID(I,J,L-1)-PMID(I,J,L)
+        TRPPRM(L) = ((PMID(I,J,L)/T(I,J,L))*(DELT/DP)) &
+     &              +((CON_RD*T(I,J,L)/(CON_G**2.))*N02)
+!
+        IF ((PM>PSTART).AND.(PM<PEND)) THEN
+         IF (TRPPRM(L)>CON_ROCP) THEN
+          TRPLVL = .TRUE.
+!
+          PTROP(I,J)  = PMID(I,J,L)
+          TTROP(I,J)  = T(I,J,L)
+          ZTROP(I,J)  = ZMID(I,J,L)
+!
+          UTROP (I,J) = UH(I,J,L)
+          VTROP (I,J) = VH(I,J,L)
+          DZ        = ZINT(I,J,L)-ZINT(I,J,L+1)
+          RSQDIF    = SQRT(((UH(I,J,L-1)-UH(I,J,L+1))*0.5)**2. &
+     &                    +((VH(I,J,L-1)-VH(I,J,L+1))*0.5)**2.)
+          SHTROP(I,J) = RSQDIF/DZ
+         ENDIF
+        ENDIF
+
+        IF (TRPLVL == .TRUE.) EXIT loopL
+        ENDDO loopL
+
+       ENDDO !end I
+      ENDDO !end J
+
+!     
+!     END OF ROUTINE.
+!     
+      RETURN
+      END


### PR DESCRIPTION
As described in comments to #1055, an alternative method of determining the tropopause level (i.e. pressure and height) is introduced for GFS output.  Use of this method is intended to allay the concern that tropopause levels from the GFS are often presented as being too high.

The initial iteration of this PR replaces the call to subroutine TPAUSE (stored in [GFSPOST.F](https://github.com/NOAA-EMC/UPP/blob/develop/sorc/ncep_post.fd/GFSPOST.F)) within the routine [MISCLN.f](https://github.com/NOAA-EMC/UPP/blob/develop/sorc/ncep_post.fd/MISCLN.f) with a call to a modified [TRPAUS.f](https://github.com/NOAA-EMC/UPP/blob/develop/sorc/ncep_post.fd/TRPAUS.f) routine (named in this PR as TRPAUS2.f).

The formula encoded in TRPAUS2.f is adapted from page 94, under section 6.12 "Tropopause Pressure" of the ECMWF IFS [document](https://www.ecmwf.int/sites/default/files/elibrary/2021/81271-ifs-documentation-cy47r3-part-iv-physical-processes_1.pdf) Cy47r3, part IV on "Physical Properties".

As testing results (provided in #1055) indicate some noise with the TRPAUS2 calculations, the TPAUSE method currently used to determine the tropopause level should not be removed -- requiring additional modification to MISCLN.f to include both TPAUSE and TRPAUS2, and new modification to the parameter files to include unique entries for the TRPAUS2-calculated values of height, ICAO height, temperature, pressure, wind, and wind shear.