### PR TITLE
Adding option to control the calculation of field 260 of Cloud Ceiling Height for 3DRTMA

### DIFF
--- a/sorc/ncep_post.fd/AVIATION.f
+++ b/sorc/ncep_post.fd/AVIATION.f
@@ -494,7 +494,7 @@
 !>     
 !> @author Binbin Zhou NCEP/EMC  @date 2005-08-18       
 !> @modification history:
-!>    2026-07-24 | Gang Zhao      | using height above seal level for RTMA
+!>    2026-07-24 | Gang Zhao      | using height above sea level for RTMA
       SUBROUTINE CALCEILING (CLDZ,TCLD,CEILING)
       USE vrbls2d, only: fis
       use params_mod, only: small, gi
@@ -516,12 +516,8 @@
           IF(ABS(TCLD(I,J)-SPVAL) <= SMALL) THEN
             CEILING(I,J)=SPVAL
           ELSE IF(TCLD(I,J) >= 50.) THEN
-            if(MODELNAME == 'RAPR')then
-              if(SUBMODELNAME == 'RTMA')then
-                CEILING(I,J) = CLDZ(I,J) ! using height ASL for RTMA (including HRRR-based 3DRTMA)
-              else
-                CEILING(I,J) = CLDZ(I,J) - FIS(I,J)*GI
-              end if
+            if(MODELNAME == 'RAPR' .AND. SUBMODELNAME /= 'RTMA')then
+              CEILING(I,J) = CLDZ(I,J) - FIS(I,J)*GI
             else
               CEILING(I,J) = CLDZ(I,J) ! for RAP/HRRR   - FIS(I,J)*GI
             endif

--- a/sorc/ncep_post.fd/AVIATION.f
+++ b/sorc/ncep_post.fd/AVIATION.f
@@ -493,10 +493,13 @@
 !> @param[inout] CEILING CEILING HEIGHT from surface (m)
 !>     
 !> @author Binbin Zhou NCEP/EMC  @date 2005-08-18       
+!> @modification history:
+!>    2026-07-24 | Gang Zhao      | using height above seal level for RTMA
       SUBROUTINE CALCEILING (CLDZ,TCLD,CEILING)
       USE vrbls2d, only: fis
       use params_mod, only: small, gi
-      use ctlblk_mod, only: jsta, jend, spval, im, modelname, ista, iend
+      use ctlblk_mod, only: jsta, jend, spval, im, modelname, ista, iend,       &
+                            submodelname
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       implicit none
 !     
@@ -514,7 +517,11 @@
             CEILING(I,J)=SPVAL
           ELSE IF(TCLD(I,J) >= 50.) THEN
             if(MODELNAME == 'RAPR')then
-              CEILING(I,J) = CLDZ(I,J) - FIS(I,J)*GI
+              if(SUBMODELNAME == 'RTMA')then
+                CEILING(I,J) = CLDZ(I,J) ! using height ASL for RTMA (including HRRR-based 3DRTMA)
+              else
+                CEILING(I,J) = CLDZ(I,J) - FIS(I,J)*GI
+              end if
             else
               CEILING(I,J) = CLDZ(I,J) ! for RAP/HRRR   - FIS(I,J)*GI
             endif

--- a/sorc/ncep_post.fd/CLDRAD.f
+++ b/sorc/ncep_post.fd/CLDRAD.f
@@ -90,6 +90,11 @@
 !> 2025-05-05 | Ben Blake         | Add sanity checks for RRFSv1 implementation
 !> 2025-05-08 | Jaymes Kenyon     | For FV3 and MPAS applications, prevent cloud base from being diagnosed as below ground
 !> 2025-11-13 | Jaymes Kenyon     | Minor refactoring: the value of "cloud_def_p" (constant) is now set in params_mod
+!> 2026-07-23 | Gang Zhao         | Only for 3DRTMA, when calculating field 260 for Cloud Ceiling Height (CCH), providing two algorithms
+!>                                | to compute the cloud base height (array CLDZ260)
+!>                                | 1) i_cch260_rtma = 1, using the same cloud base height computed with GSD legacy
+!>                                !    cloud ceiling algorithm as used for field 408
+!>                                | 2) i_cch260_rtma !=1, using the cloud base height computed with original Ferrier Feb'02 algorithm
 !>
 !> @author Russ Treadon W/NP2 @date 1993-08-30
 !---------------------------------------------------------------------------------
@@ -133,7 +138,7 @@
                             TCLOD, ARDSW, TRDSW, ARDLW, NBIN_DU, TRDLW, IM,   &
                             NBIN_SS, NBIN_OC,NBIN_BC,NBIN_SU,NBIN_NO3,DTQ2,   &
                             JM, LM, gocart_on, gccpp_on, nasa_on, me, rdaod,  &
-                            ISTA, IEND,aqf_on,TSRFC
+                            ISTA, IEND,aqf_on,TSRFC, i_cch260_rtma
       use rqstfld_mod, only: IGET, ID, LVLS, IAVBLFLD
       use gridspec_mod, only: dyval, gridtype
       use cmassi_mod,  only: TRAD_ice
@@ -154,7 +159,7 @@
                                          ITOPT, ITOPCu, ITOPDCu, ITOPSCu, ITOPGr
       REAL,dimension(im,jm)           :: GRID1
       REAL,dimension(ista:iend,jsta:jend)    :: GRID2, EGRID1, EGRID2, EGRID3,      &
-                                         CLDP, CLDZ, CLDT, CLDZCu
+                                         CLDP, CLDZ, CLDT, CLDZCu, CLDZ260
       REAL,dimension(lm)       :: RHB, watericetotal, pabovesfc
       REAL   :: watericemax, wimin, zcldbase, zcldtop, zpbltop,              &
                 rhoice, coeffp, exponfp, const1,                             &
@@ -1841,6 +1846,7 @@ snow_check:   IF (QQS(I,J,L)>=QCLDmin) THEN
                  CLDZ(I,J) = -5000.
                ENDIF       !--- End IF (IBOT <= 0) ...
             ENDIF
+            CLDZ260(I,J) = CLDZ(I,J)       ! using cloud base height computed with Ferrier's algorithm
           ENDDO         !--- End DO I loop
         ENDDO           !--- End DO J loop
 !   CLOUD BOTTOM PRESSURE
@@ -2108,6 +2114,15 @@ snow_check:   IF (QQS(I,J,L)>=QCLDmin) THEN
                 GRID1(I,J) = CLDZ(I,J)
               ENDDO
             ENDDO
+!!$omp parallel do private(i,j)
+            IF ( i_cch260_rtma == 1 ) then
+              DO J=JSTA,JEND
+              DO I=ISTA,IEND
+                CLDZ260(I,J) = CLDZ(I,J)    ! for CCH 260, using the same cloud base height computed
+                                            ! with GSD legacy algorithm as used for 408
+              ENDDO
+              ENDDO
+            END IF
                if(grib=="grib2" )then
                  cfld=cfld+1
                  fld_info(cfld)%ifld=IAVBLFLD(IGET(408))
@@ -2409,7 +2424,11 @@ snow_check:   IF (QQS(I,J,L)>=QCLDmin) THEN
  
 !    B. ZHOU: CEILING
         IF (IGET(260)>0) THEN
-            CALL CALCEILING(CLDZ,TCLD,CEILING)
+            IF ( MODELNAME == "RAPR" .and. SUBMODELNAME == "RTMA" ) then
+              CALL CALCEILING(CLDZ260,TCLD,CEILING)
+            ELSE
+              CALL CALCEILING(CLDZ,TCLD,CEILING)
+            END IF
             DO J=JSTA,JEND
               DO I=ISTA,IEND
                GRID1(I,J) = CEILING(I,J)

--- a/sorc/ncep_post.fd/CTLBLK.f
+++ b/sorc/ncep_post.fd/CTLBLK.f
@@ -21,6 +21,10 @@
 !>  2025-07-25 | Jaymes Kenyon | Add "earth_radius" namelist option
 !>  2025-12-16 | Ben Blake  | Add capecin_2m logical option
 !>  2026-03-04 | Gang Zhao  | Add synthetic_cfr logical option to switch on/off the synthetic scheme for Cloud-fraction added by Jaymes Kenyon for HRRR-3DRTMA in Nov 2025.
+!>  2026-07-23 | Gang Zhao  | Add i_cch260_rtma integer option to control the selection of the cloud base height (CLDZ)
+!>                          | which is used in the calculation of field 260 for Cloud Ceiling Height (CCH) in 3DRTMA run
+!>                          | = 0 (default) CLDZ is computed with original algorithm (convective + grid-scale; Ferrier, Feb '02)
+!>                          | = 1 CLDZ is computed with GSD legacy cloud ceiling alrorithm (used for field 408)
 !-----------------------------------------------------------------------
 !> @defgroup CTLBLK CTLBLK
 !> Sets default parameters that are used throughout the UPP code
@@ -80,6 +84,7 @@
   logical :: method_blsn   !< Turn on blowing snow effect on visibility diagnostic
   logical :: capecin_2m = .false. !< Turn on option to calculate CAPE and CIN using 2-m fields
   logical :: synthetic_cfr = .false. !< Turn on option to enable the synthetic cloud fraction scheme for HRRR-3DRTMA
+  integer :: i_cch260_rtma = 0       !< using original Ferrier's scheme to compute cloud base height for field 260 (only used for 3DRTMA)
 !
   logical :: SIGMA      !< No longer used/supported.
   logical :: RUN        !< No longer used/supported.

--- a/sorc/ncep_post.fd/CTLBLK.f
+++ b/sorc/ncep_post.fd/CTLBLK.f
@@ -24,7 +24,7 @@
 !>  2026-07-23 | Gang Zhao  | Add i_cch260_rtma integer option to control the selection of the cloud base height (CLDZ)
 !>                          | which is used in the calculation of field 260 for Cloud Ceiling Height (CCH) in 3DRTMA run
 !>                          | = 0 (default) CLDZ is computed with original algorithm (convective + grid-scale; Ferrier, Feb '02)
-!>                          | = 1 CLDZ is computed with GSD legacy cloud ceiling alrorithm (used for field 408)
+!>                          | = 1 CLDZ is computed with GSD legacy cloud ceiling algorithm (used for field 408)
 !-----------------------------------------------------------------------
 !> @defgroup CTLBLK CTLBLK
 !> Sets default parameters that are used throughout the UPP code

--- a/sorc/ncep_post.fd/WRFPOST.F
+++ b/sorc/ncep_post.fd/WRFPOST.F
@@ -45,7 +45,7 @@
 !> 2026-07-23 | Gang Zhao                 | Add i_cch260_rtma integer option to control the selection of the cloud base height (CLDZ)
 !>                                        | which is used in the calculation of field 260 for Cloud Ceiling Height (CCH) in 3DRTMA run
 !>                                        | = 0 (default) CLDZ is computed with original algorithm (convective + grid-scale; Ferrier, Feb '02)
-!>                                        | = 1 CLDZ is computed with GSD legacy cloud ceiling alrorithm (used for field 408)
+!>                                        | = 1 CLDZ is computed with GSD legacy cloud ceiling algorithm (used for field 408)
 !> @author Mike Baldwin NSSL/SPC @date 2002-06-18
 !---------------------------------------------------------------------
 !> @return wrfpost

--- a/sorc/ncep_post.fd/WRFPOST.F
+++ b/sorc/ncep_post.fd/WRFPOST.F
@@ -42,6 +42,10 @@
 !> 2025-07-25 | Jaymes Kenyon             | Add "earth_radius" namelist option
 !> 2025-12-16 | Ben Blake                 | Add capecin_2m option to calculate CAPE and CIN with 2-m fields
 !> 2026-03-04 | Gang Zhao                 | Add synthetic_cfr logical option to switch on/off the synthetic scheme for Cloud-fraction added by Jaymes Kenyon for HRRR-3DRTMA in Nov 2025.
+!> 2026-07-23 | Gang Zhao                 | Add i_cch260_rtma integer option to control the selection of the cloud base height (CLDZ)
+!>                                        | which is used in the calculation of field 260 for Cloud Ceiling Height (CCH) in 3DRTMA run
+!>                                        | = 0 (default) CLDZ is computed with original algorithm (convective + grid-scale; Ferrier, Feb '02)
+!>                                        | = 1 CLDZ is computed with GSD legacy cloud ceiling alrorithm (used for field 408)
 !> @author Mike Baldwin NSSL/SPC @date 2002-06-18
 !---------------------------------------------------------------------
 !> @return wrfpost
@@ -135,7 +139,8 @@
               mdl2agl_tim, mdl2std_tim, mdl2thandpv_tim, calrad_wcloud_tim,nasa_on,gccpp_on,         &
               fixed_tim, time_output, imin, surfce2_tim, komax, ivegsrc, d3d_on, gocart_on,rdaod,    &
               readxml_tim, spval, fullmodelname, submodelname, hyb_sigp, filenameflat, aqf_on,numx,  &
-              run_ifi_tim, slrutah_on, d2d_chem, gtg_on, method_blsn, capecin_2m, synthetic_cfr
+              run_ifi_tim, slrutah_on, d2d_chem, gtg_on, method_blsn, capecin_2m, synthetic_cfr,     &
+              i_cch260_rtma
       use grib2_module,   only: gribit2,num_pset,nrecout,first_grbtbl,grib_info_finalize
       use upp_ifi_mod, only: write_ifi_debug_files
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
@@ -165,7 +170,7 @@
       real,dimension(komax) :: po,th,pv
       namelist/nampgb/kpo,po,kth,th,kpv,pv,fileNameAER,d3d_on,gocart_on,gccpp_on, nasa_on,gtg_on,method_blsn,popascal &
                      ,hyb_sigp,rdaod,d2d_chem, aqf_on,slrutah_on, vtimeunits,numx,write_ifi_debug_files, capecin_2m   &
-                     , synthetic_cfr
+                     , synthetic_cfr, i_cch260_rtma
       integer      :: itag_ierr
       namelist/model_inputs/fileName,IOFORM,grib,DateStr,MODELNAME,SUBMODELNAME,earth_radius &
                      ,fileNameFlux,fileNameFlat
@@ -276,6 +281,7 @@
         method_blsn = .true.
         capecin_2m  = .false.
         synthetic_cfr = .false.
+        i_cch260_rtma = 0
         popascal    = .false.
         fileNameAER = ''
         rdaod       = .false.


### PR DESCRIPTION
**Description**

1. For field 260 of Cloud Ceiling Height (CCH), for (3D)RTMA, clarify that there are two algorithms used to compute cloud base height (CLDZ260), and introducing a new namelist integer option i_cch260_rtma to switch the algorithm (in CLDRAD.f)
     (1) i_cch260_rtma = 0 (default, or any integer not equalt to 1), using original Ferrier Feb'02 algorithm;
     (2) i_cch260_rtma = 1, using GSD legacy cloud ceiling algorithm;
3. For CCH field 260, define the height as height above sea level (ASL) for (3D)RTMA run (in subroutine CALCEILING of AVIATION.f);

Fixes UPP issue #1578;

**Test**

- Regression test (RT) was made. Because this modification was made based on branch "release/3drtma_v1" (which is somehow out of dated if comparing to master branch "develop"), so the RTs for "rrfs" and "mpas" failed to run. As for "3drtma, RT results are different for field 260 only which is expected, since in the modified code. field 260 is re-defined as height ASL, and by default field 260 uses original Ferrier's algorithm to compute the cloud base height. Other than those, RTs results for other systems are same as control/reference runs.
- As a test (not for merging to master branch "develop") I also applied the modifications to master branch "develop" and ran the RTs: IF set i_cch260_rtma=1 as default in source code (in CTLBLF.f and WRFPOST.f), and IF still define field 260 as height above ground level (that means no change to subroutine CALCEILING of AVIATION,f), then all RTs passed, including for 3drtma. So these modifications should be good and ready for merging to master branch "develop".

**Plan**

- Based on previous testing results, CCH field 260 with cloud base height computed with GSD legacy algorithm (i.e. i_cch260_rtma=1) performs better than CCH field 408 and CCH of 2DRTMA. We will run longer term parallel 3DRTMA, and make the verification and comparison among CCH of 260 (i_cch260=0, and 1), 408 and CCH of 2DRTMA, then make the decision on the selection of cloud ceiling height for 3DRTMA.
- An issue was found: the param file "parm/3drtma/postxconfig-NT-3drtma.txt" (the post configuration file for 3DRTMA) is not same to each other between branch "[develop](https://github.com/NOAA-EMC/UPP/blob/develop/parm/3drtma/postxconfig-NT-3drtma.txt)" and branch "[release/3drtma_v1](https://github.com/NOAA-EMC/UPP/blob/release/3drtma_v1/parm/3drtma/postxconfig-NT-3drtma.txt)".  This will be addressed later in another issue and PR for 3DRTMA.