### PR TITLE
GFS: Use WMO GRIB2 IDs, update baseline data

### DIFF
--- a/ci/jobs-dev/run_post_gfs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_gfs_WCOSS2.sh
@@ -37,8 +37,8 @@ postmsg "$logfile" "$msg"
 export POSTGPEXEC=$svndir/exec/upp.x
 
 # specify forecast start time and hour
-export startdate=2025012600
-export fhr=006
+export startdate=2026081800
+export fhr=012
 export cyc=`echo $startdate |cut -c9-10`
 
 # specify your running and output directory
@@ -54,12 +54,12 @@ export HH=`echo $NEWDATE | cut -c9-10`
 
 cat > itag <<EOF
 &model_inputs
-fileName='$homedir/data_in/gfs/gfs.t${cyc}z.atmf${fhr}.nc'
+fileName='$homedir/data_in/gfs/gfs.t${cyc}z.atm.f${fhr}.nc'
 IOFORM='netcdf'
 grib='grib2'
 DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
 MODELNAME='GFS'
-fileNameFlux='$homedir/data_in/gfs/gfs.t${cyc}z.sfcf${fhr}.nc'
+fileNameFlux='$homedir/data_in/gfs/gfs.t${cyc}z.sfc.f${fhr}.nc'
 /
 &NAMPGB
 KPO=57,PO=1000.,975.,950.,925.,900.,875.,850.,825.,800.,775.,750.,725.,700.,675.,650.,625.,600.,575.,550.,525.,500.,475.,450.,425.,400.,375.,350.,325.,300.,275.,250.,225.,200.,175.,150.,125.,100.,70.,50.,40.,30.,20.,15.,10.,7.,5.,3.,2.,1.,0.7,0.4,0.2,0.1,0.07,0.04,0.02,0.01,rdaod=.true.,
@@ -101,14 +101,14 @@ ${APRUN} ${POSTGPEXEC} < itag > outpost_gfs_goes_${NEWDATE}
 fhr=$((10#$fhr))
 FH3=$(printf "%03d" "$fhr")
 FH2=$(printf "%02d" "$fhr")
-mv GFSPRS.GrbF${FH2} gfs.t${cyc}z.master.grb2f${FH3}
-mv GFSFLX.GrbF${FH2} gfs.t${cyc}z.sfluxgrbf${FH3}.grib2
-mv GFSGOES.GrbF${FH2} gfs.t${cyc}z.special.grb2f${FH3}
+mv GFSPRS.GrbF${FH2} gfs.t${cyc}z.master.f${FH3}.grib2
+mv GFSFLX.GrbF${FH2} gfs.t${cyc}z.sflux.f${FH3}.grib2
+mv GFSGOES.GrbF${FH2} gfs.t${cyc}z.master-goes.f${FH3}.grib2
 
 # GFS post processing generates 3 files
-filelist="gfs.t${cyc}z.master.grb2f${FH3} \
-          gfs.t${cyc}z.sfluxgrbf${FH3}.grib2 \
-          gfs.t${cyc}z.special.grb2f${FH3} "
+filelist="gfs.t${cyc}z.master.f${FH3}.grib2 \
+          gfs.t${cyc}z.sflux.f${FH3}.grib2 \
+          gfs.t${cyc}z.master-goes.f${FH3}.grib2 "
 
 for file in $filelist; do
 

--- a/ci/jobs-dev/run_post_gfs_template.sh
+++ b/ci/jobs-dev/run_post_gfs_template.sh
@@ -38,8 +38,8 @@ postmsg "$logfile" "$msg"
 export POSTGPEXEC=${svndir}/exec/upp.x
 
 # specify forecast start time and hour for running your post job
-export startdate=2025012600
-export fhr=006
+export startdate=2026081800
+export fhr=012
 export cyc=`echo $startdate |cut -c9-10`
 
 # specify your running and output directory
@@ -55,12 +55,12 @@ export HH=`echo $NEWDATE | cut -c9-10`
 
 cat > itag <<EOF
 &model_inputs
-fileName='$homedir/data_in/gfs/gfs.t${cyc}z.atmf${fhr}.nc'
+fileName='$homedir/data_in/gfs/gfs.t${cyc}z.atm.f${fhr}.nc'
 IOFORM='netcdf'
 grib='grib2'
 DateStr='${YY}-${MM}-${DD}_${HH}:00:00'
 MODELNAME='GFS'
-fileNameFlux='$homedir/data_in/gfs/gfs.t${cyc}z.sfcf${fhr}.nc'
+fileNameFlux='$homedir/data_in/gfs/gfs.t${cyc}z.sfc.f${fhr}.nc'
 /
 &NAMPGB
 KPO=57,PO=1000.,975.,950.,925.,900.,875.,850.,825.,800.,775.,750.,725.,700.,675.,650.,625.,600.,575.,550.,525.,500.,475.,450.,425.,400.,375.,350.,325.,300.,275.,250.,225.,200.,175.,150.,125.,100.,70.,50.,40.,30.,20.,15.,10.,7.,5.,3.,2.,1.,0.7,0.4,0.2,0.1,0.07,0.04,0.02,0.01,rdaod=.true.,
@@ -104,14 +104,14 @@ ${APRUN} ${POSTGPEXEC} < itag > outpost_gfs_goes_${NEWDATE}
 fhr=$((10#$fhr))
 FH3=$(printf "%03d" "$fhr")
 FH2=$(printf "%02d" "$fhr")
-mv GFSPRS.GrbF${FH2} gfs.t${cyc}z.master.grb2f${FH3}
-mv GFSFLX.GrbF${FH2} gfs.t${cyc}z.sfluxgrbf${FH3}.grib2
-mv GFSGOES.GrbF${FH2} gfs.t${cyc}z.special.grb2f${FH3}
+mv GFSPRS.GrbF${FH2} gfs.t${cyc}z.master.f${FH3}.grib2
+mv GFSFLX.GrbF${FH2} gfs.t${cyc}z.sflux.f${FH3}.grib2
+mv GFSGOES.GrbF${FH2} gfs.t${cyc}z.master-goes.f${FH3}.grib2
 
 # GFS post processing generates 3 files
-filelist="gfs.t${cyc}z.master.grb2f${FH3} \
-          gfs.t${cyc}z.sfluxgrbf${FH3}.grib2 \
-          gfs.t${cyc}z.special.grb2f${FH3} "
+filelist="gfs.t${cyc}z.master.f${FH3}.grib2 \
+          gfs.t${cyc}z.sflux.f${FH3}.grib2 \
+          gfs.t${cyc}z.master-goes.f${FH3}.grib2 "
 
 for file in $filelist; do
 export filein2=$file

--- a/parm/gfs/postcntrl_gfs_anl.xml
+++ b/parm/gfs/postcntrl_gfs_anl.xml
@@ -84,7 +84,6 @@
 
     <param>
        <shortname>O3MR_ON_ISOBARIC_SFC</shortname>
-       <table_info>NCEP</table_info>
        <level>1. 2. 4. 7. 10. 20. 40. 70. 100. 200. 300. 500. 700. 1000. 1500. 2000. 3000. 4000. 5000. 7000. 10000. 12500. 15000. 17500. 20000. 22500. 25000. 27500. 30000. 32500. 35000. 37500. 40000. 42500.
         45000. 47500. 50000. 52500. 55000. 57500. 60000. 62500. 65000. 67500. 70000. 72500. 75000. 77500. 80000. 82500. 85000. 87500. 90000. 92500. 95000. 97500. 100000.</level>
        <scale>5.0</scale>
@@ -172,7 +171,6 @@
 
     <param>
        <shortname>VWSH_ON_TROPOPAUSE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -303,7 +301,6 @@
 
     <param>
        <shortname>VWSH_ON_POT_VORT_SFC</shortname>
-       <table_info>NCEP</table_info>
        <scale_fact_fixed_sfc1>9 9 9 9 9 9 9 9</scale_fact_fixed_sfc1>
        <level>500. -500. 1000. -1000. 1500. -1500. 2000. -2000.</level>
        <scale>3.0</scale>
@@ -399,7 +396,6 @@
 
     <param>
        <shortname>GFS_LFTX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -443,7 +439,6 @@
 
     <param>
        <shortname>GFS_4LFTX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 

--- a/parm/gfs/postcntrl_gfs_f00_two.xml
+++ b/parm/gfs/postcntrl_gfs_f00_two.xml
@@ -84,7 +84,6 @@
 
     <param>
        <shortname>O3MR_ON_ISOBARIC_SFC</shortname>
-       <table_info>NCEP</table_info>
        <level>1. 2. 4. 7. 10. 20. 40. 70. 100. 200. 300. 500. 700. 1000. 1500. 2000. 3000. 4000. 5000. 7000. 10000. 12500. 15000. 17500. 20000. 22500. 25000. 27500. 30000. 32500. 35000. 37500. 40000. 42500.
         45000. 47500. 50000. 52500. 55000. 57500. 60000. 62500. 65000. 67500. 70000. 72500. 75000. 77500. 80000. 82500. 85000. 87500. 90000. 92500. 95000. 97500. 100000.</level>
        <scale>5.0</scale>
@@ -127,7 +126,6 @@
 
     <param>
        <shortname>REFC_ON_ENTIRE_ATMOS</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -207,7 +205,6 @@
 
     <param>
        <shortname>SOILL_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <table_info>NCEP</table_info>
        <scale_fact_fixed_sfc1>2 2 2 2 </scale_fact_fixed_sfc1>
        <level>0. 10. 40. 100.</level>
        <scale_fact_fixed_sfc2>2 2 2 2 </scale_fact_fixed_sfc2>
@@ -217,7 +214,6 @@
 
     <param>
        <shortname>CNWAT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -228,7 +224,6 @@
 
     <param>
        <shortname>PEVPR_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -245,7 +240,6 @@
 
     <param>
        <shortname>WILT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
        <bit_map_flag>yes</bit_map_flag>
     </param>
@@ -259,13 +253,11 @@
 
     <param>
        <shortname>GFS_LFTX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
     <param>
        <shortname>GFS_4LFTX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -321,7 +313,6 @@
 
     <param>
        <shortname>USTM_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
-       <table_info>NCEP</table_info>
        <level>6000.</level>
        <level2>0.</level2>
        <scale>4.0</scale>
@@ -329,7 +320,6 @@
 
     <param>
        <shortname>VSTM_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
-       <table_info>NCEP</table_info>
        <level>6000.</level>
        <level2>0.</level2>
        <scale>4.0</scale>
@@ -337,25 +327,21 @@
 
     <param>
        <shortname>INST_CRAIN_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>1.0</scale>
     </param>
 
     <param>
        <shortname>CSNOW_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>1.0</scale>
     </param>
 
     <param>
        <shortname>CICEP_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>1.0</scale>
     </param>
 
     <param>
        <shortname>CFRZR_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>1.0</scale>
     </param>
 
@@ -376,7 +362,6 @@
 
     <param>
        <shortname>FRICV_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -416,7 +401,6 @@
 
     <param>
        <shortname>VWSH_ON_TROPOPAUSE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -614,7 +598,6 @@
 
     <param>
        <shortname>HPBL_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -719,7 +702,6 @@
 
     <param>
        <shortname>VWSH_ON_POT_VORT_SFC</shortname>
-       <table_info>NCEP</table_info>
        <scale_fact_fixed_sfc1>9 9 9 9 9 9 9 9</scale_fact_fixed_sfc1>
        <level>500. -500. 1000. -1000. 1500. -1500. 2000. -2000.</level>
        <scale>3.0</scale>
@@ -747,7 +729,6 @@
 
     <param>
        <shortname>SUNSD_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>5.0</scale>
     </param>
 
@@ -873,7 +854,6 @@
     <param>
        <shortname>REFD_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
        <pname>REFD</pname>
-       <table_info>NCEP</table_info>
        <level>4000. 1000.</level>
        <scale>4.0</scale>
     </param>
@@ -881,7 +861,6 @@
     <param>
        <shortname>REFD_ON_HYBRID_LVL</shortname>
        <pname>REFD</pname>
-       <table_info>NCEP</table_info>
        <level>1. 2.</level>
        <scale>4.0</scale>
     </param>
@@ -1019,7 +998,6 @@
 
     <param>
        <shortname>SOILL_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <table_info>NCEP</table_info>
        <scale_fact_fixed_sfc1>2 2 2 2</scale_fact_fixed_sfc1>
        <level>0. 10. 40. 100.</level>
        <scale_fact_fixed_sfc2>2 2 2 2</scale_fact_fixed_sfc2>
@@ -1029,7 +1007,6 @@
 
     <param>
        <shortname>CNWAT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -1040,10 +1017,8 @@
 
     <param>
        <shortname>PEVPR_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
-
 
     <param>
        <shortname>ICETK_ON_SURFACE</shortname>
@@ -1058,7 +1033,6 @@
 
     <param>
        <shortname>WILT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
        <bit_map_flag>yes</bit_map_flag>
     </param>
@@ -1077,25 +1051,21 @@
 
     <param>
        <shortname>INST_DSWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>INST_DLWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>INST_USWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>INST_ULWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -1128,13 +1098,11 @@
 
     <param>
        <shortname>FRICV_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>SFEXC_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -1151,7 +1119,6 @@
 
     <param>
        <shortname>INST_GFLUX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -1171,7 +1138,6 @@
 
     <param>
        <shortname>HPBL_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -1182,7 +1148,6 @@
 
     <param>
        <shortname>SUNSD_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>5.0</scale>
     </param>
 

--- a/parm/gfs/postcntrl_gfs_two.xml
+++ b/parm/gfs/postcntrl_gfs_two.xml
@@ -84,7 +84,6 @@
 
     <param>
        <shortname>O3MR_ON_ISOBARIC_SFC</shortname>
-       <table_info>NCEP</table_info>
        <level>1. 2. 4. 7. 10. 20. 40. 70. 100. 200. 300. 500. 700. 1000. 1500. 2000. 3000. 4000. 5000. 7000. 10000. 12500. 15000. 17500. 20000. 22500. 25000. 27500. 30000. 32500. 35000. 37500. 40000. 42500. 
        	45000. 47500. 50000. 52500. 55000. 57500. 60000. 62500. 65000. 67500. 70000. 72500. 75000. 77500. 80000. 82500. 85000. 87500. 90000. 92500. 95000. 97500. 100000.</level>
        <scale>5.0</scale>
@@ -127,7 +126,6 @@
 
     <param>
        <shortname>REFC_ON_ENTIRE_ATMOS</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -207,7 +205,6 @@
 
     <param>
        <shortname>SOILL_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <table_info>NCEP</table_info>
        <scale_fact_fixed_sfc1>2 2 2 2</scale_fact_fixed_sfc1>
        <level>0. 10. 40. 100.</level>
        <scale_fact_fixed_sfc2>2 2 2 2</scale_fact_fixed_sfc2>
@@ -217,7 +214,6 @@
 
     <param>
        <shortname>CNWAT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -228,7 +224,6 @@
 
     <param>
        <shortname>PEVPR_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -245,7 +240,6 @@
 
     <param>
        <shortname>WILT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
        <bit_map_flag>yes</bit_map_flag>
     </param>
@@ -259,13 +253,11 @@
 
     <param>
        <shortname>GFS_LFTX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
     <param>
        <shortname>GFS_4LFTX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -321,7 +313,6 @@
 
     <param>
        <shortname>USTM_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
-       <table_info>NCEP</table_info>
        <level>6000.</level>
        <level2>0.</level2>
        <scale>4.0</scale>
@@ -329,7 +320,6 @@
 
     <param>
        <shortname>VSTM_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
-       <table_info>NCEP</table_info>
        <level>6000.</level>
        <level2>0.</level2>
        <scale>4.0</scale>
@@ -367,25 +357,21 @@
 
     <param>
        <shortname>INST_CRAIN_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>1.0</scale>
     </param>
 
     <param>
        <shortname>CSNOW_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>1.0</scale>
     </param>
 
     <param>
        <shortname>CICEP_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>1.0</scale>
     </param>
 
     <param>
        <shortname>CFRZR_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>1.0</scale>
     </param>
 
@@ -396,7 +382,6 @@
 
     <param>
        <shortname>AVE_CPRAT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -427,7 +412,6 @@
 
     <param>
        <shortname>AVE_DSWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -445,31 +429,26 @@
 
     <param>
        <shortname>AVE_DLWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>AVE_USWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>AVE_ULWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>AVE_USWRF_ON_TOP_OF_ATMOS</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>AVE_ULWRF_ON_TOP_OF_ATMOS</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -485,7 +464,6 @@
 
     <param>
        <shortname>FRICV_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -496,7 +474,6 @@
 
     <param>
        <shortname>AVE_GFLUX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -556,7 +533,6 @@
 
     <param>
        <shortname>VWSH_ON_TROPOPAUSE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -754,7 +730,6 @@
 
     <param>
        <shortname>HPBL_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -919,7 +894,6 @@
 
     <param>
        <shortname>VWSH_ON_POT_VORT_SFC</shortname>
-       <table_info>NCEP</table_info>
        <scale_fact_fixed_sfc1>9 9 9 9 9 9 9 9</scale_fact_fixed_sfc1>
        <level>500. -500. 1000. -1000. 1500. -1500. 2000. -2000.</level>
        <scale>3.0</scale>
@@ -932,19 +906,16 @@
 
     <param>
        <shortname>AVE_CWORK_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>AVE_U-GWD_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>5.0</scale>
     </param>
 
     <param>
        <shortname>AVE_V-GWD_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>5.0</scale>
     </param>
 
@@ -975,7 +946,6 @@
 
     <param>
        <shortname>SUNSD_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>5.0</scale>
     </param>
 
@@ -1101,7 +1071,6 @@
    <param>
       <shortname>REFD_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
       <pname>REFD</pname>
-      <table_info>NCEP</table_info>
       <level>4000. 1000.</level>
       <scale>4.0</scale>
    </param>
@@ -1109,7 +1078,6 @@
    <param>
       <shortname>REFD_ON_HYBRID_LVL</shortname>
       <pname>REFD</pname>
-      <table_info>NCEP</table_info>
       <level>1. 2.</level>
       <scale>4.0</scale>
    </param>
@@ -1282,7 +1250,6 @@
 
     <param>
        <shortname>SOILL_ON_DEPTH_BEL_LAND_SFC</shortname>
-       <table_info>NCEP</table_info>
        <scale_fact_fixed_sfc1>2 2 2 2</scale_fact_fixed_sfc1>
        <level>0. 10. 40. 100.</level>
        <scale_fact_fixed_sfc2>2 2 2 2</scale_fact_fixed_sfc2>
@@ -1292,7 +1259,6 @@
 
     <param>
        <shortname>CNWAT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>3.0</scale>
     </param>
 
@@ -1303,13 +1269,11 @@
 
     <param>
        <shortname>AVE_PEVPR_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>PEVPR_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -1327,7 +1291,6 @@
 
     <param>
        <shortname>WILT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
        <bit_map_flag>yes</bit_map_flag>
     </param>
@@ -1351,7 +1314,6 @@
 
     <param>
        <shortname>AVE_CPRAT_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -1377,19 +1339,16 @@
 
     <param>
        <shortname>AVE_DSWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>INST_DSWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>AVE_DSWRF_ON_TOP_OF_ATMOS</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -1407,49 +1366,41 @@
 
     <param>
        <shortname>AVE_DLWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>INST_DLWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>AVE_USWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>INST_USWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>AVE_ULWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>INST_ULWRF_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>AVE_USWRF_ON_TOP_OF_ATMOS</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
     <param>
        <shortname>AVE_ULWRF_ON_TOP_OF_ATMOS</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -1542,13 +1493,11 @@
 
     <param>
        <shortname>FRICV_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>SFEXC_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
@@ -1570,19 +1519,16 @@
 
     <param>
        <shortname>AVE_GFLUX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>INST_GFLUX_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>ACM_SSRUN_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -1622,7 +1568,6 @@
 
     <param>
        <shortname>HPBL_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>6.0</scale>
     </param>
 
@@ -1693,19 +1638,16 @@
 
     <param>
        <shortname>AVE_CWORK_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
-       <table_info>NCEP</table_info>
        <scale>4.0</scale>
     </param>
 
     <param>
        <shortname>AVE_U-GWD_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>5.0</scale>
     </param>
 
     <param>
        <shortname>AVE_V-GWD_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>5.0</scale>
     </param>
 
@@ -1738,7 +1680,6 @@
 
     <param>
        <shortname>SUNSD_ON_SURFACE</shortname>
-       <table_info>NCEP</table_info>
        <scale>5.0</scale>
     </param>
 

--- a/parm/gfs/postxconfig-NT-gfs-anl.txt
+++ b/parm/gfs/postxconfig-NT-gfs-anl.txt
@@ -400,7 +400,7 @@ O3MR_ON_ISOBARIC_SFC
 1
 tmpl4_0
 O3MR
-NCEP
+?
 ?
 isobaric_sfc
 0
@@ -1030,7 +1030,7 @@ VWSH_ON_TROPOPAUSE
 1
 tmpl4_0
 VWSH
-NCEP
+?
 ?
 tropopause
 0
@@ -1996,7 +1996,7 @@ VWSH_ON_POT_VORT_SFC
 1
 tmpl4_0
 VWSH
-NCEP
+?
 ?
 pot_vort_sfc
 8
@@ -2626,7 +2626,7 @@ GFS_LFTX_ON_SURFACE
 1
 tmpl4_0
 LFTX
-NCEP
+?
 ?
 surface
 0
@@ -2962,7 +2962,7 @@ GFS_4LFTX_ON_SURFACE
 1
 tmpl4_0
 4LFTX
-NCEP
+?
 ?
 surface
 0

--- a/parm/gfs/postxconfig-NT-gfs-f00-two.txt
+++ b/parm/gfs/postxconfig-NT-gfs-f00-two.txt
@@ -401,7 +401,7 @@ O3MR_ON_ISOBARIC_SFC
 1
 tmpl4_0
 O3MR
-NCEP
+?
 ?
 isobaric_sfc
 0
@@ -653,7 +653,7 @@ REFC_ON_ENTIRE_ATMOS
 1
 tmpl4_0
 REFC
-NCEP
+?
 ?
 entire_atmos_single_lyr
 0
@@ -1241,7 +1241,7 @@ SOILL_ON_DEPTH_BEL_LAND_SFC
 1
 tmpl4_0
 SOILL
-NCEP
+?
 ?
 depth_bel_land_sfc
 4
@@ -1283,7 +1283,7 @@ CNWAT_ON_SURFACE
 1
 tmpl4_0
 CNWAT
-NCEP
+?
 ?
 surface
 0
@@ -1367,7 +1367,7 @@ PEVPR_ON_SURFACE
 1
 tmpl4_0
 PEVPR
-NCEP
+?
 ?
 surface
 0
@@ -1493,7 +1493,7 @@ WILT_ON_SURFACE
 1
 tmpl4_0
 WILT
-NCEP
+?
 ?
 surface
 0
@@ -1577,7 +1577,7 @@ GFS_LFTX_ON_SURFACE
 1
 tmpl4_0
 LFTX
-NCEP
+?
 ?
 surface
 0
@@ -1619,7 +1619,7 @@ GFS_4LFTX_ON_SURFACE
 1
 tmpl4_0
 4LFTX
-NCEP
+?
 ?
 surface
 0
@@ -2039,7 +2039,7 @@ USTM_ON_SPEC_HGT_LVL_ABOVE_GRND
 1
 tmpl4_0
 USTM
-NCEP
+?
 ?
 spec_hgt_lvl_above_grnd
 0
@@ -2081,7 +2081,7 @@ VSTM_ON_SPEC_HGT_LVL_ABOVE_GRND
 1
 tmpl4_0
 VSTM
-NCEP
+?
 ?
 spec_hgt_lvl_above_grnd
 0
@@ -2123,7 +2123,7 @@ INST_CRAIN_ON_SURFACE
 1
 tmpl4_0
 CRAIN
-NCEP
+?
 ?
 surface
 0
@@ -2165,7 +2165,7 @@ Categorical snow on surface
 1
 tmpl4_0
 CSNOW
-NCEP
+?
 ?
 surface
 0
@@ -2207,7 +2207,7 @@ Categorical ice pellets on surface
 1
 tmpl4_0
 CICEP
-NCEP
+?
 ?
 surface
 0
@@ -2249,7 +2249,7 @@ Categorical freezing rain on surface
 1
 tmpl4_0
 CFRZR
-NCEP
+?
 ?
 surface
 0
@@ -2417,7 +2417,7 @@ FRICV_ON_SURFACE
 1
 tmpl4_0
 FRICV
-NCEP
+?
 ?
 surface
 0
@@ -2753,7 +2753,7 @@ VWSH_ON_TROPOPAUSE
 1
 tmpl4_0
 VWSH
-NCEP
+?
 ?
 tropopause
 0
@@ -4223,7 +4223,7 @@ HPBL_ON_SURFACE
 1
 tmpl4_0
 HPBL
-NCEP
+?
 ?
 surface
 0
@@ -4937,7 +4937,7 @@ VWSH_ON_POT_VORT_SFC
 1
 tmpl4_0
 VWSH
-NCEP
+?
 ?
 pot_vort_sfc
 8
@@ -5147,7 +5147,7 @@ SUNSD_ON_SURFACE
 1
 tmpl4_0
 SUNSD
-NCEP
+?
 ?
 surface
 0
@@ -6113,7 +6113,7 @@ REFD_ON_SPEC_HGT_LVL_ABOVE_GRND
 1
 tmpl4_0
 REFD
-NCEP
+?
 ?
 spec_hgt_lvl_above_grnd
 0
@@ -6155,7 +6155,7 @@ REFD_ON_HYBRID_LVL
 1
 tmpl4_0
 REFD
-NCEP
+?
 ?
 hybrid_lvl
 0
@@ -7011,7 +7011,7 @@ SOILL_ON_DEPTH_BEL_LAND_SFC
 1
 tmpl4_0
 SOILL
-NCEP
+?
 ?
 depth_bel_land_sfc
 4
@@ -7053,7 +7053,7 @@ CNWAT_ON_SURFACE
 1
 tmpl4_0
 CNWAT
-NCEP
+?
 ?
 surface
 0
@@ -7137,7 +7137,7 @@ PEVPR_ON_SURFACE
 1
 tmpl4_0
 PEVPR
-NCEP
+?
 ?
 surface
 0
@@ -7263,7 +7263,7 @@ WILT_ON_SURFACE
 1
 tmpl4_0
 WILT
-NCEP
+?
 ?
 surface
 0
@@ -7389,7 +7389,7 @@ INST_DSWRF_ON_SURFACE
 1
 tmpl4_0
 DSWRF
-NCEP
+?
 ?
 surface
 0
@@ -7431,7 +7431,7 @@ INST_DLWRF_ON_SURFACE
 1
 tmpl4_0
 DLWRF
-NCEP
+?
 ?
 surface
 0
@@ -7473,7 +7473,7 @@ INST_USWRF_ON_SURFACE
 1
 tmpl4_0
 USWRF
-NCEP
+?
 ?
 surface
 0
@@ -7515,7 +7515,7 @@ INST_ULWRF_ON_SURFACE
 1
 tmpl4_0
 ULWRF
-NCEP
+?
 ?
 surface
 0
@@ -7767,7 +7767,7 @@ FRICV_ON_SURFACE
 1
 tmpl4_0
 FRICV
-NCEP
+?
 ?
 surface
 0
@@ -7809,7 +7809,7 @@ SFEXC_ON_SURFACE
 1
 tmpl4_0
 SFEXC
-NCEP
+?
 ?
 surface
 0
@@ -7935,7 +7935,7 @@ INST_GFLUX_ON_SURFACE
 1
 tmpl4_0
 GFLUX
-NCEP
+?
 ?
 surface
 0
@@ -8103,7 +8103,7 @@ HPBL_ON_SURFACE
 1
 tmpl4_0
 HPBL
-NCEP
+?
 ?
 surface
 0
@@ -8187,7 +8187,7 @@ SUNSD_ON_SURFACE
 1
 tmpl4_0
 SUNSD
-NCEP
+?
 ?
 surface
 0

--- a/parm/gfs/postxconfig-NT-gfs-two.txt
+++ b/parm/gfs/postxconfig-NT-gfs-two.txt
@@ -401,7 +401,7 @@ O3MR_ON_ISOBARIC_SFC
 1
 tmpl4_0
 O3MR
-NCEP
+?
 ?
 isobaric_sfc
 0
@@ -653,7 +653,7 @@ REFC_ON_ENTIRE_ATMOS
 1
 tmpl4_0
 REFC
-NCEP
+?
 ?
 entire_atmos_single_lyr
 0
@@ -1241,7 +1241,7 @@ SOILL_ON_DEPTH_BEL_LAND_SFC
 1
 tmpl4_0
 SOILL
-NCEP
+?
 ?
 depth_bel_land_sfc
 4
@@ -1283,7 +1283,7 @@ CNWAT_ON_SURFACE
 1
 tmpl4_0
 CNWAT
-NCEP
+?
 ?
 surface
 0
@@ -1367,7 +1367,7 @@ PEVPR_ON_SURFACE
 1
 tmpl4_0
 PEVPR
-NCEP
+?
 ?
 surface
 0
@@ -1493,7 +1493,7 @@ WILT_ON_SURFACE
 1
 tmpl4_0
 WILT
-NCEP
+?
 ?
 surface
 0
@@ -1577,7 +1577,7 @@ GFS_LFTX_ON_SURFACE
 1
 tmpl4_0
 LFTX
-NCEP
+?
 ?
 surface
 0
@@ -1619,7 +1619,7 @@ GFS_4LFTX_ON_SURFACE
 1
 tmpl4_0
 4LFTX
-NCEP
+?
 ?
 surface
 0
@@ -2039,7 +2039,7 @@ USTM_ON_SPEC_HGT_LVL_ABOVE_GRND
 1
 tmpl4_0
 USTM
-NCEP
+?
 ?
 spec_hgt_lvl_above_grnd
 0
@@ -2081,7 +2081,7 @@ VSTM_ON_SPEC_HGT_LVL_ABOVE_GRND
 1
 tmpl4_0
 VSTM
-NCEP
+?
 ?
 spec_hgt_lvl_above_grnd
 0
@@ -2375,7 +2375,7 @@ INST_CRAIN_ON_SURFACE
 1
 tmpl4_0
 CRAIN
-NCEP
+?
 ?
 surface
 0
@@ -2417,7 +2417,7 @@ Categorical snow on surface
 1
 tmpl4_0
 CSNOW
-NCEP
+?
 ?
 surface
 0
@@ -2459,7 +2459,7 @@ Categorical ice pellets on surface
 1
 tmpl4_0
 CICEP
-NCEP
+?
 ?
 surface
 0
@@ -2501,7 +2501,7 @@ Categorical freezing rain on surface
 1
 tmpl4_0
 CFRZR
-NCEP
+?
 ?
 surface
 0
@@ -2585,7 +2585,7 @@ AVE_CPRAT_ON_SURFACE
 1
 tmpl4_8
 CPRAT
-NCEP
+?
 AVE
 surface
 0
@@ -2837,7 +2837,7 @@ AVE_DSWRF_ON_SURFACE
 1
 tmpl4_8
 DSWRF
-NCEP
+?
 AVE
 surface
 0
@@ -2963,7 +2963,7 @@ AVE_DLWRF_ON_SURFACE
 1
 tmpl4_8
 DLWRF
-NCEP
+?
 AVE
 surface
 0
@@ -3005,7 +3005,7 @@ AVE_USWRF_ON_SURFACE
 1
 tmpl4_8
 USWRF
-NCEP
+?
 AVE
 surface
 0
@@ -3047,7 +3047,7 @@ AVE_ULWRF_ON_SURFACE
 1
 tmpl4_8
 ULWRF
-NCEP
+?
 AVE
 surface
 0
@@ -3089,7 +3089,7 @@ AVE_USWRF_ON_TOP_OF_ATMOS
 1
 tmpl4_8
 USWRF
-NCEP
+?
 AVE
 top_of_atmos
 0
@@ -3131,7 +3131,7 @@ AVE_ULWRF_ON_TOP_OF_ATMOS
 1
 tmpl4_8
 ULWRF
-NCEP
+?
 AVE
 top_of_atmos
 0
@@ -3257,7 +3257,7 @@ FRICV_ON_SURFACE
 1
 tmpl4_0
 FRICV
-NCEP
+?
 ?
 surface
 0
@@ -3341,7 +3341,7 @@ AVE_GFLUX_ON_SURFACE
 1
 tmpl4_8
 GFLUX
-NCEP
+?
 AVE
 surface
 0
@@ -3845,7 +3845,7 @@ VWSH_ON_TROPOPAUSE
 1
 tmpl4_0
 VWSH
-NCEP
+?
 ?
 tropopause
 0
@@ -5315,7 +5315,7 @@ HPBL_ON_SURFACE
 1
 tmpl4_0
 HPBL
-NCEP
+?
 ?
 surface
 0
@@ -6533,7 +6533,7 @@ VWSH_ON_POT_VORT_SFC
 1
 tmpl4_0
 VWSH
-NCEP
+?
 ?
 pot_vort_sfc
 8
@@ -6617,7 +6617,7 @@ AVE_CWORK_ON_ENTIRE_ATMOS_SINGLE_LYR
 1
 tmpl4_8
 CWORK
-NCEP
+?
 AVE
 entire_atmos_single_lyr
 0
@@ -6659,7 +6659,7 @@ AVE_U-GWD_ON_SURFACE
 1
 tmpl4_8
 U-GWD
-NCEP
+?
 AVE
 surface
 0
@@ -6701,7 +6701,7 @@ AVE_V-GWD_ON_SURFACE
 1
 tmpl4_8
 V-GWD
-NCEP
+?
 AVE
 surface
 0
@@ -6953,7 +6953,7 @@ SUNSD_ON_SURFACE
 1
 tmpl4_0
 SUNSD
-NCEP
+?
 ?
 surface
 0
@@ -7919,7 +7919,7 @@ REFD_ON_SPEC_HGT_LVL_ABOVE_GRND
 1
 tmpl4_0
 REFD
-NCEP
+?
 ?
 spec_hgt_lvl_above_grnd
 0
@@ -7961,7 +7961,7 @@ REFD_ON_HYBRID_LVL
 1
 tmpl4_0
 REFD
-NCEP
+?
 ?
 hybrid_lvl
 0
@@ -9111,7 +9111,7 @@ SOILL_ON_DEPTH_BEL_LAND_SFC
 1
 tmpl4_0
 SOILL
-NCEP
+?
 ?
 depth_bel_land_sfc
 4
@@ -9153,7 +9153,7 @@ CNWAT_ON_SURFACE
 1
 tmpl4_0
 CNWAT
-NCEP
+?
 ?
 surface
 0
@@ -9237,7 +9237,7 @@ AVE_PEVPR_ON_SURFACE
 1
 tmpl4_8
 PEVPR
-NCEP
+?
 AVE
 surface
 0
@@ -9279,7 +9279,7 @@ PEVPR_ON_SURFACE
 1
 tmpl4_0
 PEVPR
-NCEP
+?
 ?
 surface
 0
@@ -9405,7 +9405,7 @@ WILT_ON_SURFACE
 1
 tmpl4_0
 WILT
-NCEP
+?
 ?
 surface
 0
@@ -9573,7 +9573,7 @@ AVE_CPRAT_ON_SURFACE
 1
 tmpl4_8
 CPRAT
-NCEP
+?
 AVE
 surface
 0
@@ -9783,7 +9783,7 @@ AVE_DSWRF_ON_SURFACE
 1
 tmpl4_8
 DSWRF
-NCEP
+?
 AVE
 surface
 0
@@ -9825,7 +9825,7 @@ INST_DSWRF_ON_SURFACE
 1
 tmpl4_0
 DSWRF
-NCEP
+?
 ?
 surface
 0
@@ -9867,7 +9867,7 @@ AVE_DSWRF_ON_TOP_OF_ATMOS
 1
 tmpl4_8
 DSWRF
-NCEP
+?
 AVE
 top_of_atmos
 0
@@ -9993,7 +9993,7 @@ AVE_DLWRF_ON_SURFACE
 1
 tmpl4_8
 DLWRF
-NCEP
+?
 AVE
 surface
 0
@@ -10035,7 +10035,7 @@ INST_DLWRF_ON_SURFACE
 1
 tmpl4_0
 DLWRF
-NCEP
+?
 ?
 surface
 0
@@ -10077,7 +10077,7 @@ AVE_USWRF_ON_SURFACE
 1
 tmpl4_8
 USWRF
-NCEP
+?
 AVE
 surface
 0
@@ -10119,7 +10119,7 @@ INST_USWRF_ON_SURFACE
 1
 tmpl4_0
 USWRF
-NCEP
+?
 ?
 surface
 0
@@ -10161,7 +10161,7 @@ AVE_ULWRF_ON_SURFACE
 1
 tmpl4_8
 ULWRF
-NCEP
+?
 AVE
 surface
 0
@@ -10203,7 +10203,7 @@ INST_ULWRF_ON_SURFACE
 1
 tmpl4_0
 ULWRF
-NCEP
+?
 ?
 surface
 0
@@ -10245,7 +10245,7 @@ AVE_USWRF_ON_TOP_OF_ATMOS
 1
 tmpl4_8
 USWRF
-NCEP
+?
 AVE
 top_of_atmos
 0
@@ -10287,7 +10287,7 @@ AVE_ULWRF_ON_TOP_OF_ATMOS
 1
 tmpl4_8
 ULWRF
-NCEP
+?
 AVE
 top_of_atmos
 0
@@ -10959,7 +10959,7 @@ FRICV_ON_SURFACE
 1
 tmpl4_0
 FRICV
-NCEP
+?
 ?
 surface
 0
@@ -11001,7 +11001,7 @@ SFEXC_ON_SURFACE
 1
 tmpl4_0
 SFEXC
-NCEP
+?
 ?
 surface
 0
@@ -11169,7 +11169,7 @@ AVE_GFLUX_ON_SURFACE
 1
 tmpl4_8
 GFLUX
-NCEP
+?
 AVE
 surface
 0
@@ -11211,7 +11211,7 @@ INST_GFLUX_ON_SURFACE
 1
 tmpl4_0
 GFLUX
-NCEP
+?
 ?
 surface
 0
@@ -11253,7 +11253,7 @@ ACM_SSRUN_ON_SURFACE
 1
 tmpl4_8
 SSRUN
-NCEP
+?
 ACM
 surface
 0
@@ -11589,7 +11589,7 @@ HPBL_ON_SURFACE
 1
 tmpl4_0
 HPBL
-NCEP
+?
 ?
 surface
 0
@@ -12177,7 +12177,7 @@ AVE_CWORK_ON_ENTIRE_ATMOS_SINGLE_LYR
 1
 tmpl4_8
 CWORK
-NCEP
+?
 AVE
 entire_atmos_single_lyr
 0
@@ -12219,7 +12219,7 @@ AVE_U-GWD_ON_SURFACE
 1
 tmpl4_8
 U-GWD
-NCEP
+?
 AVE
 surface
 0
@@ -12261,7 +12261,7 @@ AVE_V-GWD_ON_SURFACE
 1
 tmpl4_8
 V-GWD
-NCEP
+?
 AVE
 surface
 0
@@ -12513,7 +12513,7 @@ SUNSD_ON_SURFACE
 1
 tmpl4_0
 SUNSD
-NCEP
+?
 ?
 surface
 0

--- a/tests/logs/rt.log.HERCULES_intel
+++ b/tests/logs/rt.log.HERCULES_intel
@@ -1,68 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-6f15cf3c385deeee7f5e369376e5c4320410f7be
+05649e25e35ee3f46824b85d3a398eadbe39ee0d
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -8fdeb7a816bab893f670e7f592e98713ff613c8e sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1584_hercules_intel/ci/rundir/upp-HERCULES
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1592_hercules_intel/ci/rundir/upp-HERCULES
 Baseline directory: /work/noaa/epic/role-epic/hercules/UPP
 
-Total runtime: 00h:12m:28s
-Test Date: 20260818 14:44:44
+Total runtime: 00h:12m:21s
+Test Date: 20260824 12:42:11
 Summary Results:
 
-08/18 19:34:35Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
-08/18 19:34:35Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
-08/18 19:34:36Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-08/18 19:34:51Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-08/18 19:34:52Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-08/18 19:35:03Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-08/18 19:35:11Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-08/18 19:35:14Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-08/18 19:35:15Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-08/18 19:35:15Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-08/18 19:35:25Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
-08/18 19:35:36Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-08/18 19:35:36Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-08/18 19:36:10Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-08/18 19:36:11Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-08/18 19:36:11Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-08/18 19:36:18Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-08/18 19:36:20Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-08/18 19:36:21Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-08/18 19:36:21Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-08/18 19:36:22Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-08/18 19:36:25Z -mpas test: your new post executable did not generate bit-identical POSTPRS26.tm00 as the develop branch
-08/18 19:36:27Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-08/18 19:36:44Z -mpas test: your new post executable did not generate bit-identical POSTTWO26.tm00 as the develop branch
-08/18 19:37:23Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-08/18 19:37:23Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-08/18 19:42:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-08/18 19:42:13Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-08/18 19:42:13Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-08/18 19:43:37Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-08/18 19:44:28Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-08/18 19:44:40Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-08/18 19:34:58Z -Runtime: sfs_test 00:00:24 -- baseline 00:01:20
-08/18 19:34:58Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
-08/18 19:34:58Z -Runtime: aigfs_test 00:00:07 -- baseline 00:00:30
-08/18 19:34:58Z -Runtime: gefsv12_test 00:00:23 -- baseline 00:01:00
-08/18 19:35:13Z -Runtime: gefsv13_test 00:00:43 -- baseline 00:02:00
-08/18 19:36:13Z -Runtime: nmmb_test 00:01:43 -- baseline 00:03:00
-08/18 19:36:13Z -Runtime: rap_test 00:01:08 -- baseline 00:02:00
-08/18 19:36:28Z -Runtime: hrrr_test 00:01:59 -- baseline 00:06:00
-08/18 19:36:28Z -Runtime: hafs_test 00:00:35 -- baseline 00:01:00
-08/18 19:36:28Z -Runtime: 3drtma_test 00:00:47 -- baseline 00:03:00
-08/18 19:36:58Z -Runtime: mpas_test 00:02:16 -- baseline 00:02:30
-08/18 19:36:58Z -Runtime: mpas_hfip_test 00:01:53 -- baseline 00:05:00
-08/18 19:37:28Z -Runtime: gcafs_test 00:02:56 -- baseline 00:02:30
-08/18 19:44:44Z -Runtime: rrfs_test 00:10:10 -- baseline 00:12:00
-08/18 19:44:44Z -Runtime: gfs_test 00:07:43 -- baseline 00:25:00
+08/24 17:32:31Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
+08/24 17:32:31Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
+08/24 17:32:32Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+08/24 17:32:38Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/24 17:32:39Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+08/24 17:33:05Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/24 17:33:13Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+08/24 17:33:18Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/24 17:33:19Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/24 17:33:20Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
+08/24 17:33:21Z -mpas test: your new post executable generates bit-identical POSTPRS26.tm00 as the develop branch
+08/24 17:33:22Z -mpas test: your new post executable generates bit-identical POSTTWO26.tm00 as the develop branch
+08/24 17:33:31Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/24 17:33:32Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/24 17:33:32Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/24 17:33:50Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+08/24 17:33:51Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+08/24 17:33:52Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+08/24 17:34:10Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/24 17:34:12Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/24 17:34:12Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/24 17:34:13Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/24 17:34:14Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/24 17:34:15Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/24 17:34:57Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+08/24 17:34:59Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+08/24 17:41:24Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.f012.grib2 as the develop branch
+08/24 17:41:24Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sflux.f012.grib2 as the develop branch
+08/24 17:41:24Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master-goes.f012.grib2 as the develop branch
+08/24 17:41:27Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+08/24 17:41:59Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+08/24 17:42:10Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+08/24 17:32:53Z -Runtime: sfs_test 00:00:15 -- baseline 00:01:20
+08/24 17:32:53Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
+08/24 17:32:53Z -Runtime: aigfs_test 00:00:07 -- baseline 00:00:30
+08/24 17:32:54Z -Runtime: gefsv12_test 00:00:14 -- baseline 00:01:00
+08/24 17:33:09Z -Runtime: gefsv13_test 00:00:41 -- baseline 00:02:00
+08/24 17:33:39Z -Runtime: nmmb_test 00:01:08 -- baseline 00:03:00
+08/24 17:33:39Z -Runtime: rap_test 00:00:55 -- baseline 00:02:00
+08/24 17:34:24Z -Runtime: hrrr_test 00:01:51 -- baseline 00:06:00
+08/24 17:34:24Z -Runtime: hafs_test 00:00:49 -- baseline 00:01:00
+08/24 17:34:24Z -Runtime: 3drtma_test 00:01:28 -- baseline 00:03:00
+08/24 17:34:24Z -Runtime: mpas_test 00:00:58 -- baseline 00:02:30
+08/24 17:34:24Z -Runtime: mpas_hfip_test 00:01:49 -- baseline 00:05:00
+08/24 17:35:10Z -Runtime: gcafs_test 00:02:35 -- baseline 00:02:30
+08/24 17:42:11Z -Runtime: rrfs_test 00:09:46 -- baseline 00:12:00
+08/24 17:42:11Z -Runtime: gfs_test 00:09:00 -- baseline 00:25:00
 Check tests:
 ['sfs', 'aqm', 'aigfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-There are changes in results for case mpas in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1584_hercules_intel/ci/rundir/upp-HERCULES/mpas_2026071400/POSTTWO26.tm00
-There are changes in results for case mpas in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1584_hercules_intel/ci/rundir/upp-HERCULES/mpas_2026071400/POSTPRS26.tm00
-Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1584_hercules_intel/ci/rundir/upp-HERCULES for details on differences in results for each case.
+There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1592_hercules_intel/ci/rundir/upp-HERCULES/gfs_2026081800/gfs.t00z.sflux.f012.grib2
+There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1592_hercules_intel/ci/rundir/upp-HERCULES/gfs_2026081800/gfs.t00z.master.f012.grib2
+There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/hercules/1592_hercules_intel/ci/rundir/upp-HERCULES/gfs_2026081800/gfs.t00z.master-goes.f012.grib2
+Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/hercules/1592_hercules_intel/ci/rundir/upp-HERCULES for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.ORION_intel
+++ b/tests/logs/rt.log.ORION_intel
@@ -1,68 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-6f15cf3c385deeee7f5e369376e5c4320410f7be
+05649e25e35ee3f46824b85d3a398eadbe39ee0d
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -8fdeb7a816bab893f670e7f592e98713ff613c8e sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1584_orion_intel/ci/rundir/upp-ORION
+Run directory: /work2/noaa/epic/clyden/regression-tests/upp/orion/1592_orion_intel/ci/rundir/upp-ORION
 Baseline directory: /work/noaa/epic/role-epic/orion/UPP
 
-Total runtime: 00h:22m:26s
-Test Date: 20260818 14:54:43
+Total runtime: 00h:20m:35s
+Test Date: 20260824 13:21:46
 Summary Results:
 
-08/18 19:36:05Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
-08/18 19:36:05Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
-08/18 19:36:05Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-08/18 19:36:13Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-08/18 19:36:18Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-08/18 19:37:43Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-08/18 19:37:50Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-08/18 19:38:16Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
-08/18 19:38:34Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-08/18 19:38:35Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-08/18 19:38:35Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-08/18 19:38:39Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-08/18 19:38:39Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-08/18 19:38:50Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-08/18 19:38:50Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-08/18 19:38:51Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-08/18 19:39:32Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-08/18 19:39:35Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-08/18 19:39:35Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-08/18 19:39:54Z -mpas test: your new post executable did not generate bit-identical POSTPRS26.tm00 as the develop branch
-08/18 19:40:08Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-08/18 19:40:09Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-08/18 19:40:27Z -mpas test: your new post executable did not generate bit-identical POSTTWO26.tm00 as the develop branch
-08/18 19:41:43Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-08/18 19:41:44Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-08/18 19:41:45Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-08/18 19:48:47Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-08/18 19:48:49Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-08/18 19:48:49Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-08/18 19:53:26Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-08/18 19:54:09Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-08/18 19:54:36Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-08/18 19:36:24Z -Runtime: sfs_test 00:00:31 -- baseline 00:01:20
-08/18 19:36:25Z -Runtime: aqm_test 00:00:16 -- baseline 00:00:30
-08/18 19:36:25Z -Runtime: aigfs_test 00:00:16 -- baseline 00:00:30
-08/18 19:36:25Z -Runtime: gefsv12_test 00:00:21 -- baseline 00:01:00
-08/18 19:37:55Z -Runtime: gefsv13_test 00:00:54 -- baseline 00:02:00
-08/18 19:38:40Z -Runtime: nmmb_test 00:01:39 -- baseline 00:03:00
-08/18 19:38:40Z -Runtime: rap_test 00:01:44 -- baseline 00:02:00
-08/18 19:41:56Z -Runtime: hrrr_test 00:04:49 -- baseline 00:08:00
-08/18 19:41:56Z -Runtime: hafs_test 00:00:47 -- baseline 00:01:00
-08/18 19:41:56Z -Runtime: 3drtma_test 00:01:55 -- baseline 00:03:00
-08/18 19:41:56Z -Runtime: mpas_test 00:03:31 -- baseline 00:02:30
-08/18 19:41:56Z -Runtime: mpas_hfip_test 00:03:30 -- baseline 00:05:00
-08/18 19:41:56Z -Runtime: gcafs_test 00:03:13 -- baseline 00:03:15
-08/18 19:54:42Z -Runtime: rrfs_test 00:17:40 -- baseline 00:17:00
-08/18 19:54:42Z -Runtime: gfs_test 00:11:53 -- baseline 00:26:00
+08/24 18:04:51Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+08/24 18:04:53Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
+08/24 18:04:53Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
+08/24 18:05:01Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/24 18:05:07Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+08/24 18:05:24Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+08/24 18:05:35Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/24 18:06:00Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
+08/24 18:06:01Z -mpas test: your new post executable generates bit-identical POSTPRS26.tm00 as the develop branch
+08/24 18:06:02Z -mpas test: your new post executable generates bit-identical POSTTWO26.tm00 as the develop branch
+08/24 18:06:10Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/24 18:06:11Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/24 18:06:11Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/24 18:06:25Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/24 18:06:26Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/24 18:06:32Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+08/24 18:06:32Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+08/24 18:06:33Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+08/24 18:07:37Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+08/24 18:07:39Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+08/24 18:08:00Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/24 18:08:03Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/24 18:08:04Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/24 18:08:22Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/24 18:08:23Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/24 18:08:24Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/24 18:18:22Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.f012.grib2 as the develop branch
+08/24 18:18:23Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sflux.f012.grib2 as the develop branch
+08/24 18:18:23Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master-goes.f012.grib2 as the develop branch
+08/24 18:20:43Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+08/24 18:21:23Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+08/24 18:21:36Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+08/24 18:05:11Z -Runtime: sfs_test 00:00:26 -- baseline 00:01:20
+08/24 18:05:11Z -Runtime: aqm_test 00:00:10 -- baseline 00:00:30
+08/24 18:05:11Z -Runtime: aigfs_test 00:00:12 -- baseline 00:00:30
+08/24 18:05:11Z -Runtime: gefsv12_test 00:00:20 -- baseline 00:01:00
+08/24 18:05:42Z -Runtime: gefsv13_test 00:00:54 -- baseline 00:02:00
+08/24 18:06:12Z -Runtime: nmmb_test 00:01:30 -- baseline 00:03:00
+08/24 18:06:27Z -Runtime: rap_test 00:01:45 -- baseline 00:02:00
+08/24 18:08:28Z -Runtime: hrrr_test 00:03:43 -- baseline 00:08:00
+08/24 18:08:28Z -Runtime: hafs_test 00:00:43 -- baseline 00:01:00
+08/24 18:08:28Z -Runtime: 3drtma_test 00:01:52 -- baseline 00:03:00
+08/24 18:08:28Z -Runtime: mpas_test 00:01:21 -- baseline 00:02:30
+08/24 18:08:28Z -Runtime: mpas_hfip_test 00:03:23 -- baseline 00:05:00
+08/24 18:08:28Z -Runtime: gcafs_test 00:02:58 -- baseline 00:03:15
+08/24 18:21:46Z -Runtime: rrfs_test 00:16:55 -- baseline 00:17:00
+08/24 18:21:46Z -Runtime: gfs_test 00:13:42 -- baseline 00:26:00
 Check tests:
 ['sfs', 'aqm', 'aigfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-There are changes in results for case mpas in /work2/noaa/epic/clyden/regression-tests/upp/orion/1584_orion_intel/ci/rundir/upp-ORION/mpas_2026071400/POSTTWO26.tm00
-There are changes in results for case mpas in /work2/noaa/epic/clyden/regression-tests/upp/orion/1584_orion_intel/ci/rundir/upp-ORION/mpas_2026071400/POSTPRS26.tm00
-Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/orion/1584_orion_intel/ci/rundir/upp-ORION for details on differences in results for each case.
+There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1592_orion_intel/ci/rundir/upp-ORION/gfs_2026081800/gfs.t00z.master-goes.f012.grib2
+There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1592_orion_intel/ci/rundir/upp-ORION/gfs_2026081800/gfs.t00z.master.f012.grib2
+There are changes in results for case gfs in /work2/noaa/epic/clyden/regression-tests/upp/orion/1592_orion_intel/ci/rundir/upp-ORION/gfs_2026081800/gfs.t00z.sflux.f012.grib2
+Refer to .diff files in rundir: /work2/noaa/epic/clyden/regression-tests/upp/orion/1592_orion_intel/ci/rundir/upp-ORION for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intel
+++ b/tests/logs/rt.log.URSA_intel
@@ -1,68 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-6f15cf3c385deeee7f5e369376e5c4320410f7be
+05649e25e35ee3f46824b85d3a398eadbe39ee0d
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -8fdeb7a816bab893f670e7f592e98713ff613c8e sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/1584_ursa_intel/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intel/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:09m:48s
-Test Date: 20260818 19:42:03
+Total runtime: 00h:09m:52s
+Test Date: 20260824 17:39:40
 Summary Results:
 
-08/18 19:34:31Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-08/18 19:34:33Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-08/18 19:34:44Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
-08/18 19:34:44Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-08/18 19:34:44Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
-08/18 19:35:01Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
-08/18 19:35:10Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-08/18 19:35:10Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-08/18 19:35:11Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-08/18 19:35:13Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-08/18 19:35:19Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-08/18 19:35:38Z -mpas test: your new post executable did not generate bit-identical POSTPRS26.tm00 as the develop branch
-08/18 19:35:51Z -mpas test: your new post executable did not generate bit-identical POSTTWO26.tm00 as the develop branch
-08/18 19:36:20Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-08/18 19:36:21Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-08/18 19:36:31Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-08/18 19:36:32Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-08/18 19:36:33Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-08/18 19:37:18Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-08/18 19:37:18Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-08/18 19:37:53Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-08/18 19:37:54Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-08/18 19:37:55Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-08/18 19:39:47Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-08/18 19:39:48Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-08/18 19:39:49Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-08/18 19:39:55Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-08/18 19:39:56Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-08/18 19:39:56Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-08/18 19:41:49Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-08/18 19:41:54Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-08/18 19:41:58Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-08/18 19:34:32Z -Runtime: sfs_test 00:00:16 -- baseline 00:01:20
-08/18 19:35:17Z -Runtime: aqm_test 00:00:05 -- baseline 00:00:30
-08/18 19:35:17Z -Runtime: aigfs_test 00:00:04 -- baseline 00:00:30
-08/18 19:35:17Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
-08/18 19:35:32Z -Runtime: gefsv13_test 00:00:31 -- baseline 00:02:00
-08/18 19:38:03Z -Runtime: nmmb_test 00:01:18 -- baseline 00:02:00
-08/18 19:38:03Z -Runtime: rap_test 00:00:41 -- baseline 00:02:00
-08/18 19:38:03Z -Runtime: hrrr_test 00:01:28 -- baseline 00:03:00
-08/18 19:38:03Z -Runtime: hafs_test 00:00:29 -- baseline 00:01:30
-08/18 19:38:03Z -Runtime: 3drtma_test 00:01:07 -- baseline 00:01:30
-08/18 19:38:03Z -Runtime: mpas_test 00:01:47 -- baseline 00:02:30
-08/18 19:40:03Z -Runtime: mpas_hfip_test 00:03:12 -- baseline 00:05:00
-08/18 19:40:03Z -Runtime: gcafs_test 00:01:13 -- baseline 00:02:00
-08/18 19:42:03Z -Runtime: rrfs_test 00:06:37 -- baseline 00:07:00
-08/18 19:42:03Z -Runtime: gfs_test 00:05:10 -- baseline 00:15:00
+08/24 17:31:47Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+08/24 17:32:10Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+08/24 17:32:10Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+08/24 17:32:49Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
+08/24 17:32:51Z -mpas test: your new post executable generates bit-identical POSTPRS26.tm00 as the develop branch
+08/24 17:32:51Z -mpas test: your new post executable generates bit-identical POSTTWO26.tm00 as the develop branch
+08/24 17:32:52Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+08/24 17:32:52Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+08/24 17:32:53Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+08/24 17:32:59Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+08/24 17:33:00Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+08/24 17:33:06Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
+08/24 17:33:06Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
+08/24 17:33:11Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/24 17:33:39Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/24 17:33:40Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/24 17:33:44Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/24 17:33:49Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/24 17:33:50Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/24 17:33:51Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/24 17:34:05Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/24 17:34:05Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/24 17:34:06Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/24 17:36:10Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/24 17:36:12Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/24 17:36:13Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/24 17:39:17Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.f012.grib2 as the develop branch
+08/24 17:39:17Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sflux.f012.grib2 as the develop branch
+08/24 17:39:17Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master-goes.f012.grib2 as the develop branch
+08/24 17:39:30Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+08/24 17:39:35Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+08/24 17:39:39Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+08/24 17:32:24Z -Runtime: sfs_test 00:00:16 -- baseline 00:01:20
+08/24 17:32:24Z -Runtime: aqm_test 00:00:05 -- baseline 00:00:30
+08/24 17:33:09Z -Runtime: aigfs_test 00:00:04 -- baseline 00:00:30
+08/24 17:33:24Z -Runtime: gefsv12_test 00:00:12 -- baseline 00:02:00
+08/24 17:33:54Z -Runtime: gefsv13_test 00:00:31 -- baseline 00:02:00
+08/24 17:34:09Z -Runtime: nmmb_test 00:00:51 -- baseline 00:02:00
+08/24 17:34:09Z -Runtime: rap_test 00:00:42 -- baseline 00:02:00
+08/24 17:34:09Z -Runtime: hrrr_test 00:01:25 -- baseline 00:03:00
+08/24 17:34:09Z -Runtime: hafs_test 00:00:28 -- baseline 00:01:30
+08/24 17:34:09Z -Runtime: 3drtma_test 00:01:11 -- baseline 00:01:30
+08/24 17:34:10Z -Runtime: mpas_test 00:01:09 -- baseline 00:02:30
+08/24 17:36:25Z -Runtime: mpas_hfip_test 00:03:11 -- baseline 00:05:00
+08/24 17:36:25Z -Runtime: gcafs_test 00:01:18 -- baseline 00:02:00
+08/24 17:39:40Z -Runtime: rrfs_test 00:06:29 -- baseline 00:07:00
+08/24 17:39:40Z -Runtime: gfs_test 00:06:12 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'aigfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-There are changes in results for case mpas in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/1584_ursa_intel/ci/rundir/upp-URSA/mpas_2026071400/POSTPRS26.tm00
-There are changes in results for case mpas in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/1584_ursa_intel/ci/rundir/upp-URSA/mpas_2026071400/POSTTWO26.tm00
-Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/1584_ursa_intel/ci/rundir/upp-URSA for details on differences in results for each case.
+There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intel/ci/rundir/upp-URSA/gfs_2026081800/gfs.t00z.master.f012.grib2
+There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intel/ci/rundir/upp-URSA/gfs_2026081800/gfs.t00z.master-goes.f012.grib2
+There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intel/ci/rundir/upp-URSA/gfs_2026081800/gfs.t00z.sflux.f012.grib2
+Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intel/ci/rundir/upp-URSA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.URSA_intelllvm
+++ b/tests/logs/rt.log.URSA_intelllvm
@@ -1,68 +1,69 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-6f15cf3c385deeee7f5e369376e5c4320410f7be
+05649e25e35ee3f46824b85d3a398eadbe39ee0d
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
 -8fdeb7a816bab893f670e7f592e98713ff613c8e sorc/ncep_post.fd/post_gtg.fd
 
-Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/1584_ursa_intelllvm/ci/rundir/upp-URSA
+Run directory: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intelllvm/ci/rundir/upp-URSA
 Baseline directory: /scratch4/NAGAPE/epic/role-epic/ursa/UPP/test_suite
 
-Total runtime: 00h:07m:28s
-Test Date: 20260818 19:39:44
+Total runtime: 00h:09m:29s
+Test Date: 20260824 17:39:17
 Summary Results:
 
-08/18 19:33:21Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-08/18 19:33:25Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
-08/18 19:33:25Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
-08/18 19:33:38Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-08/18 19:33:43Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-08/18 19:33:44Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-08/18 19:34:13Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-08/18 19:34:20Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
-08/18 19:34:27Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-08/18 19:34:27Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-08/18 19:34:28Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-08/18 19:34:36Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-08/18 19:34:37Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-08/18 19:34:58Z -mpas test: your new post executable did not generate bit-identical POSTPRS26.tm00 as the develop branch
-08/18 19:34:59Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-08/18 19:34:59Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-08/18 19:35:01Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-08/18 19:35:10Z -mpas test: your new post executable did not generate bit-identical POSTTWO26.tm00 as the develop branch
-08/18 19:36:13Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-08/18 19:36:14Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-08/18 19:36:27Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-08/18 19:36:29Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-08/18 19:36:30Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-08/18 19:37:50Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-08/18 19:37:51Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-08/18 19:37:51Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-08/18 19:38:11Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-08/18 19:38:12Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-08/18 19:38:12Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-08/18 19:39:24Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-08/18 19:39:34Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-08/18 19:39:40Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-08/18 19:33:43Z -Runtime: sfs_test 00:00:17 -- baseline 00:01:20
-08/18 19:33:43Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
-08/18 19:33:43Z -Runtime: aigfs_test 00:00:07 -- baseline 00:00:30
-08/18 19:33:58Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
-08/18 19:34:28Z -Runtime: gefsv13_test 00:00:33 -- baseline 00:02:00
-08/18 19:37:58Z -Runtime: nmmb_test 00:01:14 -- baseline 00:01:30
-08/18 19:37:58Z -Runtime: rap_test 00:00:39 -- baseline 00:02:00
-08/18 19:37:58Z -Runtime: hrrr_test 00:01:15 -- baseline 00:02:30
-08/18 19:37:58Z -Runtime: hafs_test 00:00:30 -- baseline 00:01:30
-08/18 19:37:58Z -Runtime: 3drtma_test 00:01:15 -- baseline 00:01:30
-08/18 19:37:58Z -Runtime: mpas_test 00:01:58 -- baseline 00:02:30
-08/18 19:37:58Z -Runtime: mpas_hfip_test 00:03:12 -- baseline 00:05:00
-08/18 19:37:58Z -Runtime: gcafs_test 00:01:10 -- baseline 00:02:30
-08/18 19:39:43Z -Runtime: rrfs_test 00:06:22 -- baseline 00:06:00
-08/18 19:39:43Z -Runtime: gfs_test 00:04:54 -- baseline 00:15:00
+08/24 17:31:03Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+08/24 17:31:09Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+08/24 17:31:20Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+08/24 17:31:25Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/24 17:31:35Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
+08/24 17:31:35Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
+08/24 17:31:36Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/24 17:31:36Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/24 17:31:51Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/24 17:31:58Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
+08/24 17:31:59Z -mpas test: your new post executable generates bit-identical POSTPRS26.tm00 as the develop branch
+08/24 17:32:00Z -mpas test: your new post executable generates bit-identical POSTTWO26.tm00 as the develop branch
+08/24 17:32:02Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+08/24 17:32:03Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+08/24 17:32:03Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+08/24 17:32:29Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/24 17:32:30Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/24 17:32:31Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/24 17:32:56Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+08/24 17:32:57Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+08/24 17:34:02Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/24 17:34:03Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/24 17:34:03Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/24 17:36:06Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/24 17:36:08Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/24 17:36:09Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/24 17:37:26Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master.f012.grib2 as the develop branch
+08/24 17:37:26Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.sflux.f012.grib2 as the develop branch
+08/24 17:37:26Z -gfs test: your new post executable did not generate bit-identical gfs.t00z.master-goes.f012.grib2 as the develop branch
+08/24 17:39:00Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+08/24 17:39:05Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+08/24 17:39:10Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+08/24 17:31:16Z -Runtime: sfs_test 00:00:19 -- baseline 00:01:20
+08/24 17:31:16Z -Runtime: aqm_test 00:00:08 -- baseline 00:00:30
+08/24 17:31:46Z -Runtime: aigfs_test 00:00:06 -- baseline 00:00:30
+08/24 17:31:46Z -Runtime: gefsv12_test 00:00:13 -- baseline 00:02:00
+08/24 17:32:01Z -Runtime: gefsv13_test 00:00:34 -- baseline 00:02:00
+08/24 17:34:17Z -Runtime: nmmb_test 00:01:01 -- baseline 00:01:30
+08/24 17:34:17Z -Runtime: rap_test 00:00:38 -- baseline 00:02:00
+08/24 17:34:17Z -Runtime: hrrr_test 00:01:13 -- baseline 00:02:30
+08/24 17:34:17Z -Runtime: hafs_test 00:00:30 -- baseline 00:01:30
+08/24 17:34:17Z -Runtime: 3drtma_test 00:01:14 -- baseline 00:01:30
+08/24 17:34:17Z -Runtime: mpas_test 00:01:10 -- baseline 00:02:30
+08/24 17:36:17Z -Runtime: mpas_hfip_test 00:03:10 -- baseline 00:05:00
+08/24 17:36:17Z -Runtime: gcafs_test 00:01:59 -- baseline 00:02:30
+08/24 17:39:17Z -Runtime: rrfs_test 00:06:03 -- baseline 00:06:00
+08/24 17:39:17Z -Runtime: gfs_test 00:05:50 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'aigfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-There are changes in results for case mpas in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/1584_ursa_intelllvm/ci/rundir/upp-URSA/mpas_2026071400/POSTPRS26.tm00
-There are changes in results for case mpas in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/1584_ursa_intelllvm/ci/rundir/upp-URSA/mpas_2026071400/POSTTWO26.tm00
-Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/1584_ursa_intelllvm/ci/rundir/upp-URSA for details on differences in results for each case.
+There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intelllvm/ci/rundir/upp-URSA/gfs_2026081800/gfs.t00z.master.f012.grib2
+There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intelllvm/ci/rundir/upp-URSA/gfs_2026081800/gfs.t00z.master-goes.f012.grib2
+There are changes in results for case gfs in /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intelllvm/ci/rundir/upp-URSA/gfs_2026081800/gfs.t00z.sflux.f012.grib2
+Refer to .diff files in rundir: /scratch4/NAGAPE/epic/Chad.Lyden/regression_tests/upp/1592_ursa_intelllvm/ci/rundir/upp-URSA for details on differences in results for each case.
 ===== End of UPP Regression Testing Log =====

--- a/tests/logs/rt.log.WCOSS2_intel
+++ b/tests/logs/rt.log.WCOSS2_intel
@@ -1,6 +1,6 @@
 ===== Start of UPP Regression Testing Log =====
 UPP Hash Tested:
-e3630ea6d27d9afba85b29e39ef4f79472b005c7
+6cc83668ac285d6d8f1e91b133667ba1cc5f82cb
 
 Submodule hashes:
 -68953f566b4d728b9ecf9a352c56e2aaeec6d8ec sorc/libIFI.fd
@@ -9,60 +9,58 @@ Submodule hashes:
 Run directory: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2
 Baseline directory: /lfs/h2/emc/vpppg/noscrub/wen.meng/test_suite
 
-Total runtime: 00h:16m:14s
-Test Date: 20260814 15:28:04
+Total runtime: 00h:16m:10s
+Test Date: 20260821 13:08:52
 Summary Results:
 
-08/14 15:15:22Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
-08/14 15:15:25Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
-08/14 15:15:32Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
-08/14 15:15:32Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
-08/14 15:15:42Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
-08/14 15:16:08Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
-08/14 15:16:29Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
-08/14 15:16:30Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
-08/14 15:16:30Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
-08/14 15:16:30Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
-08/14 15:16:30Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
-08/14 15:16:32Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
-08/14 15:16:32Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
-08/14 15:16:59Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
-08/14 15:17:00Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
-08/14 15:17:02Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
-08/14 15:17:36Z -mpas test: your new post executable did not generate bit-identical POSTPRS26.tm00 as the develop branch
-08/14 15:17:54Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
-08/14 15:17:56Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
-08/14 15:17:59Z -mpas test: your new post executable did not generate bit-identical POSTTWO26.tm00 as the develop branch
-08/14 15:18:00Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
-08/14 15:18:45Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
-08/14 15:18:48Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
-08/14 15:18:58Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
-08/14 15:19:02Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
-08/14 15:19:04Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
-08/14 15:25:51Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.grb2f006 as the develop branch
-08/14 15:25:53Z -gfs test: your new post executable generates bit-identical gfs.t00z.sfluxgrbf006.grib2 as the develop branch
-08/14 15:25:53Z -gfs test: your new post executable generates bit-identical gfs.t00z.special.grb2f006 as the develop branch
-08/14 15:26:57Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
-08/14 15:27:13Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
-08/14 15:27:21Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
-08/14 15:15:40Z -Runtime: sfs_test 00:00:45 -- baseline 00:00:50
-08/14 15:15:45Z -Runtime: aqm_test 00:00:52 -- baseline 00:01:00
-08/14 15:15:49Z -Runtime: aigfs_test 00:00:56 -- baseline 00:01:00
-08/14 15:16:10Z -Runtime: gefsv12_test 00:01:08 -- baseline 00:01:20
-08/14 15:16:46Z -Runtime: gefsv13_test 00:01:55 -- baseline 00:02:00
-08/14 15:16:50Z -Runtime: nmmb_test 00:01:57 -- baseline 00:02:20
-08/14 15:16:54Z -Runtime: rap_test 00:01:55 -- baseline 00:02:00
-08/14 15:18:19Z -Runtime: hrrr_test 00:03:27 -- baseline 00:03:40
-08/14 15:18:24Z -Runtime: hafs_test 00:01:34 -- baseline 00:02:00
-08/14 15:18:28Z -Runtime: 3drtma_test 00:02:29 -- baseline 00:03:00
-08/14 15:18:32Z -Runtime: mpas_test 00:03:28 -- baseline 00:02:40
-08/14 15:19:25Z -Runtime: mpas_hfip.test 00:04:31 -- baseline 00:05:00
-08/14 15:19:29Z -Runtime: gcafs_test 00:04:14 -- baseline 00:05:30
-08/14 15:27:58Z -Runtime: rrfs_test 00:12:54 -- baseline 00:10:00
-08/14 15:28:04Z -Runtime: gfs_test 00:11:23 -- baseline 00:15:00
+08/21 12:56:21Z -sfs test: your new post executable generates bit-identical sfs.t00z.master.grb2f060 as the develop branch
+08/21 12:56:28Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.pres.f084.grib2 as the develop branch
+08/21 12:56:28Z -aigfs test: your new post executable generates bit-identical aigfs.t18z.sfc.f084.grib2 as the develop branch
+08/21 12:56:32Z -aqm test: your new post executable generates bit-identical CMAQ08.tm00 as the develop branch
+08/21 12:56:45Z -gefsv12 test: your new post executable generates bit-identical geaer.t00z.master.grb2f060 as the develop branch
+08/21 12:57:04Z -hafs test: your new post executable generates bit-identical HURPRS42.tm00 as the develop branch
+08/21 12:57:31Z -gefsv13 test: your new post executable generates bit-identical gefs.t00z.master.grb2f009 as the develop branch
+08/21 12:57:31Z -rap test: your new post executable generates bit-identical WRFPRS.GrbF06 as the develop branch
+08/21 12:57:33Z -rap test: your new post executable generates bit-identical WRFNAT.GrbF06 as the develop branch
+08/21 12:57:42Z -nmmb test: your new post executable generates bit-identical BGDAWP03.tm00.Grib2 as the develop branch
+08/21 12:57:45Z -nmmb test: your new post executable generates bit-identical BGRD3D03.tm00.Grib2 as the develop branch
+08/21 12:57:45Z -nmmb test: your new post executable generates bit-identical BGRDSF03.tm00.Grib2 as the develop branch
+08/21 12:57:49Z -mpas test: your new post executable generates bit-identical POSTNAT26.tm00 as the develop branch
+08/21 12:57:56Z -3drtma test: your new post executable generates bit-identical WRFNAT.GrbF00 as the develop branch
+08/21 12:57:56Z -mpas test: your new post executable generates bit-identical POSTPRS26.tm00 as the develop branch
+08/21 12:57:58Z -3drtma test: your new post executable generates bit-identical WRFTWO.GrbF00 as the develop branch
+08/21 12:57:59Z -mpas test: your new post executable generates bit-identical POSTTWO26.tm00 as the develop branch
+08/21 12:58:04Z -3drtma test: your new post executable generates bit-identical WRFPRS.GrbF00 as the develop branch
+08/21 12:58:50Z -hrrr test: your new post executable generates bit-identical WRFTWO.GrbF10 as the develop branch
+08/21 12:58:51Z -hrrr test: your new post executable generates bit-identical WRFPRS.GrbF10 as the develop branch
+08/21 12:58:53Z -hrrr test: your new post executable generates bit-identical WRFNAT.GrbF10 as the develop branch
+08/21 12:59:53Z -gcafs test: your new post executable generates bit-identical GFSPRS.GrbF60 as the develop branch
+08/21 12:59:55Z -gcafs test: your new post executable generates bit-identical GFSFLX.GrbF60 as the develop branch
+08/21 13:00:06Z -mpas_hfip test: your new post executable generates bit-identical NATLEV.GrbF48 as the develop branch
+08/21 13:00:12Z -mpas_hfip test: your new post executable generates bit-identical PRSLEV.GrbF48 as the develop branch
+08/21 13:00:14Z -mpas_hfip test: your new post executable generates bit-identical 2DFLD.GrbF48 as the develop branch
+08/21 13:07:55Z -rrfs test: your new post executable generates bit-identical PRSLEV36.tm00 as the develop branch
+08/21 13:07:59Z -gfs test: your new post executable generates bit-identical gfs.t00z.master.f012.grib2 as the develop branch
+08/21 13:08:02Z -gfs test: your new post executable generates bit-identical gfs.t00z.sflux.f012.grib2 as the develop branch
+08/21 13:08:02Z -gfs test: your new post executable generates bit-identical gfs.t00z.master-goes.f012.grib2 as the develop branch
+08/21 13:08:13Z -rrfs test: your new post executable generates bit-identical NATLEV36.tm00 as the develop branch
+08/21 13:08:21Z -rrfs test: your new post executable generates bit-identical 2DFLD36.tm00 as the develop branch
+08/21 12:56:47Z -Runtime: sfs_test 00:00:47 -- baseline 00:00:50
+08/21 12:56:51Z -Runtime: aqm_test 00:01:01 -- baseline 00:01:00
+08/21 12:56:55Z -Runtime: aigfs_test 00:00:57 -- baseline 00:01:00
+08/21 12:56:59Z -Runtime: gefsv12_test 00:01:14 -- baseline 00:01:20
+08/21 12:57:52Z -Runtime: gefsv13_test 00:01:59 -- baseline 00:02:00
+08/21 12:58:13Z -Runtime: nmmb_test 00:02:14 -- baseline 00:02:20
+08/21 12:58:17Z -Runtime: rap_test 00:02:03 -- baseline 00:02:00
+08/21 12:59:10Z -Runtime: hrrr_test 00:03:23 -- baseline 00:03:40
+08/21 12:59:14Z -Runtime: hafs_test 00:01:34 -- baseline 00:02:00
+08/21 12:59:18Z -Runtime: 3drtma_test 00:02:34 -- baseline 00:03:00
+08/21 12:59:23Z -Runtime: mpas_test 00:02:33 -- baseline 00:02:40
+08/21 13:00:48Z -Runtime: mpas_hfip.test 00:04:52 -- baseline 00:05:00
+08/21 13:00:52Z -Runtime: gcafs_test 00:04:26 -- baseline 00:05:30
+08/21 13:08:47Z -Runtime: rrfs_test 00:13:02 -- baseline 00:10:00
+08/21 13:08:51Z -Runtime: gfs_test 00:12:34 -- baseline 00:15:00
 Check tests:
 ['sfs', 'aqm', 'aigfs', 'gefsv12', 'gefsv13', 'nmmb', 'rap', 'hrrr', 'hafs', '3drtma', 'mpas', 'mpas_hfip', 'gcafs', 'rrfs', 'gfs']
-There are changes in results for case mpas in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/mpas_2026071400/POSTTWO26.tm00
-There are changes in results for case mpas in /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2/mpas_2026071400/POSTPRS26.tm00
-Refer to .diff files in rundir: /lfs/h2/emc/ptmp/wen.meng/upp-WCOSS2 for details on differences in results for each case.
+No changes in test results detected.
 ===== End of UPP Regression Testing Log =====


### PR DESCRIPTION
This PR resolves issues #1590 and #1591 

GRIB2 IDs for 130 GFS parameters (30 unique IDs) are updated to use official WMO GRIB2 IDs instead of NCEP local use GRIB2 IDs.  It is unclear whether these GRIB2 ID changes will be included with the initial GFSv17 implementation, so they will only be added to the UPP develop branch for now.  In addition, input data from the GFSv17 real-time parallel is added to the GFS RT and input/output filenames are updated to match the current naming conventions.

@WenMeng-NOAA Here is my run directory on WCOSS2 - I checked the output with degrib2 and confirmed the GRIB2 IDs are modified:
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/upp-pr1592/gfs_2026081800

New baseline data is located here:
WCOSS2
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/test_suite/data_in/gfs
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/test_suite/data_out/gfs

Ursa
/scratch4/NCEPDEV/fv3-cam/Benjamin.Blake/test_suite/data_in/gfs
/scratch4/NCEPDEV/fv3-cam/Benjamin.Blake/test_suite/data_out_intel/gfs
/scratch4/NCEPDEV/fv3-cam/Benjamin.Blake/test_suite/data_out_intelllvm/gfs