### PR TITLE
[wafs_v7.1]Fix runtime error of 'floating invalid' if compiling in debug mode with 'check all' option.

### DIFF
--- a/sorc/ncep_post.fd/GFIP3.f
+++ b/sorc/ncep_post.fd/GFIP3.f
@@ -1673,7 +1673,6 @@ contains
     real :: severity
     integer :: k, n
 
-    real :: moistInt
 
     iseverity(:) = 0.0
 
@@ -1963,9 +1962,9 @@ contains
     tempAdj = 0.0
     cttAdj  = 0.0
     pcAdj   = 0.0
+
     ! ctt, cloudTopDist, lowestCloud, deltaZ: module member (cloud info)
     call cal_DampingFactors(scenario, t, pc, tempAdj, cttAdj, pcAdj)
-  
     severity = (weights(1) * dqInt + weights(2) * dzInt + &
                 weights(3) * vvInt + weights(4) * moistInt + &
                 weights(5) * ice_pot) / &
@@ -2224,6 +2223,8 @@ contains
        condAdj = cldBaseDist_map(deltaZ)
        ! For no precipitation, condAdj is 0.0
        condAdj = condAdj * prcpCondensate_map(pc, scenario)
+    else
+         condAdj=0.0
     end if
 
     return

--- a/sorc/ncep_post.fd/GFIP3.f
+++ b/sorc/ncep_post.fd/GFIP3.f
@@ -1673,6 +1673,7 @@ contains
     real :: severity
     integer :: k, n
 
+    ! moistInt: module member
 
     iseverity(:) = 0.0
 


### PR DESCRIPTION
Update:
This PR is a combination of two separate fixes: one for GFIP and the other for GTG, to fix runtime error of 'floating invalid' if compiling in debug mode with 'check all' option.

This PR was originally for GFIP. But fixing only for GFIP can't pass test runs, so later this PR includes fixing for GTG.

For GFIP, the fix is about 'moistInt'. It is a module member and shared by all subrountines in the module and should not be re-defined and made private in subroutine icing_sev

For GTG,  the fix is a submodule revision update, replacing NaN in gtg.config.gfs with meaningful values