### PR TITLE
(release/gefs_v12) Add fixes for extreme helicity values 

### DIFF
--- a/sorc/ncep_post.fd/CALHEL.f
+++ b/sorc/ncep_post.fd/CALHEL.f
@@ -79,7 +79,7 @@
       use vrbls3d,    only: zmid, uh, vh, u, v, zint
       use vrbls2d,    only: fis, u10, v10
       use masks,      only: lmv
-      use params_mod, only: g
+      use params_mod, only: g, small
       use lookup_mod, only: ITB,JTB,ITBQ,JTBQ
       use ctlblk_mod, only: jsta, jend, jsta_m, jend_m, jsta_2l, jend_2u, &
                             lm, im, jm, me
@@ -442,12 +442,13 @@
                 DU2 = UH(I,J,L)-UH(I,J,L-1)
                 DV1 = VH(I,J,L+1)-VH(I,J,L)
                 DV2 = VH(I,J,L)-VH(I,J,L-1)
-                HELI(I,J,N) = ((VH(I,J,L)-VST(I,J))*                      &
-                               (DZ2*(DU1/DZ1)+DZ1*(DU2/DZ2))              &
-                            -  (UH(I,J,L)-UST(I,J))*                      &
-                               (DZ2*(DV1/DZ1)+DZ1*(DV2/DZ2)))             &
-                               *DZ/(DZ1+DZ2)+HELI(I,J,N) 
-
+                if(abs(DZ1)>small .and. abs(DZ2)>small) then
+                  HELI(I,J,N) = ((VH(I,J,L)-VST(I,J))*                      &
+                                 (DZ2*(DU1/DZ1)+DZ1*(DU2/DZ2))              &
+                              -  (UH(I,J,L)-UST(I,J))*                      &
+                                 (DZ2*(DV1/DZ1)+DZ1*(DV2/DZ2)))             &
+                                 *DZ/(DZ1+DZ2)+HELI(I,J,N)
+                END IF
 !	    if(i==im/2.and.j==(jsta+jend)/2)print*,'Debug Helicity',depth(N),l,dz1,dz2,du1,  &
 !	     du2,dv1,dv2,ust(i,j),vst(i,j)		      
               ENDIF

--- a/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
+++ b/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
@@ -941,8 +941,8 @@
             js = fldst + (j-jsta)*im
             do i=1,im
               zint(i,j,ll)=zint(i,j,ll+1)+abs(tmp(i+js))
-!              if(recn_dpres /= -9999)pmid(i,j,ll)=rgas*dpres(i,j,ll)* &
-!                      t(i,j,ll)*(q(i,j,ll)*fv+1.0)/grav/abs(tmp(i+js))
+              if(recn_dpres /= -9999)pmid(i,j,ll)=rgas*dpres(i,j,ll)* &
+                      t(i,j,ll)*(q(i,j,ll)*fv+1.0)/grav/abs(tmp(i+js)) 
             enddo
           enddo
           if(debugprint)print*,'sample l ',VarName,' = ',ll, &
@@ -1114,15 +1114,6 @@
           ,pint(ii,jj,l)
         end do
       endif
-
-! compute pmid from averaged two layer pint
-      do l=lm,1,-1
-        do j=jsta,jend
-          do i=1,im
-            pmid(i,j,l) = 0.5*(pint(i,j,l)+pint(i,j,l+1))
-          enddo
-        enddo
-      enddo
 
 !
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
+++ b/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
@@ -941,8 +941,8 @@
             js = fldst + (j-jsta)*im
             do i=1,im
               zint(i,j,ll)=zint(i,j,ll+1)+abs(tmp(i+js))
-              if(recn_dpres /= -9999)pmid(i,j,ll)=rgas*dpres(i,j,ll)* &
-                      t(i,j,ll)*(q(i,j,ll)*fv+1.0)/grav/abs(tmp(i+js)) 
+!              if(recn_dpres /= -9999)pmid(i,j,ll)=rgas*dpres(i,j,ll)* &
+!                      t(i,j,ll)*(q(i,j,ll)*fv+1.0)/grav/abs(tmp(i+js))
             enddo
           enddo
           if(debugprint)print*,'sample l ',VarName,' = ',ll, &

--- a/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
+++ b/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
@@ -941,6 +941,8 @@
             js = fldst + (j-jsta)*im
             do i=1,im
               zint(i,j,ll)=zint(i,j,ll+1)+abs(tmp(i+js))
+              if(recn_dpres /= -9999)pmid(i,j,ll)=rgas*dpres(i,j,ll)* &
+                      t(i,j,ll)*(q(i,j,ll)*fv+1.0)/grav/abs(tmp(i+js)) 
             enddo
           enddo
           if(debugprint)print*,'sample l ',VarName,' = ',ll, &

--- a/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
+++ b/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
@@ -941,8 +941,6 @@
             js = fldst + (j-jsta)*im
             do i=1,im
               zint(i,j,ll)=zint(i,j,ll+1)+abs(tmp(i+js))
-              if(recn_dpres /= -9999)pmid(i,j,ll)=rgas*dpres(i,j,ll)* &
-                      t(i,j,ll)*(q(i,j,ll)*fv+1.0)/grav/abs(tmp(i+js)) 
             enddo
           enddo
           if(debugprint)print*,'sample l ',VarName,' = ',ll, &

--- a/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
+++ b/sorc/ncep_post.fd/INITPOST_GFS_NEMS_MPIIO.f
@@ -1115,6 +1115,15 @@
         end do
       endif
 
+! compute pmid from averaged two layer pint
+      do l=lm,1,-1
+        do j=jsta,jend
+          do i=1,im
+            pmid(i,j,l) = 0.5*(pint(i,j,l)+pint(i,j,l+1))
+          enddo
+        enddo
+      enddo
+
 !
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 !     Compute omega


### PR DESCRIPTION
This PR fixes an issue that occasionally causes extreme helicity values in GEFSv12. Two changes are made to address this issue.

~~1. Calculate midpoint pressure by averaging the upper (`pint(i,j,l+1)`)  and lower (`pint(i,j,l)`) interface pressure.~~
2.  Only calculate helicity (`HELI`) when `DZ1` and `DZ2` are greater than a near-zero parameter `small`. 

This PR will be kept in draft until an evaluation on the impact of the GEFSv12 products is completed. 

Addresses #1570