### PR TITLE
Add WAFS RT and update HAFS baseline data

### DIFF
--- a/ci/jobs-dev/run_post_dafs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_dafs_WCOSS2.sh
@@ -116,5 +116,5 @@ postmsg "$logfile" "$msg"
 done
 
 echo "PROGRAM IS COMPLETE!!!!!" 2>&1 | tee SUCCESS
-msg="Ending rrfs_ifi test"
+msg="Ending dafs test"
 postmsg "$logfile" "$msg"

--- a/ci/jobs-dev/run_post_hafs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_hafs_WCOSS2.sh
@@ -37,8 +37,8 @@ postmsg "$logfile" "$msg"
 export POSTGPEXEC=${svndir}/exec/upp.x
 
 # specify forecast start time and hour for running your post job
-export startdate=2022092800
-export fhr=009
+export startdate=2024092406
+export fhr=042
 export tmmark=tm00
 
 # specify your running and output directory

--- a/ci/jobs-dev/run_post_hafs_template.sh
+++ b/ci/jobs-dev/run_post_hafs_template.sh
@@ -38,8 +38,8 @@ postmsg "$logfile" "$msg"
 export POSTGPEXEC=${svndir}/exec/upp.x
 
 # specify forecast start time and hour for running your post job
-export startdate=2022092800
-export fhr=009
+export startdate=2024092406
+export fhr=042
 export tmmark=tm00
 
 # specify your running and output directory

--- a/ci/jobs-dev/run_post_wafs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_wafs_WCOSS2.sh
@@ -54,13 +54,13 @@ export HH=`echo $NEWDATE | cut -c9-10`
 
 cat > itag <<EOF
 &model_inputs
-fileName='$homedir/data_in/gfs/gfs.t${cyc}z.atmf${fhr}.nc'
+fileName='$homedir/data_in/wafs/gfs.t${cyc}z.atmf${fhr}.nc'
 IOFORM='netcdf'
 grib='grib2'
 DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
 MODELNAME='GFS'
 SUBMODELNAME='GFS'
-fileNameFlux='$homedir/data_in/gfs/gfs.t${cyc}z.sfcf${fhr}.nc'
+fileNameFlux='$homedir/data_in/wafs/gfs.t${cyc}z.sfcf${fhr}.nc'
 /
 &NAMPGB
 KPO=60,PO=97720.,94210.,90810.,87510.,84310.,81200.,78190.,75260.,72430.,69680.,67020.,64440.,61940.,59520.,57180.,54920.,52720.,50600.,48550.,46560.,44650.,42790.,41000.,39270.,37600.,35990.,34430.,32930.,31490.,30090.,28740.,27450.,26200.,25000.,23840.,22730.,21660.,20650.,19680.,18750.,17870.,17040.,16240.,15470.,14750.,14060.,13400.,12770.,12170.,11600.,11050.,10530.,10040.,9570.,9120.,8700.,8280.,7900.,7520.,7170.,gtg_on=.true.,popascal=.true.,

--- a/ci/jobs-dev/run_post_wafs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_wafs_WCOSS2.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+#PBS -o out.post.wafs
+#PBS -e out.post.wafs
+#PBS -N wafs_test
+#PBS -l walltime=00:30:00
+#PBS -q debug
+#PBS -A GFS-DEV
+#PBS -l place=vscatter,select=2:ncpus=48:mem=300GB
+#PBS -V
+
+set -x
+
+# specify computation resources
+export threads=1
+export OMP_NUM_THREADS=$threads
+export APRUN="mpiexec -l -n 96 -ppn 48"
+
+echo "starting time"
+date
+
+############################################
+# Loading modules
+############################################
+module reset
+module use ${svndir}/modulefiles
+module load wcoss2_intel
+module load cray-pals/1.0.12
+module load libjpeg/9c
+module load prod_util/2.0.14
+module load wgrib2/2.0.8
+module list
+
+msg="Starting wafs test"
+postmsg "$logfile" "$msg"
+
+export POSTGPEXEC=${svndir}/exec/upp.x
+
+# specify forecast start time and hour for running your post job
+export startdate=2025012600
+export fhr=006
+export cyc=`echo $startdate |cut -c9-10`
+
+# specify your running and output directory
+export DATA=$rundir/wafs_${startdate}
+rm -rf $DATA; mkdir -p $DATA
+cd $DATA
+
+export NEWDATE=`${NDATE} +${fhr} $startdate`
+export YY=`echo $NEWDATE | cut -c1-4`
+export MM=`echo $NEWDATE | cut -c5-6`
+export DD=`echo $NEWDATE | cut -c7-8`
+export HH=`echo $NEWDATE | cut -c9-10`
+
+cat > itag <<EOF
+&model_inputs
+fileName='$homedir/data_in/gfs/gfs.t${cyc}z.atmf${fhr}.nc'
+IOFORM='netcdf'
+grib='grib2'
+DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
+MODELNAME='GFS'
+SUBMODELNAME='GFS'
+fileNameFlux='$homedir/data_in/gfs/gfs.t${cyc}z.sfcf${fhr}.nc'
+/
+&NAMPGB
+KPO=60,PO=97720.,94210.,90810.,87510.,84310.,81200.,78190.,75260.,72430.,69680.,67020.,64440.,61940.,59520.,57180.,54920.,52720.,50600.,48550.,46560.,44650.,42790.,41000.,39270.,37600.,35990.,34430.,32930.,31490.,30090.,28740.,27450.,26200.,25000.,23840.,22730.,21660.,20650.,19680.,18750.,17870.,17040.,16240.,15470.,14750.,14060.,13400.,12770.,12170.,11600.,11050.,10530.,10040.,9570.,9120.,8700.,8280.,7900.,7520.,7170.,gtg_on=.true.,popascal=.true.,
+/
+EOF
+
+# copy fix data
+cp ${svndir}/fix/nam_micro_lookup.dat                     ./eta_micro_lookup.dat
+cp ${svndir}/parm/wafs/postxconfig-NT-gfs-wafs.txt        ./postxconfig-NT.txt
+cp ${svndir}/parm/params_grib2_tbl_new                    ./params_grib2_tbl_new
+cp ${svndir}/sorc/ncep_post.fd/post_gtg.fd/gtg.config.gfs .
+cp ${svndir}/sorc/ncep_post.fd/post_gtg.fd/gtg.input.gfs  .
+cp ${svndir}/sorc/ncep_post.fd/post_gtg.fd/imprintings.gtg_gfs.txt .
+
+# Run the UPP
+${APRUN} ${POSTGPEXEC} < itag > outpost_wafs_${NEWDATE}
+
+################################################
+# Compare with baseline data
+################################################
+fhr=`expr $fhr + 0`
+fhr2=`printf "%02d" $fhr`
+
+# WAFS post processing generates 1 file
+filelist="GFSPRS.GrbF${fhr2}"
+
+for file in $filelist; do
+export filein2=$file
+ls -l ${filein2}
+export err=$?
+
+if [ $err = "0" ] ; then
+
+ # use cmp to see if new pgb files are identical to the control one
+ cmp ${filein2} $homedir/data_out/wafs/${filein2}.${machine}
+
+ # if not bit-identical, use cmp_grib2_grib2 to compare each grib record
+ export err1=$?
+ if [ $err1 -eq 0 ] ; then
+  msg="wafs test: your new post executable generates bit-identical ${filein2} as the develop branch"
+  echo $msg
+ else
+  msg="wafs test: your new post executable did not generate bit-identical ${filein2} as the develop branch"
+  echo $msg
+  echo " start comparing each grib record and write the comparison result to *diff files"
+  echo " check these *diff files to make sure your new post only change variables which you intend to change"
+  $cmp_grib2_grib2 $homedir/data_out/wafs/${filein2}.${machine} ${filein2} > ${filein2}.diff
+ fi
+else
+ msg="wafs test: post failed using your new post executable to generate ${filein2}"
+ echo $msg 2>&1 | tee -a TEST_ERROR
+fi
+
+postmsg "$logfile" "$msg"
+done
+
+echo "PROGRAM IS COMPLETE!!!!!" 2>&1 | tee SUCCESS
+msg="Ending wafs test"
+postmsg "$logfile" "$msg"

--- a/ci/runtime.log.WCOSS2_intel
+++ b/ci/runtime.log.WCOSS2_intel
@@ -12,5 +12,6 @@ hafs_test 00:02:00
 mpas_test 00:02:40
 mpas_hfip_test 00:05:00
 gcafs_test 00:05:30
+wafs_test 00:07:00
 rrfs_test 00:10:00
 gfs_test 00:15:00

--- a/ci/submit_jobs_WCOSS2.sh
+++ b/ci/submit_jobs_WCOSS2.sh
@@ -3,6 +3,7 @@
 # This script is used to submit test jobs on WCOSS2.
 # # Wen Meng  05/2025  First version.
 # # Ben Blake 04/2026  Remove RRFS IFI support
+# # Ben Blake 05/2026  Add WAFS test
 # ##########################################################################
 
 jobid_list=""
@@ -27,7 +28,7 @@ fi
 
 # Run additional GTG tests
 if [[ "$have_ifi" == "yes" && "$disable_ifi" == "no" && "$have_gtg" == "yes" && "$disable_gtg" == "no" ]] ; then
-  for gtg_test in dafs; do
+  for gtg_test in dafs wafs; do
     cp $svndir/ci/jobs-dev/run_post_${gtg_test}_${machine}.sh .
     job_id=$(qsub -A "${accnr}" run_post_${gtg_test}_${machine}.sh)
     jobid_list="${jobid_list} ${job_id}"

--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,63 +1,64 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-91cfa98c787109ee991626ef6c9925dc395ca9da
+f5685305cd7b9a6f1c0071740197213c7e619b3a
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
--3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
+-c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/role-epic/jenkins/workspace/UPP_UPP-Pipeline_PR-1542/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1544_orion_hercules/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:11m:42s
-Test Date: 20260528 22:52:33
+Total runtime: 00h:12m:28s
+Test Date: 20260603 08:14:04
 Summary Results:
 
-05/29 03:43:05Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-05/29 03:43:06Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-05/29 03:43:13Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-05/29 03:43:28Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-05/29 03:43:40Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-05/29 03:43:44Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-05/29 03:43:44Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-05/29 03:43:45Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-05/29 03:43:53Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-05/29 03:43:54Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-05/29 03:44:03Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-05/29 03:44:04Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-05/29 03:44:04Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-05/29 03:44:06Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-05/29 03:44:07Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-05/29 03:44:08Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-05/29 03:44:52Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-05/29 03:44:53Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-05/29 03:44:54Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-05/29 03:44:54Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-05/29 03:44:55Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-05/29 03:44:55Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-05/29 03:45:49Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-05/29 03:45:50Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-05/29 03:50:46Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-05/29 03:50:47Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-05/29 03:50:47Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-05/29 03:52:06Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-05/29 03:52:28Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-05/29 03:52:30Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-05/29 03:43:27Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
-05/29 03:43:27Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
-05/29 03:43:27Z -Runtime: gefsv12_test 00:00:15 -- baseline 00:01:00
-05/29 03:43:42Z -Runtime: gefsv13_test 00:00:42 -- baseline 00:02:00
-05/29 03:44:12Z -Runtime: nmmb_test 00:01:06 -- baseline 00:03:00
-05/29 03:44:12Z -Runtime: rap_test 00:00:56 -- baseline 00:02:00
-05/29 03:44:57Z -Runtime: hrrr_test 00:01:57 -- baseline 00:06:00
-05/29 03:44:57Z -Runtime: hafs_test 00:00:30 -- baseline 00:01:00
-05/29 03:44:57Z -Runtime: 3drtma_test 00:00:47 -- baseline 00:03:00
-05/29 03:44:57Z -Runtime: mpas_test 00:01:10 -- baseline 00:02:30
-05/29 03:44:57Z -Runtime: mpas_hfip_test 00:01:58 -- baseline 00:05:00
-05/29 03:45:57Z -Runtime: gcafs_test 00:02:52 -- baseline 00:02:30
-05/29 03:52:33Z -Runtime: rrfs_test 00:09:32 -- baseline 00:12:00
-05/29 03:52:33Z -Runtime: gfs_test 00:07:49 -- baseline 00:25:00
+06/03 13:04:40Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/03 13:04:44Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/03 13:04:47Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/03 13:05:06Z -hafs test: your new post executable did not generate bit-identical HURPRS42.tm00 as the develop branch
+06/03 13:05:14Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/03 13:05:19Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/03 13:05:20Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/03 13:05:20Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/03 13:05:30Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/03 13:05:30Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/03 13:05:41Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/03 13:05:41Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/03 13:05:42Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/03 13:05:43Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/03 13:05:44Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/03 13:05:44Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/03 13:06:07Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/03 13:06:08Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/03 13:06:08Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/03 13:06:22Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/03 13:06:23Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/03 13:06:24Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/03 13:07:13Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/03 13:07:14Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/03 13:12:14Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/03 13:12:15Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/03 13:12:15Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/03 13:13:33Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/03 13:13:51Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/03 13:13:53Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/03 13:05:01Z -Runtime: sfs_test 00:00:12 -- baseline 00:01:20
+06/03 13:05:02Z -Runtime: aqm_test 00:00:09 -- baseline 00:00:30
+06/03 13:05:02Z -Runtime: gefsv12_test 00:00:15 -- baseline 00:01:00
+06/03 13:05:17Z -Runtime: gefsv13_test 00:00:42 -- baseline 00:02:00
+06/03 13:05:47Z -Runtime: nmmb_test 00:01:12 -- baseline 00:03:00
+06/03 13:05:47Z -Runtime: rap_test 00:00:58 -- baseline 00:02:00
+06/03 13:06:32Z -Runtime: hrrr_test 00:01:52 -- baseline 00:06:00
+06/03 13:06:32Z -Runtime: hafs_test 00:00:34 -- baseline 00:01:00
+06/03 13:06:32Z -Runtime: 3drtma_test 00:00:48 -- baseline 00:03:00
+06/03 13:06:32Z -Runtime: mpas_test 00:01:10 -- baseline 00:02:30
+06/03 13:06:32Z -Runtime: mpas_hfip_test 00:01:37 -- baseline 00:05:00
+06/03 13:07:18Z -Runtime: gcafs_test 00:02:42 -- baseline 00:02:30
+06/03 13:14:04Z -Runtime: rrfs_test 00:09:21 -- baseline 00:12:00
+06/03 13:14:04Z -Runtime: gfs_test 00:07:43 -- baseline 00:25:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-No changes in test results detected.
+There are changes in results for case hafs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1544_orion_hercules/ci/rundir/upp-HERCULES/hafs_2024092406/HURPRS42.tm00
+Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1544_orion_hercules/ci/rundir/upp-HERCULES for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,63 +1,64 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-91cfa98c787109ee991626ef6c9925dc395ca9da
+f5685305cd7b9a6f1c0071740197213c7e619b3a
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
--3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
+-c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work/noaa/epic/role-epic/jenkins/workspace/UPP_UPP-Pipeline_PR-1542/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1544_orion_intel/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 00h:20m:10s
-Test Date: 20260528 23:13:12
+Total runtime: 00h:32m:20s
+Test Date: 20260603 08:33:52
 Summary Results:
 
-05/29 03:56:51Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-05/29 03:56:52Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-05/29 03:57:05Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-05/29 03:57:17Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-05/29 03:57:35Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-05/29 03:58:05Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-05/29 03:58:06Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-05/29 03:58:06Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-05/29 03:58:23Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-05/29 03:58:23Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-05/29 03:58:31Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-05/29 03:58:32Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-05/29 03:58:33Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-05/29 03:58:33Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-05/29 03:58:34Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-05/29 03:58:35Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-05/29 03:59:47Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-05/29 03:59:48Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-05/29 04:00:10Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-05/29 04:00:14Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-05/29 04:00:16Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-05/29 04:00:20Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-05/29 04:00:21Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-05/29 04:00:23Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-05/29 04:08:14Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-05/29 04:08:16Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-05/29 04:08:16Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-05/29 04:12:38Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-05/29 04:13:01Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-05/29 04:13:06Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-05/29 03:57:09Z -Runtime: sfs_test 00:00:13 -- baseline 00:01:20
-05/29 03:57:09Z -Runtime: aqm_test 00:00:12 -- baseline 00:00:30
-05/29 03:57:09Z -Runtime: gefsv12_test 00:00:27 -- baseline 00:01:00
-05/29 03:57:39Z -Runtime: gefsv13_test 00:00:56 -- baseline 00:02:00
-05/29 03:58:10Z -Runtime: nmmb_test 00:01:27 -- baseline 00:03:00
-05/29 03:58:25Z -Runtime: rap_test 00:01:43 -- baseline 00:02:00
-05/29 04:00:25Z -Runtime: hrrr_test 00:03:43 -- baseline 00:08:00
-05/29 04:00:25Z -Runtime: hafs_test 00:00:37 -- baseline 00:01:00
-05/29 04:00:25Z -Runtime: 3drtma_test 00:01:53 -- baseline 00:03:00
-05/29 04:00:25Z -Runtime: mpas_test 00:01:55 -- baseline 00:02:30
-05/29 04:00:25Z -Runtime: mpas_hfip_test 00:03:37 -- baseline 00:05:00
-05/29 04:00:25Z -Runtime: gcafs_test 00:03:08 -- baseline 00:03:15
-05/29 04:13:12Z -Runtime: rrfs_test 00:16:26 -- baseline 00:17:00
-05/29 04:13:12Z -Runtime: gfs_test 00:11:36 -- baseline 00:26:00
+06/03 13:07:26Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/03 13:07:28Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/03 13:07:55Z -hafs test: your new post executable did not generate bit-identical HURPRS42.tm00 as the develop branch
+06/03 13:08:36Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/03 13:08:37Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/03 13:08:37Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/03 13:08:59Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/03 13:09:00Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/03 13:10:55Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/03 13:10:56Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/03 13:10:57Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/03 13:12:39Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/03 13:13:10Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/03 13:14:10Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/03 13:14:10Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/03 13:14:11Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/03 13:15:20Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/03 13:15:21Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/03 13:19:08Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/03 13:19:08Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/03 13:19:09Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/03 13:27:50Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/03 13:27:52Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/03 13:27:52Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/03 13:33:05Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/03 13:33:26Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/03 13:33:29Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/03 13:33:48Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/03 13:33:50Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/03 13:33:50Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/03 13:07:34Z -Runtime: sfs_test 00:00:10 -- baseline 00:01:20
+06/03 13:07:34Z -Runtime: aqm_test 00:00:12 -- baseline 00:00:30
+06/03 13:12:49Z -Runtime: gefsv12_test 00:00:23 -- baseline 00:01:00
+06/03 13:13:20Z -Runtime: gefsv13_test 00:00:54 -- baseline 00:02:00
+06/03 13:13:20Z -Runtime: nmmb_test 00:01:21 -- baseline 00:03:00
+06/03 13:13:20Z -Runtime: rap_test 00:01:44 -- baseline 00:02:00
+06/03 13:13:20Z -Runtime: hrrr_test 00:03:41 -- baseline 00:08:00
+06/03 13:13:20Z -Runtime: hafs_test 00:00:39 -- baseline 00:01:00
+06/03 13:14:20Z -Runtime: 3drtma_test 00:01:55 -- baseline 00:03:00
+06/03 13:19:21Z -Runtime: mpas_test 00:01:53 -- baseline 00:02:30
+06/03 13:28:07Z -Runtime: mpas_hfip_test 00:03:34 -- baseline 00:05:00
+06/03 13:28:07Z -Runtime: gcafs_test 00:03:05 -- baseline 00:03:15
+06/03 13:33:37Z -Runtime: rrfs_test 00:16:13 -- baseline 00:17:00
+06/03 13:33:52Z -Runtime: gfs_test 00:11:33 -- baseline 00:26:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-No changes in test results detected.
+There are changes in results for case hafs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1544_orion_intel/ci/rundir/upp-ORION/hafs_2024092406/HURPRS42.tm00
+Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/orion/1544_orion_intel/ci/rundir/upp-ORION for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,63 +1,63 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-91cfa98c787109ee991626ef6c9925dc395ca9da
+f5685305cd7b9a6f1c0071740197213c7e619b3a
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
--3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
+-c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch3/NAGAPE/epic/role-epic/jenkins/workspace/UPP_UPP-Pipeline_PR-1542/ci/rundir/upp-URSA
+Run directory: /scratch3/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1544_ursa_intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:10m:36s
-Test Date: 20260529 04:24:33
+Total runtime: 02h:02m:55s
+Test Date: 20260603 15:45:24
 Summary Results:
 
-05/29 04:16:09Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-05/29 04:16:18Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-05/29 04:16:32Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-05/29 04:17:06Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-05/29 04:17:08Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-05/29 04:17:09Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-05/29 04:17:10Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-05/29 04:17:13Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-05/29 04:17:14Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-05/29 04:17:15Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-05/29 04:17:30Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-05/29 04:18:05Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-05/29 04:18:05Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-05/29 04:18:06Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-05/29 04:18:06Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-05/29 04:18:30Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-05/29 04:18:31Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-05/29 04:18:32Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-05/29 04:18:36Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-05/29 04:18:37Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-05/29 04:18:38Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-05/29 04:20:34Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-05/29 04:20:36Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-05/29 04:20:37Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-05/29 04:21:25Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-05/29 04:21:26Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-05/29 04:21:26Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-05/29 04:24:08Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-05/29 04:24:13Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-05/29 04:24:18Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-05/29 04:16:46Z -Runtime: sfs_test 00:00:10 -- baseline 00:01:20
-05/29 04:16:47Z -Runtime: aqm_test 00:00:09 -- baseline 00:00:30
-05/29 04:17:17Z -Runtime: gefsv12_test 00:00:33 -- baseline 00:02:00
-05/29 04:17:32Z -Runtime: gefsv13_test 00:00:44 -- baseline 00:02:00
-05/29 04:18:47Z -Runtime: nmmb_test 00:01:03 -- baseline 00:02:00
-05/29 04:18:47Z -Runtime: rap_test 00:00:48 -- baseline 00:02:00
-05/29 04:18:47Z -Runtime: hrrr_test 00:01:36 -- baseline 00:03:00
-05/29 04:18:47Z -Runtime: hafs_test 00:00:30 -- baseline 00:01:30
-05/29 04:18:47Z -Runtime: 3drtma_test 00:01:22 -- baseline 00:01:30
-05/29 04:18:47Z -Runtime: mpas_test 00:01:24 -- baseline 00:02:30
-05/29 04:20:47Z -Runtime: mpas_hfip_test 00:03:19 -- baseline 00:05:00
-05/29 04:20:47Z -Runtime: gcafs_test 00:01:48 -- baseline 00:02:00
-05/29 04:24:33Z -Runtime: rrfs_test 00:06:46 -- baseline 00:07:00
-05/29 04:24:33Z -Runtime: gfs_test 00:05:26 -- baseline 00:15:00
+06/03 13:45:40Z -hafs test: your new post executable did not generate bit-identical HURPRS42.tm00 as the develop branch
+06/03 13:46:18Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/03 13:46:18Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/03 13:46:19Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/03 13:46:19Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/03 13:46:19Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/03 13:46:20Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/03 13:54:20Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/03 13:54:26Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/03 13:54:27Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/03 13:55:20Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/03 13:55:22Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/03 13:55:23Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/03 15:36:27Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/03 15:38:32Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/03 15:38:40Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/03 15:38:41Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/03 15:38:41Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/03 15:38:56Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/03 15:39:07Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/03 15:39:08Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/03 15:39:42Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/03 15:39:43Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/03 15:39:44Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/03 15:39:47Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/03 15:39:48Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/03 15:39:49Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/03 15:44:55Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/03 15:45:05Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/03 15:45:10Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/03 14:59:50Z -Runtime: aqm_test 00:00:05 -- baseline 00:00:30
+06/03 15:38:38Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
+06/03 15:39:08Z -Runtime: gefsv13_test 00:00:36 -- baseline 00:02:00
+06/03 15:39:53Z -Runtime: nmmb_test 00:00:24 -- baseline 00:02:00
+06/03 15:39:53Z -Runtime: rap_test 00:00:48 -- baseline 00:02:00
+06/03 15:39:53Z -Runtime: hrrr_test 00:01:29 -- baseline 00:03:00
+06/03 15:39:53Z -Runtime: hafs_test 00:00:27 -- baseline 00:01:30
+06/03 15:39:53Z -Runtime: 3drtma_test 00:01:07 -- baseline 00:01:30
+06/03 15:39:53Z -Runtime: mpas_test 00:01:06 -- baseline 00:02:30
+06/03 15:39:53Z -Runtime: mpas_hfip_test 00:03:09 -- baseline 00:05:00
+06/03 15:39:53Z -Runtime: gcafs_test 00:01:13 -- baseline 00:02:00
+06/03 15:45:24Z -Runtime: rrfs_test 00:06:50 -- baseline 00:07:00
+06/03 15:45:24Z -Runtime: gfs_test 00:05:23 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-No changes in test results detected.
+There are changes in results for case hafs in /scratch3/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1544_ursa_intel/ci/rundir/upp-URSA/hafs_2024092406/HURPRS42.tm00
+Refer to .diff files in rundir: /scratch3/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1544_ursa_intel/ci/rundir/upp-URSA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,63 +1,63 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-91cfa98c787109ee991626ef6c9925dc395ca9da
+f5685305cd7b9a6f1c0071740197213c7e619b3a
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
--3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd
+-c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch3/NAGAPE/epic/role-epic/jenkins/workspace/UPP_UPP-Pipeline_PR-1542/ci/rundir/upp-URSA
+Run directory: /scratch3/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1544_ursa_intelllvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:07m:45s
-Test Date: 20260529 04:32:37
+Total runtime: 01h:51m:49s
+Test Date: 20260603 15:34:26
 Summary Results:
 
-05/29 04:26:17Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-05/29 04:26:17Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-05/29 04:26:31Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-05/29 04:26:33Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-05/29 04:27:10Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-05/29 04:27:11Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-05/29 04:27:12Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-05/29 04:27:15Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-05/29 04:27:16Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-05/29 04:27:16Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-05/29 04:27:21Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-05/29 04:27:31Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-05/29 04:27:32Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-05/29 04:27:57Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-05/29 04:27:58Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-05/29 04:28:05Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-05/29 04:28:06Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-05/29 04:28:07Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-05/29 04:28:14Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-05/29 04:28:15Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-05/29 04:28:15Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-05/29 04:30:06Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-05/29 04:30:08Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-05/29 04:30:08Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-05/29 04:31:36Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-05/29 04:31:37Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-05/29 04:31:37Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-05/29 04:32:19Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-05/29 04:32:23Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-05/29 04:32:33Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-05/29 04:26:21Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
-05/29 04:26:36Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
-05/29 04:26:36Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
-05/29 04:27:36Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
-05/29 04:28:21Z -Runtime: nmmb_test 00:01:08 -- baseline 00:01:30
-05/29 04:28:21Z -Runtime: rap_test 00:00:40 -- baseline 00:02:00
-05/29 04:28:21Z -Runtime: hrrr_test 00:01:19 -- baseline 00:02:30
-05/29 04:28:21Z -Runtime: hafs_test 00:00:26 -- baseline 00:01:30
-05/29 04:28:21Z -Runtime: 3drtma_test 00:01:25 -- baseline 00:01:30
-05/29 04:28:21Z -Runtime: mpas_test 00:01:21 -- baseline 00:02:30
-05/29 04:30:21Z -Runtime: mpas_hfip_test 00:03:16 -- baseline 00:05:00
-05/29 04:30:21Z -Runtime: gcafs_test 00:01:18 -- baseline 00:02:30
-05/29 04:32:37Z -Runtime: rrfs_test 00:06:20 -- baseline 00:06:00
-05/29 04:32:37Z -Runtime: gfs_test 00:05:00 -- baseline 00:15:00
+06/03 13:44:43Z -hafs test: your new post executable did not generate bit-identical HURPRS42.tm00 as the develop branch
+06/03 13:45:22Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/03 13:45:23Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/03 13:45:24Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/03 13:45:28Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/03 13:45:29Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/03 13:45:30Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/03 13:47:32Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/03 13:47:34Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/03 13:47:34Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/03 13:50:20Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/03 13:50:31Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/03 13:50:36Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/03 13:52:24Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/03 13:52:25Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/03 13:53:22Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/03 13:53:24Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/03 13:56:05Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/03 13:56:05Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/03 13:56:06Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/03 14:38:47Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/03 14:38:48Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/03 14:38:49Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/03 15:28:29Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/03 15:29:51Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/03 15:29:57Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/03 15:29:58Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/03 15:34:19Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/03 15:34:19Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/03 15:34:20Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/03 13:53:33Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
+06/03 13:53:33Z -Runtime: aqm_test 00:00:10 -- baseline 00:00:30
+06/03 15:29:55Z -Runtime: gefsv13_test 00:00:34 -- baseline 00:02:00
+06/03 15:34:25Z -Runtime: nmmb_test 00:01:02 -- baseline 00:01:30
+06/03 15:34:25Z -Runtime: rap_test 00:00:41 -- baseline 00:02:00
+06/03 15:34:25Z -Runtime: hrrr_test 00:01:14 -- baseline 00:02:30
+06/03 15:34:25Z -Runtime: hafs_test 00:00:30 -- baseline 00:01:30
+06/03 15:34:25Z -Runtime: 3drtma_test 00:01:17 -- baseline 00:01:30
+06/03 15:34:25Z -Runtime: mpas_test 00:01:11 -- baseline 00:02:30
+06/03 15:34:25Z -Runtime: mpas_hfip_test 00:03:21 -- baseline 00:05:00
+06/03 15:34:25Z -Runtime: gcafs_test 00:01:11 -- baseline 00:02:30
+06/03 15:34:25Z -Runtime: rrfs_test 00:06:23 -- baseline 00:06:00
+06/03 15:34:25Z -Runtime: gfs_test 00:04:52 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-No changes in test results detected.
+There are changes in results for case hafs in /scratch3/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1544_ursa_intelllvm/ci/rundir/upp-URSA/hafs_2024092406/HURPRS42.tm00
+Refer to .diff files in rundir: /scratch3/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1544_ursa_intelllvm/ci/rundir/upp-URSA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,68 +1,71 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-8a65eb5c1fe75cb54790b5b01eb151714a128b73
+e990a075ee258cba231b4f12ecc66d340ede3020
 
 Submodule hashes:
  68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd (fip_v2.0.0-39-g68953f5)
- 3d35332fe66e3e63a285cc8d96facdf255a33481 sorc/ncep_post.fd/post_gtg.fd (ncep_post_gtg.v1.0.6-64-g3d35332)
+ c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd (ncep_post_gtg.v1.0.6-71-gc49023a)
 
-Run directory: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2
+Run directory: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:20m:13s
-Test Date: 20260528 13:08:55
+Total runtime: 00h:31m:54s
+Test Date: 20260604 13:03:21
 Summary Results:
 
-05/28 12:56:02Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-05/28 12:56:12Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-05/28 12:56:21Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-05/28 12:56:54Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
-05/28 12:56:57Z -hafs test: your new post executable generates bit-identical HURPRS09.tm00 as the develop branch
-05/28 12:57:07Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-05/28 12:57:07Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
-05/28 12:57:07Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
-05/28 12:57:08Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-05/28 12:57:08Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-05/28 12:57:09Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-05/28 12:57:10Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-05/28 12:57:15Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-05/28 12:57:31Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-05/28 12:57:33Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-05/28 12:57:34Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-05/28 12:57:43Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-05/28 12:57:43Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-05/28 12:57:45Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-05/28 12:58:33Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-05/28 12:58:34Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-05/28 12:58:36Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-05/28 12:59:05Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-05/28 12:59:06Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-05/28 12:59:46Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-05/28 12:59:48Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-05/28 12:59:50Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-05/28 13:06:39Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-05/28 13:06:40Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-05/28 13:06:40Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-05/28 13:07:48Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-05/28 13:08:00Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-05/28 13:08:05Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-05/28 12:56:15Z -Runtime: sfs_test 00:00:51 -- baseline 00:00:50
-05/28 12:56:36Z -Runtime: aqm_test 00:01:04 -- baseline 00:01:00
-05/28 12:56:40Z -Runtime: gefsv12_test 00:01:15 -- baseline 00:01:20
-05/28 12:57:33Z -Runtime: gefsv13_test 00:02:08 -- baseline 00:02:00
-05/28 12:57:37Z -Runtime: nmmb_test 00:01:59 -- baseline 00:02:20
-05/28 12:57:41Z -Runtime: rap_test 00:02:02 -- baseline 00:02:00
-05/28 12:59:06Z -Runtime: hrrr_test 00:03:28 -- baseline 00:03:40
-05/28 12:59:10Z -Runtime: hafs_test 00:01:49 -- baseline 00:02:00
-05/28 12:59:15Z -Runtime: 3drtma_test 00:02:37 -- baseline 00:03:00
-05/28 12:59:19Z -Runtime: mpas_test 00:02:26 -- baseline 00:02:40
-05/28 13:00:28Z -Runtime: mpas_hfip.test 00:04:45 -- baseline 00:05:00
-05/28 13:00:32Z -Runtime: gcafs_test 00:03:53 -- baseline 00:05:30
-05/28 13:08:41Z -Runtime: rrfs_test 00:12:56 -- baseline 00:10:00
-05/28 13:08:46Z -Runtime: gfs_test 00:11:29 -- baseline 00:15:00
-05/28 13:08:50Z -Runtime: hrrr_ifi_test 00:01:40 -- baseline 00:02:00
-05/28 13:08:54Z -Runtime: dafs_test 00:01:51 -- baseline 00:02:00
+06/04 12:38:40Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/04 12:38:41Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/04 12:39:07Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/04 12:39:24Z -hafs test: your new post executable did not generate bit-identical HURPRS42.tm00 as the develop branch
+06/04 12:39:32Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/04 12:39:33Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/04 12:39:33Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
+06/04 12:39:34Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/04 12:39:37Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/04 12:39:38Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/04 12:39:39Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/04 12:39:40Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
+06/04 12:39:41Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
+06/04 12:40:00Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/04 12:40:01Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/04 12:40:02Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/04 12:40:04Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/04 12:40:07Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/04 12:40:07Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/04 12:41:19Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/04 12:41:20Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/04 12:41:22Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/04 12:41:51Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/04 12:41:53Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/04 12:42:26Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/04 12:42:30Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/04 12:42:32Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/04 12:44:56Z -wafs test: your new post executable generates bit-identical GFSPRS.GrbF06 as the develop branch
+06/04 12:59:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/04 12:59:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/04 12:59:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/04 13:02:13Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/04 13:02:28Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/04 13:02:34Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/04 12:39:02Z -Runtime: sfs_test 00:00:51 -- baseline 00:00:50
+06/04 12:39:06Z -Runtime: aqm_test 00:00:53 -- baseline 00:01:00
+06/04 12:39:27Z -Runtime: gefsv12_test 00:01:11 -- baseline 00:01:20
+06/04 12:40:04Z -Runtime: gefsv13_test 00:01:51 -- baseline 00:02:00
+06/04 12:40:08Z -Runtime: nmmb_test 00:01:45 -- baseline 00:02:20
+06/04 12:40:13Z -Runtime: rap_test 00:01:49 -- baseline 00:02:00
+06/04 12:41:53Z -Runtime: hrrr_test 00:03:26 -- baseline 00:03:40
+06/04 12:41:58Z -Runtime: hafs_test 00:01:25 -- baseline 00:02:00
+06/04 12:42:02Z -Runtime: 3drtma_test 00:02:11 -- baseline 00:03:00
+06/04 12:42:07Z -Runtime: mpas_test 00:02:10 -- baseline 00:02:40
+06/04 12:42:59Z -Runtime: mpas_hfip.test 00:04:31 -- baseline 00:05:00
+06/04 12:43:04Z -Runtime: gcafs_test 00:03:53 -- baseline 00:05:30
+06/04 13:03:02Z -Runtime: rrfs_test 00:12:44 -- baseline 00:10:00
+06/04 13:03:06Z -Runtime: gfs_test 00:11:16 -- baseline 00:15:00
+06/04 13:03:11Z -Runtime: hrrr_ifi_test 00:01:32 -- baseline 00:02:00
+06/04 13:03:15Z -Runtime: dafs_test 00:01:38 -- baseline 00:02:00
+06/04 13:03:20Z -Runtime: wafs_test 00:06:50 -- baseline 00:07:00
 Check tests:
-['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs', 'hrrr_ifi', 'dafs']
-No changes in test results detected.
+['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs', 'hrrr_ifi', 'dafs', 'wafs']
+There are changes in results for case hafs in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/hafs_2024092406/HURPRS42.tm00
+Refer to .diff files in rundir: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2 for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
This PR resolves issues #1531 and #1536 

A WAFS regression test is added to the WCOSS2 RTs.  I used the itag information provided by Yali.  Since WAFS requires the GTG code, we will only run it on WCOSS2.  The current logic in ci/submit_jobs_WCOSS2.sh requires the presence of the GTG and IFI code in order for the WAFS test to be submitted (same logic as DAFS).  If WAFS only needs the GTG code, this logic could be modified.

The GTG submodule has also been updated with this PR.

The HAFS baseline data is also updated to use 2024 model output from Hurricane Helene.  This will result in baseline updates on all platforms.  I generated new baseline data on Ursa for Chad whenever we are ready to proceed with processing this PR:
`/scratch4/NCEPDEV/fv3-cam/Benjamin.Blake/test_suite`

@WenMeng-NOAA @YaliMao-NOAA I have run directories here on WCOSS2 if you could check the output:
`/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/upp-pr1544`
The new HAFS output files are located here:
`/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/test_suite/data_in/hafs`