### PR TITLE
Unit Tests: Change CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR

### DIFF
--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,62 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b2c0e59566be39d3695e8f4ba27297fc518be07a
+2fc90e1dfa113cbf22c2cf300d1c0a66f30fc7fc
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1554_hercules_intel/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1558_hercules_intel/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:12m:09s
-Test Date: 20260610 08:25:32
+Total runtime: 00h:12m:23s
+Test Date: 20260617 09:25:11
 Summary Results:
 
-06/10 13:15:40Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-06/10 13:15:41Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-06/10 13:15:49Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-06/10 13:16:08Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-06/10 13:16:17Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-06/10 13:16:24Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-06/10 13:16:24Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-06/10 13:16:25Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-06/10 13:16:29Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-06/10 13:16:30Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-06/10 13:16:39Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-06/10 13:16:40Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-06/10 13:16:40Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-06/10 13:16:43Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-06/10 13:16:44Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-06/10 13:16:45Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-06/10 13:17:21Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-06/10 13:17:21Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-06/10 13:17:21Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-06/10 13:17:22Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-06/10 13:17:23Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-06/10 13:17:23Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-06/10 13:18:10Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-06/10 13:18:11Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-06/10 13:23:17Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-06/10 13:23:19Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-06/10 13:23:19Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-06/10 13:24:47Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-06/10 13:25:19Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-06/10 13:25:23Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-06/10 13:16:01Z -Runtime: sfs_test 00:00:09 -- baseline 00:01:20
-06/10 13:16:01Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
-06/10 13:16:01Z -Runtime: gefsv12_test 00:00:17 -- baseline 00:01:00
-06/10 13:16:31Z -Runtime: gefsv13_test 00:00:45 -- baseline 00:02:00
-06/10 13:16:46Z -Runtime: nmmb_test 00:01:08 -- baseline 00:03:00
-06/10 13:16:46Z -Runtime: rap_test 00:00:58 -- baseline 00:02:00
-06/10 13:17:31Z -Runtime: hrrr_test 00:01:50 -- baseline 00:06:00
-06/10 13:17:31Z -Runtime: hafs_test 00:00:36 -- baseline 00:01:00
-06/10 13:17:31Z -Runtime: 3drtma_test 00:00:53 -- baseline 00:03:00
-06/10 13:17:31Z -Runtime: mpas_test 00:01:13 -- baseline 00:02:30
-06/10 13:17:31Z -Runtime: mpas_hfip_test 00:01:52 -- baseline 00:05:00
-06/10 13:18:16Z -Runtime: gcafs_test 00:02:39 -- baseline 00:02:30
-06/10 13:25:32Z -Runtime: rrfs_test 00:09:51 -- baseline 00:12:00
-06/10 13:25:32Z -Runtime: gfs_test 00:07:47 -- baseline 00:25:00
+06/17 14:15:49Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/17 14:15:49Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/17 14:15:57Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/17 14:16:17Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+06/17 14:16:24Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/17 14:16:31Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/17 14:16:31Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/17 14:16:31Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/17 14:16:40Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/17 14:16:41Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/17 14:16:51Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/17 14:16:51Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/17 14:16:51Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/17 14:16:52Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/17 14:16:52Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/17 14:16:52Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/17 14:17:33Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/17 14:17:33Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/17 14:17:34Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/17 14:17:37Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/17 14:17:39Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/17 14:17:40Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/17 14:18:21Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/17 14:18:22Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/17 14:23:24Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/17 14:23:26Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/17 14:23:26Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/17 14:24:48Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/17 14:24:57Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/17 14:24:59Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/17 14:16:08Z -Runtime: sfs_test 00:00:08 -- baseline 00:01:20
+06/17 14:16:09Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
+06/17 14:16:09Z -Runtime: gefsv12_test 00:00:16 -- baseline 00:01:00
+06/17 14:16:39Z -Runtime: gefsv13_test 00:00:43 -- baseline 00:02:00
+06/17 14:16:54Z -Runtime: nmmb_test 00:01:11 -- baseline 00:03:00
+06/17 14:16:54Z -Runtime: rap_test 00:01:00 -- baseline 00:02:00
+06/17 14:17:39Z -Runtime: hrrr_test 00:01:53 -- baseline 00:06:00
+06/17 14:17:39Z -Runtime: hafs_test 00:00:36 -- baseline 00:01:00
+06/17 14:17:39Z -Runtime: 3drtma_test 00:00:50 -- baseline 00:03:00
+06/17 14:17:39Z -Runtime: mpas_test 00:01:11 -- baseline 00:02:30
+06/17 14:17:54Z -Runtime: mpas_hfip_test 00:02:00 -- baseline 00:05:00
+06/17 14:18:25Z -Runtime: gcafs_test 00:02:41 -- baseline 00:02:30
+06/17 14:25:11Z -Runtime: rrfs_test 00:09:18 -- baseline 00:12:00
+06/17 14:25:11Z -Runtime: gfs_test 00:07:45 -- baseline 00:25:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,62 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b2c0e59566be39d3695e8f4ba27297fc518be07a
+2fc90e1dfa113cbf22c2cf300d1c0a66f30fc7fc
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1554_orion_intel/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1558_orion_intel/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 00h:19m:57s
-Test Date: 20260610 09:26:54
+Total runtime: 00h:19m:51s
+Test Date: 20260617 09:32:40
 Summary Results:
 
-06/10 14:10:25Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-06/10 14:10:28Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-06/10 14:10:32Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-06/10 14:10:55Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-06/10 14:11:09Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-06/10 14:11:10Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-06/10 14:11:10Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-06/10 14:11:10Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-06/10 14:11:58Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-06/10 14:11:59Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-06/10 14:12:05Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-06/10 14:12:05Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-06/10 14:12:05Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-06/10 14:12:07Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-06/10 14:12:08Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-06/10 14:12:08Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-06/10 14:12:09Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-06/10 14:12:10Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-06/10 14:13:36Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-06/10 14:13:38Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-06/10 14:13:38Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-06/10 14:13:54Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-06/10 14:13:54Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-06/10 14:13:56Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-06/10 14:21:56Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-06/10 14:21:58Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-06/10 14:21:58Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-06/10 14:26:09Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-06/10 14:26:42Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-06/10 14:26:47Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-06/10 14:10:46Z -Runtime: sfs_test 00:00:09 -- baseline 00:01:20
-06/10 14:10:46Z -Runtime: aqm_test 00:00:12 -- baseline 00:00:30
-06/10 14:10:46Z -Runtime: gefsv12_test 00:00:16 -- baseline 00:01:00
-06/10 14:11:16Z -Runtime: gefsv13_test 00:00:54 -- baseline 00:02:00
-06/10 14:11:16Z -Runtime: nmmb_test 00:00:55 -- baseline 00:03:00
-06/10 14:12:01Z -Runtime: rap_test 00:01:43 -- baseline 00:02:00
-06/10 14:14:02Z -Runtime: hrrr_test 00:03:40 -- baseline 00:08:00
-06/10 14:14:07Z -Runtime: hafs_test 00:00:39 -- baseline 00:01:00
-06/10 14:14:07Z -Runtime: 3drtma_test 00:01:49 -- baseline 00:03:00
-06/10 14:14:07Z -Runtime: mpas_test 00:01:52 -- baseline 00:02:30
-06/10 14:14:07Z -Runtime: mpas_hfip_test 00:03:22 -- baseline 00:05:00
-06/10 14:14:07Z -Runtime: gcafs_test 00:01:54 -- baseline 00:03:15
-06/10 14:26:53Z -Runtime: rrfs_test 00:16:28 -- baseline 00:17:00
-06/10 14:26:53Z -Runtime: gfs_test 00:11:39 -- baseline 00:26:00
+06/17 14:16:19Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/17 14:16:20Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/17 14:16:27Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/17 14:16:49Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+06/17 14:17:03Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/17 14:17:32Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/17 14:17:32Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/17 14:17:33Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/17 14:17:51Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/17 14:17:52Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/17 14:17:59Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/17 14:17:59Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/17 14:18:00Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/17 14:18:00Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/17 14:18:01Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/17 14:18:01Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/17 14:19:07Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/17 14:19:08Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/17 14:19:34Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/17 14:19:36Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/17 14:19:37Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/17 14:19:47Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/17 14:19:47Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/17 14:19:49Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/17 14:27:40Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/17 14:27:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/17 14:27:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/17 14:31:59Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/17 14:32:22Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/17 14:32:26Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/17 14:16:37Z -Runtime: sfs_test 00:00:11 -- baseline 00:01:20
+06/17 14:16:37Z -Runtime: aqm_test 00:00:12 -- baseline 00:00:30
+06/17 14:16:37Z -Runtime: gefsv12_test 00:00:19 -- baseline 00:01:00
+06/17 14:17:07Z -Runtime: gefsv13_test 00:00:55 -- baseline 00:02:00
+06/17 14:17:37Z -Runtime: nmmb_test 00:01:25 -- baseline 00:03:00
+06/17 14:17:52Z -Runtime: rap_test 00:01:44 -- baseline 00:02:00
+06/17 14:19:53Z -Runtime: hrrr_test 00:03:41 -- baseline 00:08:00
+06/17 14:19:53Z -Runtime: hafs_test 00:00:41 -- baseline 00:01:00
+06/17 14:19:53Z -Runtime: 3drtma_test 00:01:52 -- baseline 00:03:00
+06/17 14:19:53Z -Runtime: mpas_test 00:01:53 -- baseline 00:02:30
+06/17 14:19:53Z -Runtime: mpas_hfip_test 00:03:30 -- baseline 00:05:00
+06/17 14:19:53Z -Runtime: gcafs_test 00:03:00 -- baseline 00:03:15
+06/17 14:32:39Z -Runtime: rrfs_test 00:16:18 -- baseline 00:17:00
+06/17 14:32:39Z -Runtime: gfs_test 00:11:34 -- baseline 00:26:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,62 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b2c0e59566be39d3695e8f4ba27297fc518be07a
+2fc90e1dfa113cbf22c2cf300d1c0a66f30fc7fc
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1554_ursa_intel/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1558_ursa_intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:28m:01s
-Test Date: 20260610 13:41:22
+Total runtime: 00h:09m:16s
+Test Date: 20260617 14:22:02
 Summary Results:
 
-06/10 13:15:39Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-06/10 13:16:28Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-06/10 13:16:28Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-06/10 13:16:29Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-06/10 13:16:29Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-06/10 13:16:29Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-06/10 13:16:30Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-06/10 13:20:19Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-06/10 13:20:26Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-06/10 13:20:27Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-06/10 13:20:35Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-06/10 13:20:36Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-06/10 13:20:37Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-06/10 13:20:55Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-06/10 13:20:55Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-06/10 13:21:38Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-06/10 13:21:39Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-06/10 13:21:40Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-06/10 13:23:32Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-06/10 13:23:34Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-06/10 13:23:35Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-06/10 13:37:44Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-06/10 13:38:00Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-06/10 13:38:23Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-06/10 13:39:43Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-06/10 13:39:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-06/10 13:39:44Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-06/10 13:41:04Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-06/10 13:41:15Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-06/10 13:41:20Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-06/10 13:37:51Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
-06/10 13:37:52Z -Runtime: aqm_test 00:00:06 -- baseline 00:00:30
-06/10 13:38:07Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
-06/10 13:38:37Z -Runtime: gefsv13_test 00:00:36 -- baseline 00:02:00
-06/10 13:38:37Z -Runtime: nmmb_test 00:00:24 -- baseline 00:02:00
-06/10 13:38:37Z -Runtime: rap_test 00:00:42 -- baseline 00:02:00
-06/10 13:38:37Z -Runtime: hrrr_test 00:01:27 -- baseline 00:03:00
-06/10 13:38:37Z -Runtime: hafs_test 00:00:27 -- baseline 00:01:30
-06/10 13:38:37Z -Runtime: 3drtma_test 00:01:17 -- baseline 00:01:30
-06/10 13:38:37Z -Runtime: mpas_test 00:01:18 -- baseline 00:02:30
-06/10 13:38:37Z -Runtime: mpas_hfip_test 00:03:22 -- baseline 00:05:00
-06/10 13:38:37Z -Runtime: gcafs_test 00:01:14 -- baseline 00:02:00
-06/10 13:41:22Z -Runtime: rrfs_test 00:06:50 -- baseline 00:07:00
-06/10 13:41:22Z -Runtime: gfs_test 00:05:14 -- baseline 00:15:00
+06/17 14:14:39Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/17 14:14:45Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/17 14:14:58Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/17 14:15:03Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+06/17 14:15:29Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/17 14:15:41Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/17 14:15:42Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/17 14:16:02Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/17 14:16:03Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/17 14:16:03Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/17 14:16:04Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/17 14:16:04Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/17 14:16:04Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/17 14:16:10Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/17 14:16:11Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/17 14:16:17Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/17 14:16:18Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/17 14:16:19Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/17 14:16:26Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/17 14:16:27Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/17 14:16:28Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/17 14:18:10Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/17 14:18:12Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/17 14:18:12Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/17 14:20:10Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/17 14:20:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/17 14:20:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/17 14:21:44Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/17 14:21:49Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/17 14:21:53Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/17 14:15:01Z -Runtime: sfs_test 00:00:05 -- baseline 00:01:20
+06/17 14:15:01Z -Runtime: aqm_test 00:00:06 -- baseline 00:00:30
+06/17 14:15:01Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
+06/17 14:15:31Z -Runtime: gefsv13_test 00:00:32 -- baseline 00:02:00
+06/17 14:16:31Z -Runtime: nmmb_test 00:00:34 -- baseline 00:02:00
+06/17 14:16:31Z -Runtime: rap_test 00:00:41 -- baseline 00:02:00
+06/17 14:16:31Z -Runtime: hrrr_test 00:01:27 -- baseline 00:03:00
+06/17 14:16:32Z -Runtime: hafs_test 00:00:30 -- baseline 00:01:30
+06/17 14:16:32Z -Runtime: 3drtma_test 00:01:31 -- baseline 00:01:30
+06/17 14:16:32Z -Runtime: mpas_test 00:01:31 -- baseline 00:02:30
+06/17 14:18:17Z -Runtime: mpas_hfip_test 00:03:20 -- baseline 00:05:00
+06/17 14:18:17Z -Runtime: gcafs_test 00:01:14 -- baseline 00:02:00
+06/17 14:22:02Z -Runtime: rrfs_test 00:06:59 -- baseline 00:07:00
+06/17 14:22:02Z -Runtime: gfs_test 00:05:14 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,62 +1,62 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b2c0e59566be39d3695e8f4ba27297fc518be07a
+2fc90e1dfa113cbf22c2cf300d1c0a66f30fc7fc
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1554_ursa_intelllvm/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1558_ursa_intelllvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:10m:12s
-Test Date: 20260610 13:23:34
+Total runtime: 00h:07m:29s
+Test Date: 20260617 14:20:16
 Summary Results:
 
-06/10 13:15:38Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-06/10 13:16:20Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-06/10 13:16:21Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-06/10 13:16:22Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-06/10 13:16:28Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-06/10 13:16:29Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-06/10 13:16:30Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-06/10 13:17:19Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-06/10 13:18:26Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-06/10 13:19:22Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-06/10 13:19:23Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-06/10 13:19:24Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-06/10 13:19:25Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-06/10 13:19:26Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-06/10 13:19:27Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-06/10 13:19:51Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-06/10 13:19:51Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-06/10 13:20:19Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-06/10 13:20:20Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-06/10 13:20:21Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-06/10 13:20:33Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-06/10 13:20:34Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-06/10 13:20:35Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-06/10 13:20:49Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-06/10 13:22:02Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-06/10 13:22:03Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-06/10 13:22:03Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-06/10 13:23:13Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-06/10 13:23:18Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-06/10 13:23:22Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-06/10 13:17:33Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
-06/10 13:19:33Z -Runtime: aqm_test 00:00:09 -- baseline 00:00:30
-06/10 13:19:33Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
-06/10 13:21:03Z -Runtime: gefsv13_test 00:00:36 -- baseline 00:02:00
-06/10 13:21:03Z -Runtime: nmmb_test 00:00:22 -- baseline 00:01:30
-06/10 13:21:03Z -Runtime: rap_test 00:00:38 -- baseline 00:02:00
-06/10 13:21:03Z -Runtime: hrrr_test 00:01:08 -- baseline 00:02:30
-06/10 13:21:03Z -Runtime: hafs_test 00:00:26 -- baseline 00:01:30
-06/10 13:21:03Z -Runtime: 3drtma_test 00:01:18 -- baseline 00:01:30
-06/10 13:21:03Z -Runtime: mpas_test 00:01:10 -- baseline 00:02:30
-06/10 13:21:03Z -Runtime: mpas_hfip_test 00:03:15 -- baseline 00:05:00
-06/10 13:21:03Z -Runtime: gcafs_test 00:01:11 -- baseline 00:02:30
-06/10 13:23:34Z -Runtime: rrfs_test 00:06:10 -- baseline 00:06:00
-06/10 13:23:34Z -Runtime: gfs_test 00:04:51 -- baseline 00:15:00
+06/17 14:13:53Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/17 14:14:04Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/17 14:14:06Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/17 14:14:15Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+06/17 14:14:31Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/17 14:14:48Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/17 14:14:48Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/17 14:14:59Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/17 14:15:00Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/17 14:15:00Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/17 14:15:13Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/17 14:15:13Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/17 14:15:14Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/17 14:15:21Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/17 14:15:21Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/17 14:15:23Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/17 14:16:03Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/17 14:16:04Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/17 14:16:15Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/17 14:16:16Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/17 14:16:16Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/17 14:17:02Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/17 14:17:04Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/17 14:17:05Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/17 14:18:41Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/17 14:18:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/17 14:18:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/17 14:19:55Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/17 14:20:06Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/17 14:20:11Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/17 14:14:15Z -Runtime: sfs_test 00:00:07 -- baseline 00:01:20
+06/17 14:14:15Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
+06/17 14:14:15Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
+06/17 14:14:45Z -Runtime: gefsv13_test 00:00:35 -- baseline 00:02:00
+06/17 14:16:30Z -Runtime: nmmb_test 00:01:06 -- baseline 00:01:30
+06/17 14:16:30Z -Runtime: rap_test 00:00:40 -- baseline 00:02:00
+06/17 14:16:30Z -Runtime: hrrr_test 00:01:21 -- baseline 00:02:30
+06/17 14:16:30Z -Runtime: hafs_test 00:00:29 -- baseline 00:01:30
+06/17 14:16:30Z -Runtime: 3drtma_test 00:01:28 -- baseline 00:01:30
+06/17 14:16:30Z -Runtime: mpas_test 00:01:14 -- baseline 00:02:30
+06/17 14:17:15Z -Runtime: mpas_hfip_test 00:03:19 -- baseline 00:05:00
+06/17 14:17:15Z -Runtime: gcafs_test 00:02:08 -- baseline 00:02:30
+06/17 14:20:16Z -Runtime: rrfs_test 00:06:25 -- baseline 00:06:00
+06/17 14:20:16Z -Runtime: gfs_test 00:04:56 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
 No changes in test results detected.

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,69 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-a0a5d129e8bc701c4d574b19903e22ec7bf231dd
+b0f88160f6970f27d4fd7c2fc6289d0515143694
 
 Submodule hashes:
  68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd (fip_v2.0.0-39-g68953f5)
  c49023a61dc184ca85255ddbfdeee9c99d44bfd5 sorc/ncep_post.fd/post_gtg.fd (ncep_post_gtg.v1.0.6-71-gc49023a)
 
-Run directory: /lfs/h2/emc/ptmp/Benjamin.Blake/upp-WCOSS2
+Run directory: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:37m:39s
-Test Date: 20260609 14:54:59
+Total runtime: 00h:19m:38s
+Test Date: 20260615 11:52:43
 Summary Results:
 
-06/09 14:24:59Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-06/09 14:25:05Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-06/09 14:25:12Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-06/09 14:25:38Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-06/09 14:25:38Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
-06/09 14:25:45Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
-06/09 14:25:46Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
-06/09 14:25:55Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-06/09 14:25:56Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-06/09 14:25:56Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-06/09 14:26:01Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-06/09 14:26:01Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-06/09 14:26:02Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-06/09 14:26:16Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-06/09 14:26:18Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-06/09 14:26:19Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-06/09 14:26:26Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-06/09 14:26:28Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-06/09 14:26:30Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-06/09 14:27:23Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-06/09 14:27:24Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-06/09 14:27:26Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-06/09 14:28:05Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-06/09 14:28:07Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-06/09 14:28:12Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-06/09 14:28:16Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-06/09 14:28:17Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-06/09 14:30:41Z -wafs test: your new post executable generates bit-identical GFSPRS.GrbF06 as the develop branch
-06/09 14:52:14Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-06/09 14:52:16Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-06/09 14:52:16Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-06/09 14:53:32Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-06/09 14:53:49Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-06/09 14:53:56Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-06/09 14:25:14Z -Runtime: sfs_test 00:00:56 -- baseline 00:00:50
-06/09 14:25:19Z -Runtime: aqm_test 00:01:06 -- baseline 00:01:00
-06/09 14:25:43Z -Runtime: gefsv12_test 00:01:16 -- baseline 00:01:20
-06/09 14:26:19Z -Runtime: gefsv13_test 00:02:02 -- baseline 00:02:00
-06/09 14:26:24Z -Runtime: nmmb_test 00:01:58 -- baseline 00:02:20
-06/09 14:26:30Z -Runtime: rap_test 00:02:03 -- baseline 00:02:00
-06/09 14:27:56Z -Runtime: hrrr_test 00:03:29 -- baseline 00:03:40
-06/09 14:28:00Z -Runtime: hafs_test 00:01:39 -- baseline 00:02:00
-06/09 14:28:04Z -Runtime: 3drtma_test 00:02:33 -- baseline 00:03:00
-06/09 14:28:09Z -Runtime: mpas_test 00:02:24 -- baseline 00:02:40
-06/09 14:28:46Z -Runtime: mpas_hfip.test 00:04:25 -- baseline 00:05:00
-06/09 14:28:50Z -Runtime: gcafs_test 00:04:10 -- baseline 00:05:30
-06/09 14:54:37Z -Runtime: rrfs_test 00:12:51 -- baseline 00:10:00
-06/09 14:54:44Z -Runtime: gfs_test 00:11:30 -- baseline 00:15:00
-06/09 14:54:49Z -Runtime: hrrr_ifi_test 00:01:37 -- baseline 00:02:00
-06/09 14:54:54Z -Runtime: dafs_test 00:01:42 -- baseline 00:02:00
-06/09 14:54:58Z -Runtime: wafs_test 00:06:36 -- baseline 00:07:00
+06/15 11:40:12Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/15 11:40:17Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/15 11:40:25Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/15 11:40:45Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+06/15 11:40:56Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
+06/15 11:40:57Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
+06/15 11:40:57Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
+06/15 11:41:02Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/15 11:41:04Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/15 11:41:10Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/15 11:41:12Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/15 11:41:12Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/15 11:41:17Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/15 11:41:31Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/15 11:41:33Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/15 11:41:34Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/15 11:41:36Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/15 11:41:37Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/15 11:41:38Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/15 11:42:38Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/15 11:42:40Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/15 11:42:41Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/15 11:43:20Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/15 11:43:21Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/15 11:43:45Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/15 11:43:49Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/15 11:43:51Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/15 11:45:47Z -wafs test: your new post executable generates bit-identical GFSPRS.GrbF06 as the develop branch
+06/15 11:50:41Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/15 11:50:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/15 11:50:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/15 11:51:32Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/15 11:51:50Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/15 11:51:56Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/15 11:40:35Z -Runtime: sfs_test 00:00:55 -- baseline 00:00:50
+06/15 11:40:39Z -Runtime: aqm_test 00:00:53 -- baseline 00:01:00
+06/15 11:40:44Z -Runtime: gefsv12_test 00:01:08 -- baseline 00:01:20
+06/15 11:41:36Z -Runtime: gefsv13_test 00:01:58 -- baseline 00:02:00
+06/15 11:41:40Z -Runtime: nmmb_test 00:01:54 -- baseline 00:02:20
+06/15 11:41:45Z -Runtime: rap_test 00:01:45 -- baseline 00:02:00
+06/15 11:43:09Z -Runtime: hrrr_test 00:03:24 -- baseline 00:03:40
+06/15 11:43:14Z -Runtime: hafs_test 00:01:26 -- baseline 00:02:00
+06/15 11:43:18Z -Runtime: 3drtma_test 00:02:21 -- baseline 00:03:00
+06/15 11:43:22Z -Runtime: mpas_test 00:02:18 -- baseline 00:02:40
+06/15 11:44:15Z -Runtime: mpas_hfip.test 00:04:34 -- baseline 00:05:00
+06/15 11:44:19Z -Runtime: gcafs_test 00:04:03 -- baseline 00:05:30
+06/15 11:52:25Z -Runtime: rrfs_test 00:12:44 -- baseline 00:10:00
+06/15 11:52:29Z -Runtime: gfs_test 00:11:29 -- baseline 00:15:00
+06/15 11:52:34Z -Runtime: hrrr_ifi_test 00:01:40 -- baseline 00:02:00
+06/15 11:52:38Z -Runtime: dafs_test 00:01:39 -- baseline 00:02:00
+06/15 11:52:42Z -Runtime: wafs_test 00:06:28 -- baseline 00:07:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs', 'hrrr_ifi', 'dafs', 'wafs']
 No changes in test results detected.

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,6 +1,6 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-b0f88160f6970f27d4fd7c2fc6289d0515143694
+cd3752075572fc88a87003b540036ed7ce14be2e
 
 Submodule hashes:
  68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd (fip_v2.0.0-39-g68953f5)
@@ -9,61 +9,61 @@ Submodule hashes:
 Run directory: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:19m:38s
-Test Date: 20260615 11:52:43
+Total runtime: 00h:20m:27s
+Test Date: 20260616 11:49:32
 Summary Results:
 
-06/15 11:40:12Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-06/15 11:40:17Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-06/15 11:40:25Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-06/15 11:40:45Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-06/15 11:40:56Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
-06/15 11:40:57Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
-06/15 11:40:57Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
-06/15 11:41:02Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-06/15 11:41:04Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-06/15 11:41:10Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-06/15 11:41:12Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-06/15 11:41:12Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-06/15 11:41:17Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-06/15 11:41:31Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
-06/15 11:41:33Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
-06/15 11:41:34Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
-06/15 11:41:36Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-06/15 11:41:37Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-06/15 11:41:38Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-06/15 11:42:38Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-06/15 11:42:40Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-06/15 11:42:41Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-06/15 11:43:20Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-06/15 11:43:21Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-06/15 11:43:45Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-06/15 11:43:49Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-06/15 11:43:51Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-06/15 11:45:47Z -wafs test: your new post executable generates bit-identical GFSPRS.GrbF06 as the develop branch
-06/15 11:50:41Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-06/15 11:50:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-06/15 11:50:42Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-06/15 11:51:32Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-06/15 11:51:50Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-06/15 11:51:56Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-06/15 11:40:35Z -Runtime: sfs_test 00:00:55 -- baseline 00:00:50
-06/15 11:40:39Z -Runtime: aqm_test 00:00:53 -- baseline 00:01:00
-06/15 11:40:44Z -Runtime: gefsv12_test 00:01:08 -- baseline 00:01:20
-06/15 11:41:36Z -Runtime: gefsv13_test 00:01:58 -- baseline 00:02:00
-06/15 11:41:40Z -Runtime: nmmb_test 00:01:54 -- baseline 00:02:20
-06/15 11:41:45Z -Runtime: rap_test 00:01:45 -- baseline 00:02:00
-06/15 11:43:09Z -Runtime: hrrr_test 00:03:24 -- baseline 00:03:40
-06/15 11:43:14Z -Runtime: hafs_test 00:01:26 -- baseline 00:02:00
-06/15 11:43:18Z -Runtime: 3drtma_test 00:02:21 -- baseline 00:03:00
-06/15 11:43:22Z -Runtime: mpas_test 00:02:18 -- baseline 00:02:40
-06/15 11:44:15Z -Runtime: mpas_hfip.test 00:04:34 -- baseline 00:05:00
-06/15 11:44:19Z -Runtime: gcafs_test 00:04:03 -- baseline 00:05:30
-06/15 11:52:25Z -Runtime: rrfs_test 00:12:44 -- baseline 00:10:00
-06/15 11:52:29Z -Runtime: gfs_test 00:11:29 -- baseline 00:15:00
-06/15 11:52:34Z -Runtime: hrrr_ifi_test 00:01:40 -- baseline 00:02:00
-06/15 11:52:38Z -Runtime: dafs_test 00:01:39 -- baseline 00:02:00
-06/15 11:52:42Z -Runtime: wafs_test 00:06:28 -- baseline 00:07:00
+06/16 11:36:19Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+06/16 11:36:30Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+06/16 11:36:44Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+06/16 11:37:08Z -hrrr_ifi test: your new post executable generates bit-identical IFIFIP.GrbF10 as the develop branch
+06/16 11:37:09Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+06/16 11:37:20Z -dafs test: your new post executable generates bit-identical AVIATION.GrbF08 as the develop branch
+06/16 11:37:21Z -dafs test: your new post executable generates bit-identical IFIFIP.GrbF08 as the develop branch
+06/16 11:37:22Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+06/16 11:37:23Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+06/16 11:37:31Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+06/16 11:37:38Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+06/16 11:37:39Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+06/16 11:37:40Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+06/16 11:37:47Z -mpas test: your new post executable generates bit-identical POSTNAT12.tm00 as the develop branch
+06/16 11:37:49Z -mpas test: your new post executable generates bit-identical POSTPRS12.tm00 as the develop branch
+06/16 11:37:50Z -mpas test: your new post executable generates bit-identical POSTTWO12.tm00 as the develop branch
+06/16 11:37:59Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+06/16 11:38:00Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+06/16 11:38:02Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+06/16 11:38:56Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+06/16 11:38:57Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+06/16 11:39:00Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+06/16 11:39:55Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+06/16 11:39:58Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+06/16 11:40:02Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+06/16 11:40:08Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+06/16 11:40:10Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+06/16 11:42:09Z -wafs test: your new post executable generates bit-identical GFSPRS.GrbF06 as the develop branch
+06/16 11:46:59Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
+06/16 11:47:01Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
+06/16 11:47:01Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
+06/16 11:47:54Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+06/16 11:48:18Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+06/16 11:48:42Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+06/16 11:36:42Z -Runtime: sfs_test 00:00:50 -- baseline 00:00:50
+06/16 11:36:47Z -Runtime: aqm_test 00:01:05 -- baseline 00:01:00
+06/16 11:37:07Z -Runtime: gefsv12_test 00:01:19 -- baseline 00:01:20
+06/16 11:38:00Z -Runtime: gefsv13_test 00:02:05 -- baseline 00:02:00
+06/16 11:38:04Z -Runtime: nmmb_test 00:02:14 -- baseline 00:02:20
+06/16 11:38:08Z -Runtime: rap_test 00:01:58 -- baseline 00:02:00
+06/16 11:39:17Z -Runtime: hrrr_test 00:03:36 -- baseline 00:03:40
+06/16 11:39:22Z -Runtime: hafs_test 00:01:43 -- baseline 00:02:00
+06/16 11:39:26Z -Runtime: 3drtma_test 00:02:37 -- baseline 00:03:00
+06/16 11:39:30Z -Runtime: mpas_test 00:02:26 -- baseline 00:02:40
+06/16 11:40:39Z -Runtime: mpas_hfip.test 00:04:42 -- baseline 00:05:00
+06/16 11:40:43Z -Runtime: gcafs_test 00:04:30 -- baseline 00:05:30
+06/16 11:49:12Z -Runtime: rrfs_test 00:13:20 -- baseline 00:10:00
+06/16 11:49:17Z -Runtime: gfs_test 00:11:36 -- baseline 00:15:00
+06/16 11:49:22Z -Runtime: hrrr_ifi_test 00:01:39 -- baseline 00:02:00
+06/16 11:49:27Z -Runtime: dafs_test 00:01:52 -- baseline 00:02:00
+06/16 11:49:31Z -Runtime: wafs_test 00:06:39 -- baseline 00:07:00
 Check tests:
 ['sfs', 'aqm', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs', 'hrrr_ifi', 'dafs', 'wafs']
 No changes in test results detected.

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -97,13 +97,13 @@ create_test(test_ngmslp)
 create_test(test_table)
 create_test(test_tableq)
 
-configure_file(${CMAKE_SOURCE_DIR}/fix/hires_micro_lookup.dat
+configure_file(${PROJECT_SOURCE_DIR}/fix/hires_micro_lookup.dat
                ${CMAKE_CURRENT_BINARY_DIR}/eta_micro_lookup.dat COPYONLY)
 create_test(test_microinit)
 set_tests_properties(test_microinit PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 if(BUILD_WITH_NEMSIO)
-  create_test(test_assignnemsiovar SRC_FILES ${CMAKE_SOURCE_DIR}/sorc/ncep_post.fd/ASSIGNNEMSIOVAR.f)
+  create_test(test_assignnemsiovar SRC_FILES ${PROJECT_SOURCE_DIR}/sorc/ncep_post.fd/ASSIGNNEMSIOVAR.f)
 endif()
 
 # The following tests require MPI to run.

--- a/unit_tests/test_microinit.f90
+++ b/unit_tests/test_microinit.f90
@@ -179,8 +179,8 @@ program test_microinit
                 " Expected = ", EXP_TRAD_ICE(i)
             res = 1
         end if
-        print '(A,I0,A,1X,ES16.10)', "RQR_DRMIN(", i, ") =", RQR_DRmin
-        print '(A,I0,A,1X,ES16.10)', "RQR_DRMAX(", i, ") =", RQR_DRmax
+        print '(A,I0,A,1X,ES17.10)', "RQR_DRMIN(", i, ") =", RQR_DRmin
+        print '(A,I0,A,1X,ES17.10)', "RQR_DRMAX(", i, ") =", RQR_DRmax
         !if (abs(RQR_DRmin - EXP_RQR_DRmin(i)) > tol) then
         !    print *, "Test Case ", i, " Failed: RQR_DRmin = ", RQR_DRmin, &
         !        " Expected = ", EXP_RQR_DRmin(i)


### PR DESCRIPTION
This small change could potentially resolve issue #1545 

I tested building the UPP code with this suggested change and it completed successfully.  The unit tests also run well with this change, so we could consider adding it to the UPP develop branch.