### PR TITLE
[GFS.v17] Update wcoss2 modules for package uniformity

### DIFF
--- a/modulefiles/wcoss2_intel.lua
+++ b/modulefiles/wcoss2_intel.lua
@@ -2,22 +2,24 @@ help([[
 Load environment to build post on WCOSS2
 ]])
 
-PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
+PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.5.0"
 intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-craype_ver=os.getenv("craype_ver") or "2.7.10"
-cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.9"
+craype_ver=os.getenv("craype_ver") or "2.7.17"
+cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.19"
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 load(pathJoin("intel", intel_ver))
 load(pathJoin("craype", craype_ver))
 load(pathJoin("cray-mpich", cray_mpich_ver))
 
-cmake_ver=os.getenv("cmake_ver") or "3.20.2"
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 load(pathJoin("cmake", cmake_ver))
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
-netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
-load(pathJoin("hdf5", hdf5_ver))
-load(pathJoin("netcdf", netcdf_ver))
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+pnetcdf_ver=os.getenv("pnetcdf_ver") or "1.12.2"
+netcdf_ver=os.getenv("netcdf_ver") or "4.9.2"
+load(pathJoin("hdf5-D", hdf5_ver))
+load(pathJoin("netcdf-D", netcdf_ver))
+load(pathJoin("pnetcdf-D", pnetcdf_ver))
 
 jasper_ver=os.getenv("jasper_ver") or "2.0.25"
 libpng_ver=os.getenv("libpng_ver") or "1.6.37"
@@ -27,11 +29,11 @@ load(pathJoin("libpng", libpng_ver))
 load(pathJoin("zlib", zlib_ver))
 
 g2_ver=os.getenv("g2_ver") or "3.5.1"
-g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.16.0"
+g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.17.0"
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-ip_ver=os.getenv("ip_ver") or "4.0.0"
-sp_ver=os.getenv("sp_ver") or "2.3.3"
-crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
+ip_ver=os.getenv("ip_ver") or "5.2.0"
+sp_ver=os.getenv("sp_ver") or "2.4.0"
+crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
 w3emc_ver=os.getenv("w3emc_ver") or "2.12.0"
 load(pathJoin("g2", g2_ver))
 load(pathJoin("g2tmpl", g2tmpl_ver))


### PR DESCRIPTION
This PR is updating the libraries used by UPP to the same versions and types that will be utilized by the GFSv17 package. The biggest change here is updating the to the hdf5-D, netcdf-D, and pnetcdf-D versions. The defaults for other libraries are brought up to the versions that will be used for the gfs package. 

Resovles #1552 