### PR TITLE
Test gcc.yml fix

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -60,7 +60,7 @@ jobs:
           sudo apt install cmake
           spack external find
           spack add mpich@3.4.2
-          spack add doxygen
+          spack add doxygen@1.17.0
           spack concretize
           spack install -v --fail-fast --dirty
           spack clean --all


### PR DESCRIPTION
The GCC workflow was attempting to pull the incorrect version of Doxygen (3.31)
```
CMake Warning at /usr/local/share/cmake-3.31/Modules/FindDoxygen.cmake:494 (message):
  Doxygen executable failed unexpected while determining version (exit
  status: Illegal instruction).  Disabling Doxygen.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.31/Modules/FindDoxygen.cmake:659 (_Doxygen_find_doxygen)
  CMakeLists.txt:149 (find_package)
-- Configuring incomplete, errors occurred!


CMake Error at /usr/local/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
```
The successful builds were using Doxygen version 1.1.7.0
```
-- Found Doxygen: /home/runner/work/UPP/UPP/spack/var/spack/environments/upp-env/.spack-env/view/bin/doxygen (found version "1.17.0") found components: doxygen missing components: dot
-- Configuring done (13.4s)
```

The fix is to explicitly request version 1.17.0 in the workflow file.